### PR TITLE
feat: Add copy-to-clipboard button for data load errors

### DIFF
--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -115,9 +115,14 @@ namespace Yafc {
                         ShowDropDown(gui, gui.lastRect, ProjectErrorMoreInfo, new Padding(0.5f), 30f);
                     }
                 }
-                if (gui.BuildButton("Back")) {
-                    errorMessage = null;
-                    Rebuild();
+                using (gui.EnterRow()) {
+                    if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
+                        SDL.SDL_SetClipboardText(errorMessage);
+                    }
+                    if (gui.RemainingRow().BuildButton("Back")) {
+                        errorMessage = null;
+                        Rebuild();
+                    }
                 }
             }
             else {

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,8 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version x.y.z
 Date: 
+    Features:
+        - Add "Copy to Clipboard" button for data loading errors
     Bugfixes:
         - Fix regression in fluid variant selection when adding recipes.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
We have a button like this for errors that happen in project pages, but not for errors during data load. Now we do!

## Testing
- [x] Cause a data load error (I did this by just adding a throw somewhere in the deserializer) and copy the text to clipboard, then paste it into notepad or something just to make sure it works

Closes #146 