### PR TITLE
Update the "Extra products" box to show only the extra production

### DIFF
--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -23,8 +23,14 @@ namespace Yafc {
             gui.spacing = 0.5f;
             gui.BuildText("Consumption: " + DataUtils.FormatAmount(totalOutput, link.goods.flowUnitOfMeasure), Font.subheader);
             BuildFlow(gui, output, totalOutput);
-            if (link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) && totalInput != totalOutput) {
-                gui.BuildText((totalInput > totalOutput ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(totalInput - totalOutput), link.goods.flowUnitOfMeasure), Font.subheader, color: SchemeColor.Error);
+            if (link.amount != 0) {
+                gui.spacing = 0.5f;
+                gui.BuildText((link.amount > 0 ? "Requested production: " : "Requested consumption: ") + DataUtils.FormatAmount(MathF.Abs(link.amount), link.goods.flowUnitOfMeasure), Font.subheader, color: SchemeColor.GreenAlt);
+            }
+            if (link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) && totalInput != totalOutput + link.amount) {
+                float amount = totalInput - totalOutput - link.amount;
+                gui.spacing = 0.5f;
+                gui.BuildText((amount > 0 ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(amount), link.goods.flowUnitOfMeasure), Font.subheader, color: SchemeColor.Error);
             }
         }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -486,7 +486,7 @@ goodsHaveNoProduction:;
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 var grid = gui.EnterInlineGrid(3f, 1f);
                 if (recipe.isOverviewMode) {
-                    view.BuildTableProducts(gui, recipe.subgroup, recipe.owner, ref grid);
+                    view.BuildTableProducts(gui, recipe.subgroup, recipe.owner, ref grid, false);
                 }
                 else {
                     bool handledSpentFuel = false;
@@ -997,7 +997,9 @@ goodsHaveNoProduction:;
         /// </summary>
         private static bool CheckPossibleOverproducing(ProductionLink link) => link.algorithm == LinkAlgorithm.AllowOverProduction && link.flags.HasFlag(ProductionLink.Flags.LinkNotMatched);
 
-        private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid) {
+        /// <param name="isForSummary">If <see langword="true"/>, this call is for a summary box, at the top of a root-level or nested table.
+        /// If <see langword="false"/>, this call is for collapsed recipe row.</param>
+        private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid, bool isForSummary) {
             var flow = table.flow;
             int firstProduct = Array.BinarySearch(flow, new ProductionTableFlow(Database.voidEnergy, 1e-9f, null), model);
             if (firstProduct < 0) {
@@ -1006,6 +1008,9 @@ goodsHaveNoProduction:;
 
             for (int i = firstProduct; i < flow.Length; i++) {
                 float amt = flow[i].amount;
+                if (isForSummary) {
+                    amt -= flow[i].link?.amount ?? 0;
+                }
                 if (amt <= 0f) {
                     continue;
                 }
@@ -1285,7 +1290,7 @@ goodsHaveNoProduction:;
                 using (gui.EnterGroup(pad)) {
                     gui.BuildText(isRoot ? "Extra products:" : "Export products:");
                     var grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
-                    BuildTableProducts(gui, table, table, ref grid);
+                    BuildTableProducts(gui, table, table, ref grid, true);
                     grid.Dispose();
                 }
                 if (gui.isBuilding) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -999,7 +999,9 @@ goodsHaveNoProduction:;
 
         /// <param name="isForSummary">If <see langword="true"/>, this call is for a summary box, at the top of a root-level or nested table.
         /// If <see langword="false"/>, this call is for collapsed recipe row.</param>
-        private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid, bool isForSummary) {
+        /// <param name="initializeDrawArea">If not <see langword="null"/>, this will be called before drawing the first element. This method may choose not to draw
+        /// some or all of a table's extra products, and this lets the caller suppress the surrounding UI elements if no product end up being drawn.</param>
+        private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid, bool isForSummary, Action<ImGui>? initializeDrawArea = null) {
             var flow = table.flow;
             int firstProduct = Array.BinarySearch(flow, new ProductionTableFlow(Database.voidEnergy, 1e-9f, null), model);
             if (firstProduct < 0) {
@@ -1014,6 +1016,9 @@ goodsHaveNoProduction:;
                 if (amt <= 0f) {
                     continue;
                 }
+
+                initializeDrawArea?.Invoke(gui);
+                initializeDrawArea = null;
 
                 grid.Next();
                 BuildGoodsIcon(gui, flow[i].goods, flow[i].link, amt, ProductDropdownType.Product, null, context, HintLocations.OnConsumingRecipes);
@@ -1287,14 +1292,23 @@ goodsHaveNoProduction:;
             }
 
             if (table.flow.Length > 0 && table.flow[^1].amount > 0) {
-                using (gui.EnterGroup(pad)) {
+                ImGui.Context? context = null;
+                ImGuiUtils.InlineGridBuilder grid = default;
+                void initializeGrid(ImGui gui) {
+                    context = gui.EnterGroup(pad);
                     gui.BuildText(isRoot ? "Extra products:" : "Export products:");
-                    var grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
-                    BuildTableProducts(gui, table, table, ref grid, true);
-                    grid.Dispose();
+                    grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
                 }
-                if (gui.isBuilding) {
-                    gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
+
+                BuildTableProducts(gui, table, table, ref grid, true, initializeGrid);
+
+                if (context != null) {
+                    grid.Dispose();
+                    context.Value.Dispose();
+
+                    if (gui.isBuilding) {
+                        gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
+                    }
                 }
             }
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Date:
         - Add "Copy to Clipboard" button for data loading errors
     Bugfixes:
         - Fix regression in fluid variant selection when adding recipes.
+        - "Extra products" will now show only the extra production of a requested product.
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.7.5
 Date: July 27th 2024


### PR DESCRIPTION
The Extra products box now looks like this
![image](https://github.com/user-attachments/assets/7c28ade4-d5b1-4339-aff8-ff2aea3d1f6d)

And the Link summary now looks like this: (It used to show "Overproduction: 8/m", which is correct in the same way that showing 8/m extra product was correct.)
![image](https://github.com/user-attachments/assets/b2d55b2b-c6dd-45d6-877e-86ccaa618de6)
