### PR TITLE
Fix deleting beacon modules

### DIFF
--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -170,7 +170,8 @@ namespace Yafc {
                 if (evt == GoodsWithAmountEvent.LeftButtonClick) {
                     SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
                         if (sel == null) {
-                            _ = modules.RecordUndo().list.Remove(rowCustomModule);
+                            _ = modules.RecordUndo();
+                            list.Remove(rowCustomModule);
                         }
                         else {
                             rowCustomModule.RecordUndo().module = sel;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -561,7 +561,7 @@ goodsHaveNoProduction:;
                         case Click.Left:
                             ShowModuleDropDown(gui, recipe);
                             break;
-                        case Click.Right when item is not null:
+                        case Click.Right when recipe.modules != null:
                             recipe.RecordUndo().RemoveFixedModules();
                             break;
                     }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -597,7 +597,7 @@ goodsHaveNoProduction:;
                     .OrderByDescending(x => x.template.IsCompatibleWith(recipe))];
 
                 gui.ShowDropDown(dropGui => {
-                    if (dropGui.BuildButton("Use default modules").WithTooltip(dropGui, "Shortcut: right-click") && dropGui.CloseDropdown()) {
+                    if (recipe.modules != null && dropGui.BuildButton("Use default modules").WithTooltip(dropGui, "Shortcut: right-click") && dropGui.CloseDropdown()) {
                         recipe.RemoveFixedModules();
                     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,12 +15,14 @@ Version x.y.z
 Date: 
     Features:
         - Autofocus the project name field when you create a new project
+        - When opening the main window, use the same column widths as when it was last closed.
+    Bugfixes:
+        - Sometimes, deleting and/or right-click resetting modules would not work.
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.7.4
 Date: July 24th 2024
     Features:
         - Add the ability to switch through project pages with control-tab and control-shift-tab
-        - When opening the main window, use the same column widths as when it was last closed.
     Bugfixes:
         - Fix a possible threading race while destroying textures, which could cause an illegal access crash.
         - Fix a loading error when mods use non-ASCII characters in their settings.


### PR DESCRIPTION
You could set the number of modules in a beacon to 0, but you couldn't delete them:
![image](https://github.com/user-attachments/assets/5a107974-4c7a-4e08-ae9b-9a7595c744cd)

Also, when you explicitly set no modules for a recipe, right-clicking didn't reset them to the default.
![fix-deleting-beacon-modules](https://github.com/user-attachments/assets/458fb75e-a96b-4df7-8c4f-18e90e5a158a)