### PR TITLE
One way to create a recipe was not using the correct comparer for fluids.

### DIFF
--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -138,10 +138,10 @@ match:
         /// Add a recipe or technology to this table, and configure the crafter and fuel to reasonable values.
         /// </summary>
         /// <param name="recipe">The recipe or technology to add.</param>
-        /// <param name="ingredientVariantComparer">If not <see langword="null"/>, the comparer to use when deciding which fluid variants to use.</param>
+        /// <param name="ingredientVariantComparer">The comparer to use when deciding which fluid variants to use.</param>
         /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter or lab that can use this fuel, assuming such an entity exists.
         /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler/lab if any are available.</param>
-        public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods>? ingredientVariantComparer = null, Goods? selectedFuel = null) {
+        public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods> ingredientVariantComparer, Goods? selectedFuel = null) {
             RecipeRow recipeRow = new RecipeRow(this, recipe);
             this.RecordUndo().recipes.Add(recipeRow);
             EntityCrafter? selectedFuelCrafter = selectedFuel?.fuelFor.OfType<EntityCrafter>().Where(e => e.recipes.Contains(recipe)).AutoSelect(DataUtils.FavoriteCrafter);

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -732,7 +732,7 @@ goodsHaveNoProduction:;
                     }
                 }
                 if (!allRecipes.Contains(rec) || (await MessageBox.Show("Recipe already exists", $"Add a second copy of {rec.locName}?", "Add a copy", "Cancel")).choice) {
-                    context.AddRecipe(rec, selectedFuel: selectedFuel);
+                    context.AddRecipe(rec, DefaultVariantOrdering, selectedFuel);
                 }
             }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,11 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version x.y.z
 Date: 
+    Bugfixes:
+        - Fix regression in fluid variant selection when adding recipes.
+----------------------------------------------------------------------------------------------------------------------
+Version 0.7.5
+Date: July 27th 2024
     Features:
         - Autofocus the project name field when you create a new project
         - When opening the main window, use the same column widths as when it was last closed.


### PR DESCRIPTION
This fixes #214, a regression introduced in 7092d503, where I failed to pass `DefaultVariantOrdering`.