### PR TITLE
Replace Console.WriteLine with proper logging

### DIFF
--- a/Yafc.Model/Analysis/AutomationAnalysis.cs
+++ b/Yafc.Model/Analysis/AutomationAnalysis.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
+using Serilog;
+using Yafc.UI;
 
 namespace Yafc.Model {
     public enum AutomationStatus : sbyte {
@@ -8,6 +9,7 @@ namespace Yafc.Model {
     }
 
     public class AutomationAnalysis : Analysis {
+        private static readonly ILogger logger = Logging.GetLogger<AutomationAnalysis>();
         public static readonly AutomationAnalysis Instance = new AutomationAnalysis();
         public Mapping<FactorioObject, AutomationStatus> automatable;
 
@@ -107,7 +109,7 @@ namespace Yafc.Model {
             }
             state[Database.voidEnergy] = AutomationStatus.NotAutomatable;
 
-            Console.WriteLine("Automation analysis (first pass) finished in " + time.ElapsedMilliseconds + " ms. Unknowns left: " + unknowns);
+            logger.Information("Automation analysis (first pass) finished in " + time.ElapsedMilliseconds + " ms. Unknowns left: " + unknowns);
             if (unknowns > 0) {
                 // TODO run graph analysis if there are any unknowns left... Right now assume they are not automatable
                 foreach (var (k, v) in state) {

--- a/Yafc.Model/Analysis/AutomationAnalysis.cs
+++ b/Yafc.Model/Analysis/AutomationAnalysis.cs
@@ -109,7 +109,7 @@ namespace Yafc.Model {
             }
             state[Database.voidEnergy] = AutomationStatus.NotAutomatable;
 
-            logger.Information("Automation analysis (first pass) finished in " + time.ElapsedMilliseconds + " ms. Unknowns left: " + unknowns);
+            logger.Information("Automation analysis (first pass) finished in {ElapsedTime}ms. Unknowns left: {unknownsRemaining}", time.ElapsedMilliseconds, unknowns);
             if (unknowns > 0) {
                 // TODO run graph analysis if there are any unknowns left... Right now assume they are not automatable
                 foreach (var (k, v) in state) {

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -258,12 +258,12 @@ namespace Yafc.Model {
             }
 
             var result = workspaceSolver.TrySolveWithDifferentSeeds();
-            logger.Information("Cost analysis completed in " + time.ElapsedMilliseconds + " ms. with result " + result);
+            logger.Information("Cost analysis completed in {ElapsedTime}ms with result {result}", time.ElapsedMilliseconds, result);
             float sumImportance = 1f;
             int totalRecipes = 0;
             if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
                 float objectiveValue = (float)objective.Value();
-                logger.Information("Estimated modpack cost: " + DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
+                logger.Information("Estimated modpack cost: {EstimatedCost}", DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
                 foreach (Goods g in Database.goods.all.ExceptExcluded(this)) {
                     if (variables[g] == null) {
                         continue;

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -4,9 +4,13 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Google.OrTools.LinearSolver;
+using Serilog;
+using Yafc.UI;
 
 namespace Yafc.Model {
     public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
+        private readonly ILogger logger = Logging.GetLogger<CostAnalysis>();
+
         public static readonly CostAnalysis Instance = new CostAnalysis(false);
         public static readonly CostAnalysis InstanceAtMilestones = new CostAnalysis(true);
         public static CostAnalysis Get(bool atCurrentMilestones) {
@@ -254,12 +258,12 @@ namespace Yafc.Model {
             }
 
             var result = workspaceSolver.TrySolveWithDifferentSeeds();
-            Console.WriteLine("Cost analysis completed in " + time.ElapsedMilliseconds + " ms. with result " + result);
+            logger.Information("Cost analysis completed in " + time.ElapsedMilliseconds + " ms. with result " + result);
             float sumImportance = 1f;
             int totalRecipes = 0;
             if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
                 float objectiveValue = (float)objective.Value();
-                Console.WriteLine("Estimated modpack cost: " + DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
+                logger.Information("Estimated modpack cost: " + DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
                 foreach (Goods g in Database.goods.all.ExceptExcluded(this)) {
                     if (variables[g] == null) {
                         continue;

--- a/Yafc.Model/Analysis/Milestones.cs
+++ b/Yafc.Model/Analysis/Milestones.cs
@@ -174,7 +174,7 @@ namespace Yafc.Model {
                         Array.Resize(ref currentMilestones, nextMilestoneIndex);
                         break;
                     }
-                    logger.Information("Processing milestone " + milestone.locName);
+                    logger.Information("Processing milestone {Milestone}", milestone.locName);
                     processingQueue.Enqueue(milestone.id);
                     processing[milestone] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
                 }
@@ -232,7 +232,7 @@ namespace Yafc.Model {
 
                     accessibleObjects++;
                     //var obj = Database.objects[elem];
-                    //logger.Information("Added object " + obj.locName + " [" + obj.GetType().Name + "] with mask " + elementFlags.ToString() + " (was " + cur.ToString() + ")");
+                    //logger.Information("Added object {LocalizedName} [{Type}] with mask {MilestoneMask} (was {PreviousMask})", obj.locName, obj.GetType().Name, elementFlags, cur);
                     if (processing[elem] == ProcessingFlags.MilestoneNeedOrdering) {
                         processing[elem] = 0;
                         elementFlags |= nextMilestoneMask;
@@ -274,7 +274,7 @@ skip:;
                 warnings.Error("There are some milestones that are not accessible: " + string.Join(", ", milestonesNotReachable.Select(x => x.locName)) + ". You may remove these from milestone list," +
                                MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
             }
-            logger.Information("Milestones calculation finished in " + time.ElapsedMilliseconds + " ms.");
+            logger.Information("Milestones calculation finished in {ElapsedTime}ms.", time.ElapsedMilliseconds);
             milestoneResult = result;
         }
 

--- a/Yafc.Model/Analysis/Milestones.cs
+++ b/Yafc.Model/Analysis/Milestones.cs
@@ -2,10 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Serilog;
+using Yafc.UI;
 
 namespace Yafc.Model {
     public class Milestones : Analysis {
         public static readonly Milestones Instance = new Milestones();
+
+        private static readonly ILogger logger = Logging.GetLogger<Milestones>();
 
         public FactorioObject[] currentMilestones = [];
         private Mapping<FactorioObject, Bits> milestoneResult;
@@ -170,7 +174,7 @@ namespace Yafc.Model {
                         Array.Resize(ref currentMilestones, nextMilestoneIndex);
                         break;
                     }
-                    Console.WriteLine("Processing milestone " + milestone.locName);
+                    logger.Information("Processing milestone " + milestone.locName);
                     processingQueue.Enqueue(milestone.id);
                     processing[milestone] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
                 }
@@ -228,7 +232,7 @@ namespace Yafc.Model {
 
                     accessibleObjects++;
                     //var obj = Database.objects[elem];
-                    //Console.WriteLine("Added object " + obj.locName + " [" + obj.GetType().Name + "] with mask " + elementFlags.ToString() + " (was " + cur.ToString() + ")");
+                    //logger.Information("Added object " + obj.locName + " [" + obj.GetType().Name + "] with mask " + elementFlags.ToString() + " (was " + cur.ToString() + ")");
                     if (processing[elem] == ProcessingFlags.MilestoneNeedOrdering) {
                         processing[elem] = 0;
                         elementFlags |= nextMilestoneMask;
@@ -270,7 +274,7 @@ skip:;
                 warnings.Error("There are some milestones that are not accessible: " + string.Join(", ", milestonesNotReachable.Select(x => x.locName)) + ". You may remove these from milestone list," +
                                MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
             }
-            Console.WriteLine("Milestones calculation finished in " + time.ElapsedMilliseconds + " ms.");
+            logger.Information("Milestones calculation finished in " + time.ElapsedMilliseconds + " ms.");
             milestoneResult = result;
         }
 

--- a/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
+++ b/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
@@ -18,12 +18,12 @@ namespace Yafc.Model {
             bool loops = false;
             foreach (var m in merged) {
                 if (m.userData.list != null) {
-                    logger.Information("Technology loop: " + string.Join(", ", m.userData.list.Select(x => x.locName)));
+                    logger.Error("Technology loop: {LoopMembers}", string.Join(", ", m.userData.list.Select(x => x.locName)));
                     loops = true;
                 }
             }
             if (!loops) {
-                logger.Information("No technology loops found");
+                logger.Information("No technology loops found.");
             }
         }
     }

--- a/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
+++ b/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
@@ -1,8 +1,11 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
+using Serilog;
+using Yafc.UI;
 
 namespace Yafc.Model {
     public static class TechnologyLoopsFinder {
+        private static readonly ILogger logger = Logging.GetLogger(typeof(TechnologyLoopsFinder));
+
         public static void FindTechnologyLoops() {
             Graph<Technology> graph = new Graph<Technology>();
             foreach (var technology in Database.technologies.all) {
@@ -15,12 +18,12 @@ namespace Yafc.Model {
             bool loops = false;
             foreach (var m in merged) {
                 if (m.userData.list != null) {
-                    Console.WriteLine("Technology loop: " + string.Join(", ", m.userData.list.Select(x => x.locName)));
+                    logger.Information("Technology loop: " + string.Join(", ", m.userData.list.Select(x => x.locName)));
                     loops = true;
                 }
             }
             if (!loops) {
-                Console.WriteLine("No technology loops found");
+                logger.Information("No technology loops found");
             }
         }
     }

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -8,10 +8,13 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Google.OrTools.LinearSolver;
+using Serilog;
 using Yafc.UI;
 
 namespace Yafc.Model {
     public static partial class DataUtils {
+        private static readonly ILogger logger = Logging.GetLogger(typeof(DataUtils));
+
         public static readonly FactorioObjectComparer<FactorioObject> DefaultOrdering = new FactorioObjectComparer<FactorioObject>((x, y) => {
             float yFlow = y.ApproximateFlow();
             float xFlow = x.ApproximateFlow();
@@ -183,7 +186,7 @@ namespace Yafc.Model {
             for (int i = 0; i < 3; i++) {
                 Stopwatch time = Stopwatch.StartNew();
                 var result = solver.Solve();
-                Console.WriteLine("Solution completed in " + time.ElapsedMilliseconds + " ms with result " + result);
+                logger.Information("Solution completed in " + time.ElapsedMilliseconds + " ms with result " + result);
                 if (result == Solver.ResultStatus.ABNORMAL) {
                     _ = solver.SetSolverSpecificParametersAsString("random_seed:" + random.Next());
                     continue;
@@ -197,12 +200,12 @@ namespace Yafc.Model {
         public static void VerySlowTryFindBadObjective(Solver solver) {
             var vars = solver.variables();
             var obj = solver.Objective();
-            Console.WriteLine(solver.ExportModelAsLpFormat(false));
+            logger.Information(solver.ExportModelAsLpFormat(false));
             foreach (var v in vars) {
                 obj.SetCoefficient(v, 0);
                 var result = solver.Solve();
                 if (result == Solver.ResultStatus.OPTIMAL) {
-                    Console.WriteLine("Infeasibility candidate: " + v.Name());
+                    logger.Information("Infeasibility candidate: " + v.Name());
                     return;
                 }
             }

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -186,7 +186,7 @@ namespace Yafc.Model {
             for (int i = 0; i < 3; i++) {
                 Stopwatch time = Stopwatch.StartNew();
                 var result = solver.Solve();
-                logger.Information("Solution completed in " + time.ElapsedMilliseconds + " ms with result " + result);
+                logger.Information("Solution completed in {ElapsedTime}ms with result {result}", time.ElapsedMilliseconds, result);
                 if (result == Solver.ResultStatus.ABNORMAL) {
                     _ = solver.SetSolverSpecificParametersAsString("random_seed:" + random.Next());
                     continue;
@@ -205,7 +205,7 @@ namespace Yafc.Model {
                 obj.SetCoefficient(v, 0);
                 var result = solver.Solve();
                 if (result == Solver.ResultStatus.OPTIMAL) {
-                    logger.Information("Infeasibility candidate: " + v.Name());
+                    logger.Warning("Infeasibility candidate: {candidate}", v.Name());
                     return;
                 }
             }

--- a/Yafc.Model/Model/AutoPlanner.cs
+++ b/Yafc.Model/Model/AutoPlanner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Google.OrTools.LinearSolver;
+using Serilog;
 using Yafc.UI;
 
 #nullable disable warnings // Disabling nullable in legacy code.
@@ -27,6 +28,7 @@ namespace Yafc.Model {
     }
 
     public class AutoPlanner(ModelObject page) : ProjectPageContents(page) {
+        private static readonly ILogger logger = Logging.GetLogger<AutoPlanner>();
         public List<AutoPlannerGoal> goals { get; } = [];
         public HashSet<Recipe> done { get; } = [];
         public HashSet<Goods> roots { get; } = [];
@@ -105,9 +107,9 @@ namespace Yafc.Model {
             }
 
             var solverResult = bestFlowSolver.Solve();
-            Console.WriteLine("Solution completed with result " + solverResult);
+            logger.Information("Solution completed with result " + solverResult);
             if (solverResult is not Solver.ResultStatus.OPTIMAL and not Solver.ResultStatus.FEASIBLE) {
-                Console.WriteLine(bestFlowSolver.ExportModelAsLpFormat(false));
+                logger.Information(bestFlowSolver.ExportModelAsLpFormat(false));
                 this.tiers = null;
                 return "Model have no solution";
             }
@@ -225,7 +227,7 @@ nope:;
                         }
                     }
                     remainingNodes.Clear();
-                    Console.WriteLine("Tier creation failure");
+                    logger.Information("Tier creation failure");
                 }
                 tiers.Add(currentTier.Select(x => new AutoPlannerRecipe {
                     recipe = x,

--- a/Yafc.Model/Model/AutoPlanner.cs
+++ b/Yafc.Model/Model/AutoPlanner.cs
@@ -107,11 +107,11 @@ namespace Yafc.Model {
             }
 
             var solverResult = bestFlowSolver.Solve();
-            logger.Information("Solution completed with result " + solverResult);
+            logger.Information("Solution completed with result {result}", solverResult);
             if (solverResult is not Solver.ResultStatus.OPTIMAL and not Solver.ResultStatus.FEASIBLE) {
                 logger.Information(bestFlowSolver.ExportModelAsLpFormat(false));
                 this.tiers = null;
-                return "Model have no solution";
+                return "Model has no solution";
             }
 
             Graph<Recipe> graph = new Graph<Recipe>();

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Google.OrTools.LinearSolver;
+using Serilog;
 using Yafc.UI;
 
 namespace Yafc.Model {
@@ -16,6 +17,7 @@ namespace Yafc.Model {
     }
 
     public class ProductionTable : ProjectPageContents, IComparer<ProductionTableFlow>, IElementGroup<RecipeRow> {
+        private static readonly ILogger logger = Logging.GetLogger<ProductionTable>();
         [SkipSerialization] public Dictionary<Goods, ProductionLink> linkMap { get; } = [];
         List<RecipeRow> IElementGroup<RecipeRow>.elements => recipes;
         [NoUndo]
@@ -408,7 +410,7 @@ match:
 
                 result = productionTableSolver.Solve();
 
-                Console.WriteLine("Solver finished with result " + result);
+                logger.Information("Solver finished with result " + result);
                 await Ui.EnterMainThread();
 
                 if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -410,7 +410,7 @@ match:
 
                 result = productionTableSolver.Solve();
 
-                logger.Information("Solver finished with result " + result);
+                logger.Information("Solver finished with result {result}", result);
                 await Ui.EnterMainThread();
 
                 if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {

--- a/Yafc.Model/Serialization/ErrorCollector.cs
+++ b/Yafc.Model/Serialization/ErrorCollector.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using Serilog;
+using Yafc.UI;
 
 namespace Yafc.Model {
     public enum ErrorSeverity {
@@ -14,6 +16,7 @@ namespace Yafc.Model {
     }
 
     public class ErrorCollector {
+        private static readonly ILogger logger = Logging.GetLogger<ErrorCollector>();
         private readonly Dictionary<(string message, ErrorSeverity severity), int> allErrors = [];
         public ErrorSeverity severity { get; private set; }
         public void Error(string message, ErrorSeverity severity) {
@@ -24,7 +27,7 @@ namespace Yafc.Model {
 
             _ = allErrors.TryGetValue(key, out int prevC);
             allErrors[key] = prevC + 1;
-            Console.WriteLine(message);
+            logger.Information(message);
         }
 
         public (string error, ErrorSeverity severity)[] GetArrErrors() {
@@ -54,7 +57,7 @@ namespace Yafc.Model {
             }
 
             Error(s, errorSeverity);
-            Console.Error.WriteLine(exception.StackTrace);
+            logger.Error(exception, "Exception encountered");
         }
     }
 }

--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
+using Serilog;
+using Yafc.UI;
 
 namespace Yafc.Model {
     [AttributeUsage(AttributeTargets.Property)]
@@ -12,6 +14,7 @@ namespace Yafc.Model {
     public class NoUndoAttribute : Attribute { }
 
     internal abstract class SerializationMap {
+        private static readonly ILogger logger = Logging.GetLogger<SerializationMap>();
         public UndoSnapshot MakeUndoSnapshot(ModelObject target) {
             UndoSnapshotBuilder snapshotBuilder = new(target);
             BuildUndo(target, snapshotBuilder);
@@ -40,6 +43,7 @@ namespace Yafc.Model {
     }
 
     internal static class SerializationMap<T> where T : class {
+        private static readonly ILogger logger = Logging.GetLogger(typeof(SerializationMap<T>));
         private static readonly Type? parentType;
         private static readonly ConstructorInfo constructor;
         private static readonly PropertySerializer<T>[] properties;
@@ -308,7 +312,7 @@ namespace Yafc.Model {
                 var property = FindProperty(ref reader, ref lastMatch);
                 if (property == null || lastMatch < constructorProperties) {
                     if (property == null) {
-                        Console.Error.WriteLine("Json has extra property: " + reader.GetString());
+                        logger.Error("Json has extra property: " + reader.GetString());
                     }
 
                     reader.Skip();

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -5,13 +5,14 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using SDL2;
+using Serilog;
 using Yafc.Model;
 using Yafc.UI;
 
 namespace Yafc.Parser {
     internal partial class FactorioDataDeserializer {
+        private static readonly ILogger logger = Logging.GetLogger<FactorioDataDeserializer>();
         private LuaTable raw = null!; // null-forgiving: Initialized at the beginning of LoadData.
         private bool GetRef<T>(LuaTable table, string key, [MaybeNullWhen(false)] out T result) where T : FactorioObject, new() {
             result = null;
@@ -393,7 +394,7 @@ namespace Yafc.Parser {
         }
 
         private Fluid SplitFluid(Fluid basic, int temperature) {
-            Console.WriteLine("Splitting fluid " + basic.name + " at " + temperature);
+            logger.Information("Splitting fluid " + basic.name + " at " + temperature);
             basic.variants ??= [basic];
             var copy = basic.Clone();
             copy.SetTemperature(temperature);

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -394,7 +394,7 @@ namespace Yafc.Parser {
         }
 
         private Fluid SplitFluid(Fluid basic, int temperature) {
-            logger.Information("Splitting fluid " + basic.name + " at " + temperature);
+            logger.Information("Splitting fluid {FluidName} at {Temperature}", basic.name, temperature);
             basic.variants ??= [basic];
             var copy = basic.Clone();
             copy.SetTemperature(temperature);

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -5,7 +5,9 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Serilog;
 using Yafc.Model;
+using Yafc.UI;
 
 namespace Yafc.Parser {
     public static partial class FactorioDataSource {
@@ -13,6 +15,7 @@ namespace Yafc.Parser {
          * please check the implementation comment of ModInfo. 
          */
 
+        private static readonly ILogger logger = Logging.GetLogger(typeof(FactorioDataSource));
         internal static Dictionary<string, ModInfo> allMods = [];
         public static readonly Version defaultFactorioVersion = new Version(1, 1);
         private static byte[] ReadAllBytes(this Stream stream, int length) {
@@ -165,7 +168,7 @@ namespace Yafc.Parser {
                 }
 
                 allMods["core"] = null!;
-                Console.WriteLine("Mod list parsed");
+                logger.Information("Mod list parsed");
 
                 List<ModInfo> allFoundMods = [];
                 FindMods(factorioPath, progress, allFoundMods);
@@ -253,7 +256,7 @@ namespace Yafc.Parser {
                     _ = sortedMods.RemoveAll(x => !modsToLoad.Contains(x));
                 }
 
-                Console.WriteLine("All mods found! Loading order: " + string.Join(", ", modLoadOrder));
+                logger.Information("All mods found! Loading order: " + string.Join(", ", modLoadOrder));
 
                 if (locale != "en") {
                     foreach (string mod in modLoadOrder) {
@@ -283,7 +286,7 @@ namespace Yafc.Parser {
                         settings = FactorioPropertyTree.ReadModSettings(new BinaryReader(fs), dataContext);
                     }
 
-                    Console.WriteLine("Mod settings parsed");
+                    logger.Information("Mod settings parsed");
                 }
                 settings ??= dataContext.NewTable();
 
@@ -299,7 +302,7 @@ namespace Yafc.Parser {
 
                 FactorioDataDeserializer deserializer = new FactorioDataDeserializer(expensive, factorioVersion ?? defaultFactorioVersion);
                 var project = deserializer.LoadData(projectPath, dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
-                Console.WriteLine("Completed!");
+                logger.Information("Completed!");
                 progress.Report(("Completed!", ""));
                 return project;
             }

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -198,13 +198,20 @@ namespace Yafc.Parser {
                     }
                 }
 
+                string? missingMod = null;
+
                 foreach (var (name, mod) in allMods) {
                     currentLoadingMod = name;
                     if (mod == null) {
-                        throw new NotSupportedException("Mod not found: " + name + ". Try loading this pack in Factorio first.");
+                        missingMod ??= name;
+                        logger.Error("Mod not found: {ModName}.", name);
                     }
 
-                    mod.ParseDependencies();
+                    mod?.ParseDependencies();
+                }
+
+                if (missingMod != null) {
+                    throw new NotSupportedException("Mod not found: " + missingMod + ". Try loading this pack in Factorio first.");
                 }
 
 

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -256,7 +256,7 @@ namespace Yafc.Parser {
                     _ = sortedMods.RemoveAll(x => !modsToLoad.Contains(x));
                 }
 
-                logger.Information("All mods found! Loading order: " + string.Join(", ", modLoadOrder));
+                logger.Information("All mods found! Loading order: {LoadOrder}", string.Join(", ", modLoadOrder));
 
                 if (locale != "en") {
                     foreach (string mod in modLoadOrder) {

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -405,7 +405,7 @@ namespace Yafc.Parser {
                 return 1;
             }
             required[argument] = LUA_REFNIL;
-            logger.Information("Require " + requiredFile.mod + "/" + requiredFile.path);
+            logger.Information("Require {RequiredFile}", requiredFile.mod + "/" + requiredFile.path);
             byte[] bytes = FactorioDataSource.ReadModFile(requiredFile.mod, requiredFile.path);
             if (bytes != null) {
                 _ = lua_pushstring(L, argument);
@@ -413,14 +413,14 @@ namespace Yafc.Parser {
                 int result = Exec(bytes, requiredFile.mod, requiredFile.path, argumentReg);
                 if (modFixes.TryGetValue(requiredFile, out byte[]? fix)) {
                     string modFixName = "mod-fix-" + requiredFile.mod + "." + requiredFile.path;
-                    logger.Information("Running mod-fix " + modFixName);
+                    logger.Information("Running mod-fix {ModFix}", modFixName);
                     result = Exec(fix, "*", modFixName, result);
                 }
                 required[argument] = result;
                 GetReg(result);
             }
             else {
-                logger.Error("LUA require failed: mod " + mod + " file " + file);
+                logger.Error("LUA require failed: mod {mod}, file {file}", mod, file);
                 lua_pushnil(L);
             }
             return 1;
@@ -487,7 +487,7 @@ namespace Yafc.Parser {
                     continue;
                 }
 
-                logger.Information("Executing " + mod + "/" + fileName);
+                logger.Information("Executing file {Filename}", mod + "/" + fileName);
                 _ = Exec(bytes, mod, fileName);
             }
         }

--- a/Yafc.UI/Core/ExceptionScreen.cs
+++ b/Yafc.UI/Core/ExceptionScreen.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using SDL2;
+using Serilog;
 
 namespace Yafc.UI {
     public class ExceptionScreen : WindowUtility {
+        private static readonly ILogger logger = Logging.GetLogger<ExceptionScreen>();
         private static bool exists;
         private static bool ignoreAll;
 
         public static void ShowException(Exception ex) {
-            Console.Error.WriteLine(ex.Message);
-            Console.Error.WriteLine(ex.StackTrace);
+            logger.Error(ex, "Exception encountered");
             if (!exists && !ignoreAll) {
                 exists = true;
                 Ui.DispatchInMainThread(state => new ExceptionScreen(ex), null);

--- a/Yafc.UI/Core/Logging.cs
+++ b/Yafc.UI/Core/Logging.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Diagnostics;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+
+namespace Yafc.UI;
+
+/// <summary>
+/// Contains default configuration for logging, to both a structured log file and to the console.
+/// </summary>
+public static class Logging {
+    private static Action<LoggerConfiguration> configureLogger;
+    private static bool canChangeConfiguration = true;
+    private static readonly Lazy<ILogger> logger = new(CreateLogger);
+
+    static Logging() => configureLogger = configure => configure
+        // TODO: This file location must change if we introduce installers that place the executable in non-user-writable locations.
+        .WriteTo.File(new JsonFormatter(renderMessage: true), "yafc.log", rollingInterval: RollingInterval.Day, retainedFileTimeLimit: new TimeSpan(7, 0, 0, 0))
+        .WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Information, standardErrorFromLevel: LogEventLevel.Error, outputTemplate: "{Message:lj}{NewLine}{Exception}")
+        .Enrich.WithThreadId()
+        .Enrich.With<StackTraceEnricher>()
+        .MinimumLevel.Verbose();
+
+    /// <summary>
+    /// Call before calling <see cref="GetLogger"/> to replace the logging configuration with your preferred configuration.
+    /// All default settings (Sinks and Enrichers) will be removed if you call this method.
+    /// </summary>
+    /// <param name="configureLogger">An <see cref="Action{T}"/> that configures the supplied <see cref="LoggerConfiguration"/>.</param>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="GetLogger"/> has been called.</exception>
+    public static void SetLoggerConfiguration(Action<LoggerConfiguration> configureLogger) {
+        ArgumentNullException.ThrowIfNull(configureLogger, nameof(configureLogger));
+        if (!canChangeConfiguration) {
+            throw new InvalidOperationException("Do not change configuration after getting the logger; it will have no effect.");
+        }
+        Logging.configureLogger = configureLogger;
+    }
+
+    /// <summary>
+    /// Call to to get the logger, with either the default configuration or the configuration most recently passed to <see cref="SetLoggerConfiguration"/>.
+    /// </summary>
+    public static ILogger GetLogger<T>() => logger.Value.ForContext(typeof(T));
+    public static ILogger GetLogger(Type type) => logger.Value.ForContext(type);
+
+    private static Logger CreateLogger() {
+        canChangeConfiguration = false;
+        LoggerConfiguration configuration = new LoggerConfiguration();
+        configureLogger(configuration);
+        return configuration.CreateLogger();
+    }
+
+    /// <summary>
+    /// Enrich log events with the source class unconditionally, and with a full stack trace for debug and verbose events.
+    /// </summary>
+    private sealed class StackTraceEnricher : ILogEventEnricher {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory) {
+            if (logEvent.Level is LogEventLevel.Debug or LogEventLevel.Verbose) {
+                for (int i = 1; ; i++) {
+                    StackTrace trace = new(i); // Null-forgive everything in StackTrace.
+                    if (trace.GetFrame(0)!.GetMethod()!.DeclaringType!.Namespace!.StartsWith("Yafc")) {
+                        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty("StackTrace", trace));
+                        break;
+                    }
+                    if (trace.FrameCount == 0) {
+                        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty("StackTrace", new StackTrace()));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -156,7 +156,7 @@ namespace Yafc.UI {
                                     window.WindowRestored();
                                     break;
                                 default:
-                                    logger.Information("Window event of type " + evt.window.windowEvent);
+                                    logger.Information("Window event of type {event}", evt.window.windowEvent);
                                     window.Rebuild(); // might be something like "window exposed", better to paint the UI again
                                     break;
                             }
@@ -171,7 +171,7 @@ namespace Yafc.UI {
 
                             break;
                         default:
-                            logger.Information("Event of type " + evt.type);
+                            logger.Information("Event of type {event}", evt.type);
                             break;
                     }
 

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -5,9 +5,12 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using SDL2;
+using Serilog;
 
 namespace Yafc.UI {
     public static class Ui {
+        private static readonly ILogger logger = Logging.GetLogger(typeof(Ui));
+
         public static bool quit { get; private set; }
 
         private static readonly Dictionary<uint, Window> windows = [];
@@ -21,7 +24,7 @@ namespace Yafc.UI {
                     _ = SetProcessDpiAwareness(2);
                 }
                 catch (Exception) {
-                    Console.WriteLine("DPI awareness setup failed"); // On older versions on Windows
+                    logger.Information("DPI awareness setup failed"); // On older versions on Windows
                 }
             }
             _ = SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
@@ -153,7 +156,7 @@ namespace Yafc.UI {
                                     window.WindowRestored();
                                     break;
                                 default:
-                                    Console.WriteLine("Window event of type " + evt.window.windowEvent);
+                                    logger.Information("Window event of type " + evt.window.windowEvent);
                                     window.Rebuild(); // might be something like "window exposed", better to paint the UI again
                                     break;
                             }
@@ -168,7 +171,7 @@ namespace Yafc.UI {
 
                             break;
                         default:
-                            Console.WriteLine("Event of type " + evt.type);
+                            logger.Information("Event of type " + evt.type);
                             break;
                     }
 

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -1,10 +1,12 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using SDL2;
+using Serilog;
 
 namespace Yafc.UI {
     public abstract class Window : IDisposable {
+        private static readonly ILogger logger = Logging.GetLogger<Window>();
+
         public readonly ImGui rootGui;
         internal IntPtr window;
         /// <summary>Window icon, singleton so it is reused for all windows</summary>
@@ -51,7 +53,7 @@ namespace Yafc.UI {
                 icon = SDL_image.IMG_Load("image.ico");
                 if (icon == IntPtr.Zero) {
                     string error = SDL.SDL_GetError();
-                    Console.WriteLine("Failed to load application icon: " + error);
+                    logger.Information("Failed to load application icon: " + error);
                 }
             }
 

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -53,7 +53,7 @@ namespace Yafc.UI {
                 icon = SDL_image.IMG_Load("image.ico");
                 if (icon == IntPtr.Zero) {
                     string error = SDL.SDL_GetError();
-                    logger.Information("Failed to load application icon: " + error);
+                    logger.Warning("Failed to load application icon: {error}", error);
                 }
             }
 

--- a/Yafc.UI/Rendering/IconAtlas.cs
+++ b/Yafc.UI/Rendering/IconAtlas.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using SDL2;
+using Serilog;
 
 namespace Yafc.UI {
     public class IconAtlas {
+        private static readonly ILogger logger = Logging.GetLogger<IconAtlas>();
         private IntPtr prevRender;
 
         private const int IconSize = IconCollection.IconSize;
@@ -53,7 +55,7 @@ namespace Yafc.UI {
             if (!texture.existMap[index]) {
                 nint iconSurfacePtr = IconCollection.GetIconSurface(icon);
                 if (iconSurfacePtr == IntPtr.Zero) {
-                    Console.Error.WriteLine("Non-existing icon: " + icon);
+                    logger.Error("Non-existing icon: " + icon);
                     return;
                 }
                 ref var iconSurface = ref RenderingUtils.AsSdlSurface(iconSurfacePtr);

--- a/Yafc.UI/Yafc.UI.csproj
+++ b/Yafc.UI/Yafc.UI.csproj
@@ -9,6 +9,9 @@
 
     <ItemGroup>
       <PackageReference Include="SDL2-CS.NetCore" Version="2.0.8" />
+      <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -704,7 +704,7 @@ namespace Yafc {
             }
         }
 
-        public void Report((string, string) value) => logger.Information(value.ToString()); // TODO
+        public void Report((string, string) value) => logger.Information("Status: {primary}, {secondary}", value.Item1, value.Item2); // TODO
 
         public bool IsSameObjectHovered(ImGui gui, FactorioObject? obj) => objectTooltip.IsSameObjectHovered(gui, obj);
 

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -9,11 +9,13 @@ using System.Numerics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using SDL2;
+using Serilog;
 using Yafc.Model;
 using Yafc.UI;
 
 namespace Yafc {
     public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string, string)> {
+        private static readonly ILogger logger = Logging.GetLogger<WindowMain>();
         ///<summary>Unique ID for the Summary page</summary>
         public static readonly Guid SummaryGuid = Guid.Parse("9bdea333-4be2-4be3-b708-b36a64672a40");
         public static MainScreen Instance { get; private set; } = null!; // null-forgiving: Set by the instance constructor
@@ -702,7 +704,7 @@ namespace Yafc {
             }
         }
 
-        public void Report((string, string) value) => Console.WriteLine(value); // TODO
+        public void Report((string, string) value) => logger.Information(value.ToString()); // TODO
 
         public bool IsSameObjectHovered(ImGui gui, FactorioObject? obj) => objectTooltip.IsSameObjectHovered(gui, obj);
 

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -336,7 +336,7 @@ namespace Yafc {
 
                 Close();
                 GC.Collect();
-                logger.Information("GC: " + GC.GetTotalMemory(false));
+                logger.Information("GC: {TotalMemory}", GC.GetTotalMemory(false));
             }
             catch (Exception ex) {
                 await Ui.EnterMainThread();

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -5,12 +5,14 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using SDL2;
+using Serilog;
 using Yafc.Model;
 using Yafc.Parser;
 using Yafc.UI;
 
 namespace Yafc {
     public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboardFocus {
+        private readonly ILogger logger = Logging.GetLogger<WelcomeScreen>();
         private bool loading;
         private string? currentLoad1, currentLoad2;
         private string path = "", dataPath = "", modsPath = "";
@@ -326,7 +328,7 @@ namespace Yafc {
                 ErrorCollector collector = new ErrorCollector();
                 var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, netProduction, this, collector, Preferences.Instance.language);
                 await Ui.EnterMainThread();
-                Console.WriteLine("Opening main screen");
+                logger.Information("Opening main screen");
                 _ = new MainScreen(displayIndex, project);
                 if (collector.severity > ErrorSeverity.None) {
                     ErrorListPanel.Show(collector);
@@ -334,7 +336,7 @@ namespace Yafc {
 
                 Close();
                 GC.Collect();
-                Console.WriteLine("GC: " + GC.GetTotalMemory(false));
+                logger.Information("GC: " + GC.GetTotalMemory(false));
             }
             catch (Exception ex) {
                 await Ui.EnterMainThread();

--- a/Yafc/Yafc.csproj
+++ b/Yafc/Yafc.csproj
@@ -49,4 +49,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="4.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This closes #54 by replacing the calls to Console.WriteLine with calls to calls into Serilog. In cases where Yafc currently produces console output, it should not change that output.

I was briefly tempted to write the logs to a SQLite database, but decided not to do that so the logs would be somewhat user-readable. The log files will look something like this, and will be deleted is they're over a week old: [yafc20240717.zip](https://github.com/user-attachments/files/16262567/yafc20240717.zip)

This was prompted by https://github.com/shpaass/yafc-ce/issues/178#issuecomment-2227386924, which made me think that it might be useful to log the transitions to and from the UI thread, along with their call stacks.

@Dorus, I used Serilog instead of Microsoft.Extensions.Logging because there does not appear to be a Microsoft.Extensions.Logging.File nuget package. If I'm wrong there, I'm happy to use a Microsoft.Extensions.Logging-based package instead, as long as it provides structured logging. That is, something where I can easily distinguish between ["Disk quota {} set for user {}" and "Disk quota {} exceed by user {}"](https://softwareengineering.stackexchange.com/a/312586).