### PR TITLE
feat: focus project name on new-project

### DIFF
--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -152,6 +152,7 @@ namespace Yafc.UI {
         internal void InternalPresent(DrawingSurface surface, Rect position, Rect screenClip) {
             if (surface.window != null) {
                 window = surface.window;
+                window.SetNextRepaint(nextRebuildTimer);
             }
 
             nint renderer = surface.renderer;

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -95,7 +95,7 @@ namespace Yafc.UI {
                 case ImGuiAction.Build:
                     var textColor = color + 2;
                     string? textToBuild;
-                    if (focused) {
+                    if (focused && !string.IsNullOrEmpty(text)) {
                         textToBuild = this.text;
                     }
                     else if (string.IsNullOrEmpty(text)) {

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -16,6 +16,7 @@ namespace Yafc {
         private string name;
         private FactorioObject? icon;
         private readonly Action<string, FactorioObject?>? callback;
+        private Rect projectNameRect = default;
 
         private ProjectPageSettingsPanel(ProjectPage? editingPage, Action<string, FactorioObject?>? callback) {
             this.editingPage = editingPage;
@@ -26,6 +27,10 @@ namespace Yafc {
 
         private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
             _ = gui.BuildTextInput(name, out name, "Input name");
+            if (projectNameRect == default && editingPage == null) {
+                gui.SetTextInputFocus(gui.lastRect, "");
+            }
+            projectNameRect = gui.lastRect;
             if (gui.BuildFactorioObjectButton(icon, 4f, MilestoneDisplay.None, SchemeColor.Grey) == Click.Left) {
                 SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,11 @@
 //     Internal changes: 
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version x.y.z
+Date: 
+    Features:
+        - Autofocus the project name field when you create a new project
+----------------------------------------------------------------------------------------------------------------------
 Version 0.7.4
 Date: July 24th 2024
     Features:


### PR DESCRIPTION
Autofocus the project name field when the user creates a new project (via ctrl-T on the main screen or by clicking the plus).

Commit 67eec91e0891afe513b3ea31ed51598faeea6d57 is the one that actually does that; it takes the same approach used for autofocusing the search field, and seems to work well.

Commit c15a0bf9e2653ab2b856d8b46ed6f3a955418332 allows the prompt text to continue to be present until the first character is typed. You might reasonably think this is a misfeature; I added it because with autofocusing, the user will never see the prompt text in the name field otherwise. There's something a little weird with this where the first character you type will cause the caret to jump around slightly (doesn't alter the input, it just pops to the end of the prompt text for a frame) - would love input on how to fix this.

Commit 83206ef9b3b539cdf570343ac12efd6b3a020aba is light on code and heavy on explanation in the commit log - read that for more information. tldr the caret blink was extremely inconsistent because of a couple core render loop issues; if you put your mouse in the wrong place it would stop blinking, for instance. This was probably never previously noticed because you would never previously have a text field focused that didn't also have your mouse in it, in which case the caret would blink just fine, but now the mouse probably won't be in the autofocused name field and might even be over some other UI element that causes SDL events.

## Testing

- [x] When you press ctrl-t on the main window, the project settings popup has the name field autofocused
- [x] When you click the + button in the tab bar of the main window, the project settings pop has the name field autofocused
- [x] When you edit an already-existing page, the name field is not autofocused
- [x] The caret, if present, always blinks steadily even if your mouse is somewhere weird

Closes #187 