### PR TITLE
Include Yafc version in the build deliverables

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,15 @@
 rm -rf Build
+
+VERSION=$(grep -oPm1 "(?<=<AssemblyVersion>)[^<]+" Yafc/Yafc.csproj)
+echo "Building YAFC version $VERSION..."
+
 dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows
 dotnet publish Yafc/Yafc.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
 dotnet publish Yafc/Yafc.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
 
 pushd Build
-tar czf Linux.tar.gz Linux
-tar czf OSX.tar.gz OSX
-zip -r Windows.zip Windows
+tar czf Yafc-CE-Linux-$VERSION.tar.gz Linux
+tar czf Yafc-CE-OSX-$VERSION.tar.gz OSX
+zip -r Yafc-CE-Windows-$VERSION.zip Windows
 popd
 


### PR DESCRIPTION
I choose for grep as the tool to extract the version from Yafc.csproj. It is also possible to use other tools, but I guessed that grep should be (widely) available. Also in GitBash, if not let me know and we'll find another tool for the job.

Note that this is a 'quick and dirty' solution, XML should be parsed by an XML parser. As this is not critical (archive names would be messed up), I tried to keep it simple (without parsers). Additionally, the version is printed at the start of the script, so it is immediately clear if/when it got messed up.

Fixes #205 