### PR TITLE
Fix missing localisation texts

### DIFF
--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -379,7 +379,11 @@ namespace YAFC.Parser {
             if (obj is LuaTable table) {
                 if (!table.Get(1, out string key))
                     return;
-                Localize(key, table);
+
+                if (key == "?")
+                    Localize(table[2]);  // Skip over the ?
+                else
+                    Localize(key, table);
             }
             else localeBuilder.Append(obj);
         }
@@ -421,7 +425,7 @@ namespace YAFC.Parser {
                 }
             }
 
-            var s = localeBuilder.ToString();
+            var s = localeBuilder.ToString().TrimStart();
             localeBuilder.Clear();
             return s;
         }
@@ -440,8 +444,6 @@ namespace YAFC.Parser {
 
             key = FactorioLocalization.Localize(key);
             if (key == null) {
-                if (table != null)
-                    localeBuilder.Append(string.Join(" ", table.ArrayElements<string>()));
                 return;
             }
 


### PR DESCRIPTION
"Fixes" the localisation by skipping over the "?" in the localisation list
The code also returns nothing instead of the localisation key if it can't find it (matches Factorio behaviour)
Trims the start of the localisation string to avoid empty lines caused by the aforementioned.

FWIW, I don't think it s OK to merge as-is, but I wanted to show that this does fix a number of localisation issues. Just need to work out how to do it safely/correctly.

Fixes #43