### PR TITLE
fix: use modern Direct3D on windows

### DIFF
--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -68,9 +68,69 @@ namespace Yafc.UI {
 
         public override Window window { get; }
 
+        /// <summary>
+        /// Function <c>PickRenderDriver()</c> picks the best rendering backend available on the platform.
+        /// 
+        /// This seems like something that SDL2 should do on its own, since the point of SDL2 is to abstract across platform render
+        /// APIs, and it sort of does - but SDL2 has been around for a really long time and its defaults reflect that. On Windows,
+        /// it will autoselect DirectX/Direct3D 9 if given half a chance; DX9 was of course the version that shipped in 2002 and
+        /// supported Windows 98. This is despite the fact that SDL2 supports DX12 and DX11 where possible, and in 2024 "where possible"
+        /// is really going to be "everywhere" - it just doesn't seem to default select them.
+        /// 
+        /// Instead, we can specify the render driver to use when building a renderer instance; to figure out which one, you have to
+        /// go iterate through all the render drivers the library supports and pick the right one by string comparing its name.
+        /// </summary>
+        /// <param name="flags">
+        /// The flags you were going to/are about to pass to SDL_CreateRenderer, just to make sure the function doesn't pick something
+        /// incompatible (this is paranoia since the major renderers tend to support everything relevant).
+        /// </param>
+        /// <returns>The index of the selected render driver, including 0 (SDL autoselect) if no known-best driver exists on this machine. 
+        /// This value should be fed to the second argument of SDL_CreateRenderer()</returns>
+        private static int PickRenderDriver(SDL.SDL_RendererFlags flags) {
+            nint numRenderDrivers = SDL.SDL_GetNumRenderDrivers();
+            System.Diagnostics.Debug.WriteLine($"Render drivers available: {numRenderDrivers}");
+            int selectedRenderDriver = 0;
+            for (int thisRenderDriver = 0; thisRenderDriver < numRenderDrivers; thisRenderDriver++) {
+                nint res = SDL.SDL_GetRenderDriverInfo(thisRenderDriver, out SDL.SDL_RendererInfo rendererInfo);
+                if (res != 0) {
+                    string reason = SDL.SDL_GetError();
+                    System.Diagnostics.Debug.WriteLine($"Render driver {thisRenderDriver} GetInfo failed: {res}: {reason}");
+                    continue;
+                }
+                // This is for some reason the one data structure that the dotnet library doesn't provide a native unmarshal for
+                string? driverName = Marshal.PtrToStringAnsi(rendererInfo.name);
+                if (driverName is null) {
+                    System.Diagnostics.Debug.WriteLine($"Render driver {thisRenderDriver} has an empty name, cannot compare, skipping");
+                    continue;
+                }
+                System.Diagnostics.Debug.WriteLine($"Render driver {thisRenderDriver} is {driverName} flags 0x{rendererInfo.flags.ToString("X")}");
+                if ((rendererInfo.flags | (uint)flags) != rendererInfo.flags) {
+                    System.Diagnostics.Debug.WriteLine($"Render driver {driverName} flags do not cover requested flags {flags}, skipping");
+                    continue;
+                }
+
+                // SDL2 does actually have a fixed (from code) ordering of available render drivers, so doing a full list scan instead of returning
+                // immediately is a bit paranoid, but paranoia comes well-recommended when dealing with graphics drivers
+                if (driverName == "direct3d12") {
+                    System.Diagnostics.Debug.WriteLine($"Selecting render driver {thisRenderDriver} (DX12)");
+                    selectedRenderDriver = thisRenderDriver;
+                }
+                else if (driverName == "direct3d11" && selectedRenderDriver == 0) {
+                    System.Diagnostics.Debug.WriteLine($"Selecting render driver {thisRenderDriver} (DX11)");
+                    selectedRenderDriver = thisRenderDriver;
+                }
+            }
+            System.Diagnostics.Debug.WriteLine($"Selected render driver index {selectedRenderDriver}");
+            return selectedRenderDriver;
+        }
+
         public MainWindowDrawingSurface(WindowMain window) : base(window.pixelsPerUnit) {
             this.window = window;
-            renderer = SDL.SDL_CreateRenderer(window.window, 0, SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC);
+
+            renderer = SDL.SDL_CreateRenderer(window.window, PickRenderDriver(SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC), SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC);
+
+            nint result = SDL.SDL_GetRendererInfo(renderer, out SDL.SDL_RendererInfo info);
+            System.Diagnostics.Debug.WriteLine($"Driver: {SDL.SDL_GetCurrentVideoDriver()} Renderer: {Marshal.PtrToStringAnsi(info.name)}");
             circleTexture = SDL.SDL_CreateTextureFromSurface(renderer, RenderingUtils.CircleSurface);
             byte colorMod = RenderingUtils.darkMode ? (byte)255 : (byte)0;
             _ = SDL.SDL_SetTextureColorMod(circleTexture, colorMod, colorMod, colorMod);


### PR DESCRIPTION
When we call SDL_CreateRenderer(..., 0, <flags>), SDL2 will pick "the most appropriate renderer" from its list of defaults that support the passed flags. The thing is that its list of defaults is straight out of 1998 on Windows, and in most cases will end up selecting Direct3d/DirectX 9. Stack traces for crashes and freezes in #178 tend to show NT waiter deadlocks in d3d9 drivers (at least on my machine); implementing this change means (again at least on my machine) those crashes and hangs go away.

This change should be safe on non-windows machines (and on windows machines that for whatever reason don't support DX12 or 11) because it will default to picking 0 (autoselect) and only opt in to the higher directx versions if SDL2 says they're available.

## Testing
- If we can get a build, would love more people to run it for more time to see if it helps more generally than on my PC (but it does seem plausible that this would fix the issue)
- I'm like 90% sure this will work on other platforms but I'm slightly concerned about whether proton and wine present DX drivers to SDL2 that might cause linux installs of the tool to use them instead of gles. On the other hand maybe that's fine since those tools work will and this is mostly developed for windows anyway.