### PR TITLE
Encode strings as UTF8 when sending them to Lua, to match the string decoding.

### DIFF
--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -51,13 +51,13 @@ namespace Yafc.Parser {
         [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
         private static partial void lua_close(IntPtr state);
 
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller))]
+        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         private static partial Result luaL_loadbufferx(IntPtr state, in byte buf, IntPtr sz, string name, string? mode);
         [LibraryImport(LUA)]
         [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
         private static partial Result lua_pcallk(IntPtr state, int nargs, int nresults, int msgh, IntPtr ctx, IntPtr k);
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller))]
+        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         private static partial void luaL_traceback(IntPtr state, IntPtr state2, string? msg, int level);
 
@@ -74,10 +74,10 @@ namespace Yafc.Parser {
         [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         private static partial double lua_tonumberx(IntPtr state, int idx, [MarshalAs(UnmanagedType.Bool)] out bool isnum);
 
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller))]
+        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         private static partial int lua_getglobal(IntPtr state, string var);
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller))]
+        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         private static partial void lua_setglobal(IntPtr state, string name);
         [LibraryImport(LUA)]
@@ -90,7 +90,7 @@ namespace Yafc.Parser {
         [LibraryImport(LUA)]
         [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
         private static partial void lua_pushnil(IntPtr state);
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller))]
+        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         private static partial IntPtr lua_pushstring(IntPtr state, string s);
         [LibraryImport(LUA)]

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Date:
         - Add the ability to switch through project pages with control-tab and control-shift-tab
     Bugfixes:
         - Fix a possible threading race while destroying textures, which could cause an illegal access crash.
+        - Fix a loading error when mods use non-ASCII characters in their settings.
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.7.3
 Date: July 21st 2024


### PR DESCRIPTION
Lua uses UTF8 strings, not Ansi. This usually doesn't matter, except that Schall Alien Loot has setting values containing the character `×` (U+00D7), and this gets garbled when loaded from mod-settings.dat.

In addition to Schall, I checked loading with AngelBobMadClown, ExoticIndustries, IR3, Nullius, Pyanodon, and SE. The only error I encountered was #105.