### PR TITLE
feat: change pages with ctrl-tab

### DIFF
--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -146,20 +146,27 @@ namespace Yafc.Model {
 
         public void RemovePage(ProjectPage page) {
             page.MarkAsDeleted();
-            _ = this.RecordUndo().pages.Remove(page);
+            _ = this.RecordUndo();
+            pages.Remove(page);
+            displayPages.Remove(page.guid);
         }
 
         /// <summary>
         /// Get the page that is visually next (i.e. to the right of the current selected page on the tab bar)
         /// from the specified one.
         /// </summary>
-        /// <param name="currentPage">The page to get the next page from (probably the current page).</param>
+        /// <param name="currentPage">The page to get the next page from (probably the current page).
+        /// This is a nullable parameter because sometimes there isn't a current page at all; if it's
+        /// null, we'll return the first display page (if any).</param>
         /// <param name="forward">Whether to move visually-forward (true), i.e. left to right, or
         /// visually-backward (false), i.e. right-to-left.</param>
         /// <returns>The page object that should be set to active.</returns>
         public ProjectPage? VisibleNeighborOfPage(ProjectPage? currentPage, bool forward) {
             if (currentPage == null) {
-                return null;
+                if (displayPages.Count == 0) {
+                    return null;
+                }
+                return pagesByGuid[displayPages.First()];
             }
             var currentGuid = currentPage.guid;
             var currentVisualIndex = displayPages.IndexOf(currentGuid);

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -148,6 +148,29 @@ namespace Yafc.Model {
             page.MarkAsDeleted();
             _ = this.RecordUndo().pages.Remove(page);
         }
+
+        /// <summary>
+        /// Get the page that is visually next (i.e. to the right of the current selected page on the tab bar)
+        /// from the specified one.
+        /// </summary>
+        /// <param name="currentPage">The page to get the next page from (probably the current page).</param>
+        /// <returns>The page object that should be set to active.</returns>
+        public ProjectPage? VisibleNeighborOfPage(ProjectPage? currentPage, bool forward = true) {
+            if (currentPage == null) {
+                return null;
+            }
+            var currentGuid = currentPage.guid;
+            var currentVisualIndex = displayPages.IndexOf(currentGuid);
+            return pagesByGuid[displayPages[forward ? NextVisualIndex() : PreviousVisualIndex()]];
+            int NextVisualIndex() {
+                var naiveNextVisualIndex = currentVisualIndex + 1;
+                return naiveNextVisualIndex >= displayPages.Count ? 0 : naiveNextVisualIndex;
+            }
+            int PreviousVisualIndex() {
+                var naivePreviousVisualIndex = currentVisualIndex - 1;
+                return naivePreviousVisualIndex < 0 ? displayPages.Count - 1 : naivePreviousVisualIndex;
+            }
+        }
     }
 
     public class ProjectSettings(Project project) : ModelObject<Project>(project) {

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -154,8 +154,10 @@ namespace Yafc.Model {
         /// from the specified one.
         /// </summary>
         /// <param name="currentPage">The page to get the next page from (probably the current page).</param>
+        /// <param name="forward">Whether to move visually-forward (true), i.e. left to right, or
+        /// visually-backward (false), i.e. right-to-left.</param>
         /// <returns>The page object that should be set to active.</returns>
-        public ProjectPage? VisibleNeighborOfPage(ProjectPage? currentPage, bool forward = true) {
+        public ProjectPage? VisibleNeighborOfPage(ProjectPage? currentPage, bool forward) {
             if (currentPage == null) {
                 return null;
             }

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -163,6 +163,10 @@ namespace Yafc {
             else {
                 activePageView = null;
             }
+            // Note: This call exists to get any open dropdowns to close. Normally, they inherently lose
+            // focus when you switch project pages because you had to move the mouse up to the tab bar and
+            // click on a page tab; now you can switch pages without doing that, so if you don't explicitly
+            // reset focus the dropdown from the old page will still get rendered on the new page.
             InputSystem.Instance.SetMouseFocus(null);
             Rebuild();
         }

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -163,7 +163,7 @@ namespace Yafc {
             else {
                 activePageView = null;
             }
-
+            InputSystem.Instance.SetMouseFocus(null);
             Rebuild();
         }
 
@@ -589,6 +589,9 @@ namespace Yafc {
                         break;
                     case SDL.SDL_Scancode.SDL_SCANCODE_T:
                         ProductionTableView.CreateProductionSheet();
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_TAB:
+                        SetActivePage(project.VisibleNeighborOfPage(activePage, (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) == 0));
                         break;
                     default:
                         if (_activePageView?.ControlKey(key.scancode) != true) {

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -89,6 +89,8 @@ namespace Yafc {
             bodyContent.offset = prevOffset;
             return surface;
         }
+
+
     }
 
     public abstract class ProjectPageView<T> : ProjectPageView where T : ProjectPageContents {

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -89,8 +89,6 @@ namespace Yafc {
             bodyContent.offset = prevOffset;
             return surface;
         }
-
-
     }
 
     public abstract class ProjectPageView<T> : ProjectPageView where T : ProjectPageContents {

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,8 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.7.4
 Date:
+    Features:
+        - Add the ability to switch through project pages with control-tab and control-shift-tab
     Bugfixes:
         - Fix a possible threading race while destroying textures, which could cause an illegal access crash.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Use the common browser interaction ctrl-tab to switch pages forward and shift-tab to switch pages back.

Implementation-wise, we have to break a little layering by using the displayPages list of guids that really only the tab bar is supposed to care about... but we have to call ChangePage in the main screen, so I'm not sure how else to do it.

The other change of note is forcing a focus change when you switch tabs; this is to get any active dropdowns (i.e. the GoodsIcon dropdowns for switching recipes or switching modules) to disappear if you hit control-tab while one is open, since the mouse isn't otherwise moving and clicking like it would be if you switched tabs with the mouse.

It's also a pretty good way to test #198 by just holding down the button! ~[This branch](https://github.com/sfoster1/yafc-ce/tree/tabs-and-destroys) has both.~ That got merged and I rebased so you can just test that on a build of this branch 