### PR TITLE
[DRAFT] Autosave by default

### DIFF
--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -600,7 +600,7 @@ namespace YAFC {
             string path = await new FilesystemScreen("Save project", "Save project as", "Save", string.IsNullOrEmpty(project.attachedFileName) ? null : Path.GetDirectoryName(project.attachedFileName),
                 FilesystemScreen.Mode.SelectOrCreateFile, "project", this, null, "yafc");
             if (path != null) {
-                project.Save(path);
+                await project.Save(path);
                 Preferences.Instance.AddProject(path, DataUtils.dataPath, DataUtils.modsPath, DataUtils.expensiveRecipes);
                 return true;
             }
@@ -608,13 +608,14 @@ namespace YAFC {
             return false;
         }
 
-        private Task<bool> SaveProject() {
-            if (!string.IsNullOrEmpty(project.attachedFileName)) {
-                project.Save(project.attachedFileName);
-                return Task.FromResult(true);
+        private async Task<bool> SaveProject() {
+            if (!string.IsNullOrEmpty(project.attachedFileName))
+            {
+                await project.Save(project.attachedFileName);
+                return true;
             }
 
-            return SaveProjectAs();
+            return await SaveProjectAs();
         }
 
         private async void LoadProjectLight() {

--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -609,8 +609,7 @@ namespace YAFC {
         }
 
         private async Task<bool> SaveProject() {
-            if (!string.IsNullOrEmpty(project.attachedFileName))
-            {
+            if (!string.IsNullOrEmpty(project.attachedFileName)) {
                 await project.Save(project.attachedFileName);
                 return true;
             }

--- a/YAFC/Windows/PreferencesScreen.cs
+++ b/YAFC/Windows/PreferencesScreen.cs
@@ -73,6 +73,13 @@ namespace YAFC {
                 gui.Rebuild();
             }, width: 25f);
 
+            using (gui.EnterRow()) {
+                gui.BuildText("Autosave project:", topOffset: 0.25f);
+                if (gui.BuildCheckBox("enable", prefs.enableAutosave, out bool newAutosave)) {
+                    prefs.RecordUndo().enableAutosave = newAutosave;
+                }
+            }
+
             if (gui.BuildButton("Done")) {
                 Close();
             }

--- a/YAFCmodel/Model/Project.cs
+++ b/YAFCmodel/Model/Project.cs
@@ -114,13 +114,13 @@ namespace YAFC.Model {
                  *
                  * - 2024-02-13, shihan42
                  */
-                var saveTask = current.Save(current.attachedFileName);
+                Task saveTask = current.Save(current.attachedFileName);
                 saveTask.Wait();
             }
         }
 
         public async Task Save(string fileName) {
-            if (lastSavedVersion == projectVersion && fileName == attachedFileName)
+            if (lastSavedVersion == projectVersion && fileName == attachedFileName) {
                 return;
             }
             using (MemoryStream ms = new MemoryStream()) {

--- a/YAFCmodel/Model/Project.cs
+++ b/YAFCmodel/Model/Project.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace YAFC.Model {
     public class Project : ModelObject {
@@ -102,19 +103,17 @@ namespace YAFC.Model {
             return proj;
         }
 
-        public void Save(string fileName) {
+        public async Task Save(string fileName) {
             if (lastSavedVersion == projectVersion && fileName == attachedFileName) {
                 return;
             }
-
             using (MemoryStream ms = new MemoryStream()) {
-                using (Utf8JsonWriter writer = new Utf8JsonWriter(ms, JsonUtils.DefaultWriterOptions)) {
+                await using (Utf8JsonWriter writer = new Utf8JsonWriter(ms, JsonUtils.DefaultWriterOptions)) {
                     SerializationMap<Project>.SerializeToJson(this, writer);
                 }
-
                 ms.Position = 0;
-                using FileStream fs = new FileStream(fileName, FileMode.Create, FileAccess.Write);
-                ms.CopyTo(fs);
+                await using FileStream fs = new FileStream(fileName, FileMode.Create, FileAccess.Write);
+                await ms.CopyToAsync(fs);
             }
             attachedFileName = fileName;
             lastSavedVersion = projectVersion;

--- a/YAFCmodel/Model/Project.cs
+++ b/YAFCmodel/Model/Project.cs
@@ -103,8 +103,24 @@ namespace YAFC.Model {
             return proj;
         }
 
+        public static void QueueAutosave() {
+            if (current.preferences.enableAutosave && !string.IsNullOrEmpty(current.attachedFileName)) {
+                /*
+                 * We must wait for the save method to finish before we can continue. This
+                 * prevents possible changes to the project while it's being saved.
+                 *
+                 * This solution is by far not ideal, but as long as we don't have
+                 * proper async/await support in the UI, it's the best we can do.
+                 *
+                 * - 2024-02-13, shihan42
+                 */
+                var saveTask = current.Save(current.attachedFileName);
+                saveTask.Wait();
+            }
+        }
+
         public async Task Save(string fileName) {
-            if (lastSavedVersion == projectVersion && fileName == attachedFileName) {
+            if (lastSavedVersion == projectVersion && fileName == attachedFileName)
                 return;
             }
             using (MemoryStream ms = new MemoryStream()) {

--- a/YAFCmodel/Model/Project.cs
+++ b/YAFCmodel/Model/Project.cs
@@ -194,6 +194,7 @@ namespace YAFC.Model {
         public HashSet<FactorioObject> sourceResources { get; } = new HashSet<FactorioObject>();
         public HashSet<FactorioObject> favourites { get; } = new HashSet<FactorioObject>();
         public Technology targetTechnology { get; set; }
+        public bool enableAutosave { get; set; } = true;
 
         protected internal override void AfterDeserialize() {
             base.AfterDeserialize();


### PR DESCRIPTION
These are the first steps to solve #22
Right now, I'd like to get some feedback on two possible pitfalls/problems. That's why this is a draft PR.

The **first problem** arises in regard to proper async methods:
All the methods that are responsible for saving the project are converted to support async I/O, but we can't have that yet. The whole UI framework doesn't use the async/await pattern. This pattern commonly needs "async all the way", starting at the UI events and ending in the method that for example use async file I/O.

I'm not sure if it is feasible or even a good idea at this point to rewrite the UI system. That could be a lot of work with possibly low benefits. But on the other hand, saving even big production sheets never exceeded a handful of milliseconds on my machine. So we could just ignore this (as I do in `Project.QueueAutosave()`). But tests with big real life examples would be nice.

The **second problem** is the need to manually include the call to autosave at every occasion where we want the autosave to trigger (if it is enabled).

At first I tried to attach the autosave to the undo system. But that didn't really make sense, as the undo system registers the status *before* a change. With a typical call such as `project.RecordUndo().pages.Add(page);` the status of the displayed pages is only changed *after* the undo.

Shenanigans with deferred execution after a call to `RecordUndo()` are more a hack than an actual solution and introduce synchronization issues over threads.

Any ideas how we should proceed?