### PR TITLE
When a script indirectly requires itself, re-run it instead of returning nil.

### DIFF
--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -404,7 +404,6 @@ namespace Yafc.Parser {
                 GetReg(value);
                 return 1;
             }
-            required[argument] = LUA_REFNIL;
             logger.Information("Require {RequiredFile}", requiredFile.mod + "/" + requiredFile.path);
             byte[] bytes = FactorioDataSource.ReadModFile(requiredFile.mod, requiredFile.path);
             if (bytes != null) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Date:
     Bugfixes:
         - Fix a possible threading race while destroying textures, which could cause an illegal access crash.
         - Fix a loading error when mods use non-ASCII characters in their settings.
+        - Fix errors when loading KuxOrbitalCannon and Deadlock SE bridge
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.7.3
 Date: July 21st 2024


### PR DESCRIPTION
This matches Factorio's behavior, and fixes both #105 and #145.