### PR TITLE
Fix: Add nullcheck for linkedGoods

### DIFF
--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -187,6 +188,9 @@ match:
                     _ = summer.TryGetValue(linkedGoods, out var prev);
                     prev.cons += recipe.recipesPerSecond * ingredient.amount;
                     summer[linkedGoods] = prev;
+                }
+                else {
+                    Debug.WriteLine("linkedGoods should not have been null here.");
                 }
             }
 

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -183,9 +183,11 @@ match:
             for (int i = 0; i < recipe.recipe.ingredients.Length; i++) {
                 var ingredient = recipe.recipe.ingredients[i];
                 var linkedGoods = recipe.links.ingredientGoods[i];
-                _ = summer.TryGetValue(linkedGoods, out var prev);
-                prev.cons += recipe.recipesPerSecond * ingredient.amount;
-                summer[linkedGoods] = prev;
+                if (linkedGoods is not null) {
+                    _ = summer.TryGetValue(linkedGoods, out var prev);
+                    prev.cons += recipe.recipesPerSecond * ingredient.amount;
+                    summer[linkedGoods] = prev;
+                }
             }
 
             if (recipe.fuel != null && !float.IsNaN(recipe.parameters.fuelUsagePerSecondPerBuilding)) {


### PR DESCRIPTION
While using YaFC-CE today i ran into an exception because `linkedGoods` in `summer.TryGetValue(linkedGoods, ...)` was null. This fixed that.

It's kinda a blind fix since i have no steps to reproduce, YaFC was hanging right after the exception message (i made another issue for that). But judging the code this should work.