### PR TITLE
fix: destroy textures on the main thread

### DIFF
--- a/Yafc.UI/Core/DrawingSurface.cs
+++ b/Yafc.UI/Core/DrawingSurface.cs
@@ -11,9 +11,9 @@ namespace Yafc.UI {
 
         public TextureHandle Destroy() {
             if (valid) {
-                SDL.SDL_DestroyTexture(handle);
+                var capturedHandle = handle;
+                Ui.DispatchInMainThread(_ => SDL.SDL_DestroyTexture(capturedHandle), null);
             }
-
             return default;
         }
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,11 @@
 //     Internal changes: 
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version 0.7.4
+Date:
+    Bugfixes:
+        - Fix a possible threading race while destroying textures, which could cause an illegal access crash.
+----------------------------------------------------------------------------------------------------------------------
 Version 0.7.3
 Date: July 21st 2024
     Features:


### PR DESCRIPTION
SDL2 is not, generally speaking, threadsafe especially in video APIs and even more so in video APIs that access some shared resource like render driver work queues. Textures, and SDL_DestroyTexture, are one such resource.

However, we've been calling SDL_DestroyTexture in the finalizer of our wrapper TextureHandle. The CLR is generally happy to do things like run finalizers in a GC thread, and therefore we're calling SDL_DestroyTexture from a non-main thread.

We can (slightly) abuse the SDL event loop to fix this by pushing the actual SDL_DestroyTexture call through a user event via the UI base class's static method, which will definitely fix this issue.

It's hard to prove that this is or isn't the cause of the problems in #178, but thread traces where the main thread is running an SDL texture operation while the GC thread is calling SDL_DestroyTexture have popped up a couple times in crash repros, so let's try avoiding it.

## Testing
- I used my branch where I added ctrl-tab (https://github.com/sfoster1/yafc-ce/tree/tabs-and-destroys) to test this by holding down ctrl tab while waving the mouse around, which should create and destroy quite a lot of textures. Before this change, we'd crash pretty quickly; after, we don't.
- Also, I ran that under AppVerifier and it didn't tell me anything so I don't think we're leaking the handles either.