### PR TITLE
Refactor UI control drawing to add styles and reduce the number of parameters

### DIFF
--- a/Yafc.UI/Core/ExceptionScreen.cs
+++ b/Yafc.UI/Core/ExceptionScreen.cs
@@ -35,8 +35,8 @@ namespace Yafc.UI {
 
         protected override void BuildContents(ImGui gui) {
             gui.BuildText(ex.GetType().Name, Font.header);
-            gui.BuildText(ex.Message, Font.subheader, true);
-            gui.BuildText(ex.StackTrace, Font.text, true);
+            gui.BuildText(ex.Message, new TextBlockDisplayStyle(Font.subheader, true));
+            gui.BuildText(ex.StackTrace, TextBlockDisplayStyle.WrappedText);
             using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
                 if (gui.BuildButton("Close")) {
                     Close();

--- a/Yafc.UI/Core/Structs.cs
+++ b/Yafc.UI/Core/Structs.cs
@@ -64,6 +64,21 @@
         TagColorBlueTextFaint
     }
 
+    public enum SchemeColorGroup {
+        Pure = SchemeColor.PureBackground,
+        Background = SchemeColor.Background,
+        Primary = SchemeColor.Primary,
+        Secondary = SchemeColor.Secondary,
+        Error = SchemeColor.Error,
+        Grey = SchemeColor.Grey,
+        Magenta = SchemeColor.Magenta,
+        Green = SchemeColor.Green,
+        TagColorGreen = SchemeColor.TagColorGreen,
+        TagColorYellow = SchemeColor.TagColorYellow,
+        TagColorRed = SchemeColor.TagColorRed,
+        TagColorBlue = SchemeColor.TagColorBlue,
+    }
+
     public enum RectangleBorder {
         None,
         Thin,

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -88,12 +88,14 @@ namespace Yafc.UI {
             set => state.textColor = value;
         }
 
-        public void BuildText(string? text, Font? font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, SchemeColor color = SchemeColor.None, float topOffset = 0f, float maxWidth = float.MaxValue) {
+        public void BuildText(string? text, TextBlockDisplayStyle? displayStyle = null, float topOffset = 0f, float maxWidth = float.MaxValue) {
+            displayStyle ??= TextBlockDisplayStyle.Default();
+            SchemeColor color = displayStyle.Color;
             if (color == SchemeColor.None) {
                 color = state.textColor;
             }
 
-            var rect = AllocateTextRect(out var cache, text, font, wrap, align, topOffset, maxWidth);
+            Rect rect = AllocateTextRect(out TextCache? cache, text, displayStyle, topOffset, maxWidth);
             if (action == ImGuiAction.Build && cache != null) {
                 DrawRenderable(rect, cache, color);
             }
@@ -112,16 +114,16 @@ namespace Yafc.UI {
             return new Vector2(textWidth, cache.texRect.h / pixelsPerUnit);
         }
 
-        public Rect AllocateTextRect(out TextCache? cache, string? text, Font? font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, float topOffset = 0f, float maxWidth = float.MaxValue) {
-            var fontSize = GetFontSize(font);
+        public Rect AllocateTextRect(out TextCache? cache, string? text, TextBlockDisplayStyle displayStyle, float topOffset = 0f, float maxWidth = float.MaxValue) {
+            FontFile.FontSize fontSize = GetFontSize(displayStyle.Font);
             Rect rect;
             if (string.IsNullOrEmpty(text)) {
                 cache = null;
                 rect = AllocateRect(0f, topOffset + (fontSize.lineSize / pixelsPerUnit));
             }
             else {
-                Vector2 textSize = GetTextDimensions(out cache, text, font, wrap, maxWidth);
-                rect = AllocateRect(textSize.X, topOffset + (textSize.Y), align);
+                Vector2 textSize = GetTextDimensions(out cache, text, displayStyle.Font, displayStyle.WrapText, maxWidth);
+                rect = AllocateRect(textSize.X, topOffset + (textSize.Y), displayStyle.Alignment);
             }
 
             if (topOffset != 0f) {

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -150,7 +150,7 @@ namespace Yafc.UI {
             return BuildTextInput(text, out newText, placeholder, icon, delayed, padding, setInitialFocus: setInitialFocus);
         }
 
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, Icon icon, bool delayed, Padding padding, RectAlignment alignment = RectAlignment.MiddleLeft, SchemeColor color = SchemeColor.Grey, bool setInitialFocus = false) {
+        public bool BuildTextInput(string? text, out string newText, string? placeholder, Icon icon, bool delayed, Padding padding, RectAlignment alignment = RectAlignment.MiddleLeft, SchemeColorGroup color = SchemeColorGroup.Grey, bool setInitialFocus = false) {
             setInitialFocus &= textInputHelper == null;
             textInputHelper ??= new ImGuiTextInputHelper(this);
             bool result = textInputHelper.BuildTextInput(text, out newText, placeholder, GetFontSize(), delayed, icon, padding, alignment, color);

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -148,14 +148,17 @@ namespace Yafc.UI {
 
         private ImGuiTextInputHelper? textInputHelper;
         public bool BuildTextInput(string? text, out string newText, string? placeholder, Icon icon = Icon.None, bool delayed = false, bool setInitialFocus = false) {
-            Padding padding = new Padding(icon == Icon.None ? 0.8f : 0.5f, 0.5f);
-            return BuildTextInput(text, out newText, placeholder, icon, delayed, padding, setInitialFocus: setInitialFocus);
+            TextBoxDisplayStyle displayStyle = TextBoxDisplayStyle.DefaultTextInput;
+            if (icon != Icon.None) {
+                displayStyle = displayStyle with { Icon = icon };
+            }
+            return BuildTextInput(text, out newText, placeholder, displayStyle, delayed, setInitialFocus);
         }
 
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, Icon icon, bool delayed, Padding padding, RectAlignment alignment = RectAlignment.MiddleLeft, SchemeColorGroup color = SchemeColorGroup.Grey, bool setInitialFocus = false) {
+        public bool BuildTextInput(string? text, out string newText, string? placeholder, TextBoxDisplayStyle displayStyle, bool delayed, bool setInitialFocus = false) {
             setInitialFocus &= textInputHelper == null;
             textInputHelper ??= new ImGuiTextInputHelper(this);
-            bool result = textInputHelper.BuildTextInput(text, out newText, placeholder, GetFontSize(), delayed, icon, padding, alignment, color);
+            bool result = textInputHelper.BuildTextInput(text, out newText, placeholder, GetFontSize(), delayed, displayStyle);
             if (setInitialFocus) {
                 SetTextInputFocus(lastRect, "");
             }

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -55,13 +55,13 @@ namespace Yafc.UI {
             }
         }
 
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, FontFile.FontSize fontSize, bool delayed, Icon icon, Padding padding, RectAlignment alignment, SchemeColorGroup color) {
+        public bool BuildTextInput(string? text, out string newText, string? placeholder, FontFile.FontSize fontSize, bool delayed, TextBoxDisplayStyle displayStyle) {
             newText = text ?? "";
             Rect textRect, realTextRect;
-            using (gui.EnterGroup(padding, RectAllocator.LeftRow)) {
+            using (gui.EnterGroup(displayStyle.Padding, RectAllocator.LeftRow)) {
                 float lineSize = gui.PixelsToUnits(fontSize.lineSize);
-                if (icon != Icon.None) {
-                    gui.BuildIcon(icon, lineSize, (SchemeColor)color + 3);
+                if (displayStyle.Icon != Icon.None) {
+                    gui.BuildIcon(displayStyle.Icon, lineSize, (SchemeColor)displayStyle.ColorGroup + 3);
                 }
 
                 textRect = gui.RemainingRow(0.3f).AllocateRect(0, lineSize, RectAlignment.MiddleFullRow);
@@ -81,32 +81,32 @@ namespace Yafc.UI {
 
                     if (gui.ConsumeMouseDown(boundingRect)) {
                         SetFocus(boundingRect, text ?? "");
-                        GetTextParameters(this.text, textRect, fontSize, alignment, out _, out _, out _, out realTextRect);
+                        GetTextParameters(this.text, textRect, fontSize, displayStyle.Alignment, out _, out _, out _, out realTextRect);
                         SetCaret(FindCaretIndex(text, gui.mousePosition.X - realTextRect.X, fontSize, textRect.Width));
                     }
                     break;
                 case ImGuiAction.MouseMove:
                     if (focused && gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
-                        GetTextParameters(this.text, textRect, fontSize, alignment, out _, out _, out _, out realTextRect);
+                        GetTextParameters(this.text, textRect, fontSize, displayStyle.Alignment, out _, out _, out _, out realTextRect);
                         SetCaret(caret, FindCaretIndex(this.text, gui.mousePosition.X - realTextRect.X, fontSize, textRect.Width));
                     }
                     _ = gui.ConsumeMouseOver(boundingRect, RenderingUtils.cursorCaret, false);
                     break;
                 case ImGuiAction.Build:
-                    SchemeColor textColor = (SchemeColor)color + 2;
+                    SchemeColor textColor = (SchemeColor)displayStyle.ColorGroup + 2;
                     string? textToBuild;
                     if (focused && !string.IsNullOrEmpty(text)) {
                         textToBuild = this.text;
                     }
                     else if (string.IsNullOrEmpty(text)) {
                         textToBuild = placeholder;
-                        textColor = (SchemeColor)color + 3;
+                        textColor = (SchemeColor)displayStyle.ColorGroup + 3;
                     }
                     else {
                         textToBuild = text;
                     }
 
-                    GetTextParameters(textToBuild, textRect, fontSize, alignment, out var cachedText, out float scale, out float textWidth, out realTextRect);
+                    GetTextParameters(textToBuild, textRect, fontSize, displayStyle.Alignment, out TextCache? cachedText, out float scale, out float textWidth, out realTextRect);
                     if (cachedText != null) {
                         gui.DrawRenderable(realTextRect, cachedText, textColor);
                     }
@@ -125,11 +125,11 @@ namespace Yafc.UI {
                             gui.SetNextRebuild(nextCaretTimer);
                             if (caretVisible) {
                                 float caretPosition = GetCharacterPosition(caret, fontSize, textWidth) * scale;
-                                gui.DrawRectangle(new Rect(caretPosition + realTextRect.X - 0.05f, realTextRect.Y, 0.1f, realTextRect.Height), (SchemeColor)color + 2);
+                                gui.DrawRectangle(new Rect(caretPosition + realTextRect.X - 0.05f, realTextRect.Y, 0.1f, realTextRect.Height), (SchemeColor)displayStyle.ColorGroup + 2);
                             }
                         }
                     }
-                    gui.DrawRectangle(boundingRect, (SchemeColor)color);
+                    gui.DrawRectangle(boundingRect, (SchemeColor)displayStyle.ColorGroup);
                     break;
             }
 

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -55,13 +55,13 @@ namespace Yafc.UI {
             }
         }
 
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, FontFile.FontSize fontSize, bool delayed, Icon icon, Padding padding, RectAlignment alignment, SchemeColor color) {
+        public bool BuildTextInput(string? text, out string newText, string? placeholder, FontFile.FontSize fontSize, bool delayed, Icon icon, Padding padding, RectAlignment alignment, SchemeColorGroup color) {
             newText = text ?? "";
             Rect textRect, realTextRect;
             using (gui.EnterGroup(padding, RectAllocator.LeftRow)) {
                 float lineSize = gui.PixelsToUnits(fontSize.lineSize);
                 if (icon != Icon.None) {
-                    gui.BuildIcon(icon, lineSize, color + 3);
+                    gui.BuildIcon(icon, lineSize, (SchemeColor)color + 3);
                 }
 
                 textRect = gui.RemainingRow(0.3f).AllocateRect(0, lineSize, RectAlignment.MiddleFullRow);
@@ -93,14 +93,14 @@ namespace Yafc.UI {
                     _ = gui.ConsumeMouseOver(boundingRect, RenderingUtils.cursorCaret, false);
                     break;
                 case ImGuiAction.Build:
-                    var textColor = color + 2;
+                    SchemeColor textColor = (SchemeColor)color + 2;
                     string? textToBuild;
                     if (focused && !string.IsNullOrEmpty(text)) {
                         textToBuild = this.text;
                     }
                     else if (string.IsNullOrEmpty(text)) {
                         textToBuild = placeholder;
-                        textColor = color + 3;
+                        textColor = (SchemeColor)color + 3;
                     }
                     else {
                         textToBuild = text;
@@ -125,11 +125,11 @@ namespace Yafc.UI {
                             gui.SetNextRebuild(nextCaretTimer);
                             if (caretVisible) {
                                 float caretPosition = GetCharacterPosition(caret, fontSize, textWidth) * scale;
-                                gui.DrawRectangle(new Rect(caretPosition + realTextRect.X - 0.05f, realTextRect.Y, 0.1f, realTextRect.Height), color + 2);
+                                gui.DrawRectangle(new Rect(caretPosition + realTextRect.X - 0.05f, realTextRect.Y, 0.1f, realTextRect.Height), (SchemeColor)color + 2);
                             }
                         }
                     }
-                    gui.DrawRectangle(boundingRect, color);
+                    gui.DrawRectangle(boundingRect, (SchemeColor)color);
                     break;
             }
 

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -58,7 +58,7 @@ namespace Yafc.UI {
         public static string ScanToString(SDL.SDL_Scancode scancode) => SDL.SDL_GetKeyName(SDL.SDL_GetKeyFromScancode(scancode));
 
         public static bool BuildLink(this ImGui gui, string text) {
-            gui.BuildText(text, color: SchemeColor.Link);
+            gui.BuildText(text, TextBlockDisplayStyle.Default(SchemeColor.Link));
             var rect = gui.lastRect;
             switch (gui.action) {
                 case ImGuiAction.MouseMove:
@@ -105,7 +105,7 @@ namespace Yafc.UI {
             }
 
             using (gui.EnterGroup(padding ?? DefaultButtonPadding, active ? color + 2 : color + 3)) {
-                gui.BuildText(text, Font.text, align: RectAlignment.Middle);
+                gui.BuildText(text, TextBlockDisplayStyle.Centered);
             }
 
             return active ? gui.BuildButton(gui.lastRect, color, color + 1) : ButtonEvent.None;
@@ -119,10 +119,10 @@ namespace Yafc.UI {
                     gui.BuildIcon(icon, color: icon >= Icon.FirstCustom ? disabled ? SchemeColor.SourceFaint : SchemeColor.Source : textColor);
                 }
 
-                gui.BuildText(text, Font.text, true, color: textColor);
+                gui.BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = textColor });
                 if (rightText != null) {
                     gui.allocator = RectAllocator.RightRow;
-                    gui.BuildText(rightText, align: RectAlignment.MiddleRight);
+                    gui.BuildText(rightText, new TextBlockDisplayStyle(Alignment: RectAlignment.MiddleRight));
                 }
             }
             return gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey);
@@ -142,7 +142,7 @@ namespace Yafc.UI {
             Rect textRect;
             TextCache? cache;
             using (gui.EnterGroup(DefaultButtonPadding)) {
-                textRect = gui.AllocateTextRect(out cache, text, align: RectAlignment.Middle);
+                textRect = gui.AllocateTextRect(out cache, text, TextBlockDisplayStyle.Centered);
             }
 
             var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
@@ -200,7 +200,7 @@ namespace Yafc.UI {
         public static bool BuildCheckBox(this ImGui gui, string text, bool value, out bool newValue, SchemeColor color = SchemeColor.None, RectAllocator allocator = RectAllocator.LeftRow) {
             using (gui.EnterRow(allocator: allocator)) {
                 gui.BuildIcon(value ? Icon.CheckBoxCheck : Icon.CheckBoxEmpty, 1.5f, color);
-                gui.BuildText(text, Font.text, color: color);
+                gui.BuildText(text, TextBlockDisplayStyle.Default(color));
             }
 
             if (gui.OnClick(gui.lastRect)) {
@@ -215,7 +215,7 @@ namespace Yafc.UI {
         public static bool BuildRadioButton(this ImGui gui, string option, bool selected, SchemeColor color = SchemeColor.None) {
             using (gui.EnterRow()) {
                 gui.BuildIcon(selected ? Icon.RadioCheck : Icon.RadioEmpty, 1.5f, color);
-                gui.BuildText(option, Font.text, color: color, wrap: true);
+                gui.BuildText(option, TextBlockDisplayStyle.WrappedText with { Color = color });
             }
 
             return !selected && gui.OnClick(gui.lastRect);
@@ -239,7 +239,7 @@ namespace Yafc.UI {
                     closed = true;
                 }
 
-                gui.RemainingRow().BuildText(text, align: RectAlignment.Middle);
+                gui.RemainingRow().BuildText(text, TextBlockDisplayStyle.Centered);
             }
             if (gui.isBuilding) {
                 gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
@@ -263,7 +263,7 @@ namespace Yafc.UI {
 
         public static void ShowTooltip(this ImGui gui, Rect rect, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, rect, builder, width);
 
-        public static void ShowTooltip(this ImGui gui, Rect rect, string text, float width = 20f) => gui.window?.ShowTooltip(gui, rect, x => x.BuildText(text, wrap: true), width);
+        public static void ShowTooltip(this ImGui gui, Rect rect, string text, float width = 20f) => gui.window?.ShowTooltip(gui, rect, x => x.BuildText(text, TextBlockDisplayStyle.WrappedText), width);
 
         public static void ShowTooltip(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, gui.lastRect, builder, width);
 

--- a/Yafc.UI/ImGui/TextDisplayStyles.cs
+++ b/Yafc.UI/ImGui/TextDisplayStyles.cs
@@ -1,0 +1,37 @@
+﻿namespace Yafc.UI;
+
+/// <summary>
+/// Contains the display parameters for fixed text (<c>TextBlock</c> in WPF, <c>Label</c> in WinForms)
+/// </summary>
+/// <param name="Font">The <see cref="UI.Font"/> to use when drawing the text, or <see langword="null"/> to use <see cref="Font.text"/>.</param>
+/// <param name="WrapText">Specifies whether or not the text should be wrapped.</param>
+/// <param name="Alignment">Where the text should be drawn within the renderable area.</param>
+/// <param name="Color">The color to use, or <see cref="SchemeColor.None"/> to use the previous color.</param>
+public record TextBlockDisplayStyle(Font? Font = null, bool WrapText = false, RectAlignment Alignment = RectAlignment.MiddleLeft, SchemeColor Color = SchemeColor.None) {
+    /// <summary>
+    /// Gets the default display style (<see cref="Font.text"/>, not wrapped, left-aligned), with the specified color.
+    /// </summary>
+    /// <param name="color">The color to use, or <see cref="SchemeColor.None"/> to use the previous color.</param>
+    public static TextBlockDisplayStyle Default(SchemeColor color = SchemeColor.None) => new(Color: color);
+    /// <summary>
+    /// Gets the display style for nonwrapped centered text.
+    /// </summary>
+    public static TextBlockDisplayStyle Centered { get; } = new(Alignment: RectAlignment.Middle);
+    /// <summary>
+    /// Gets the display style for hint text.
+    /// </summary>
+    public static TextBlockDisplayStyle HintText { get; } = new(Color: SchemeColor.BackgroundTextFaint);
+    /// <summary>
+    /// Gets the display style for wrapped, left-aligned text.
+    /// </summary>
+    public static TextBlockDisplayStyle WrappedText { get; } = new(WrapText: true);
+    /// <summary>
+    /// Gets the display style for most error messages.
+    /// </summary>
+    public static TextBlockDisplayStyle ErrorText { get; } = new(WrapText: true, Color: SchemeColor.Error);
+
+    /// <summary>
+    /// Converts a font to the default display style (not wrapped, left-aligned, default color) for that font.
+    /// </summary>
+    public static implicit operator TextBlockDisplayStyle(Font font) => new(font);
+}

--- a/Yafc.UI/ImGui/TextDisplayStyles.cs
+++ b/Yafc.UI/ImGui/TextDisplayStyles.cs
@@ -35,3 +35,25 @@ public record TextBlockDisplayStyle(Font? Font = null, bool WrapText = false, Re
     /// </summary>
     public static implicit operator TextBlockDisplayStyle(Font font) => new(font);
 }
+
+/// <summary>
+/// Contains the display parameters for editable text (<c>TextBox</c> in both WPF and WinForms)
+/// </summary>
+/// <param name="Icon">The <see cref="Icon"/> to display to the left of the text, or <see cref="Icon.None"/> to display no icon.</param>
+/// <param name="Padding">The <see cref="UI.Padding"/> to place between the text and the edges of the editable area. (The box area not used by <paramref name="Icon"/>.)</param>
+/// <param name="Alignment">The <see cref="RectAlignment"/> to apply when drawing the text within the edit box.</param>
+/// <param name="ColorGroup">The <see cref="SchemeColorGroup"/> to use when drawing the edit box.</param>
+public record TextBoxDisplayStyle(Icon Icon, Padding Padding, RectAlignment Alignment, SchemeColorGroup ColorGroup) {
+    /// <summary>
+    /// Gets the default display style, used for the Preferences screen and calls to <see cref="ImGui.BuildTextInput(string?, out string, string?, Icon, bool, bool)"/>.
+    /// </summary>
+    public static TextBoxDisplayStyle DefaultTextInput { get; } = new(Icon.None, new Padding(.5f), RectAlignment.MiddleLeft, SchemeColorGroup.Grey);
+    /// <summary>
+    /// Gets the display style for input boxes on the Module Filler Parameters screen.
+    /// </summary>
+    public static TextBoxDisplayStyle ModuleParametersTextInput { get; } = new(Icon.None, new Padding(.5f, 0), RectAlignment.MiddleLeft, SchemeColorGroup.Grey);
+    /// <summary>
+    /// Gets the display style for amounts associated with Factorio objects. (<c><see langword="with"/> { ColorGroup = <see cref="SchemeColorGroup.Grey"/> }</c> for built building counts.)
+    /// </summary>
+    public static TextBoxDisplayStyle FactorioObjectInput { get; } = new(Icon.None, default, RectAlignment.Middle, SchemeColorGroup.Secondary);
+}

--- a/Yafc/Utils/ObjectDisplayStyles.cs
+++ b/Yafc/Utils/ObjectDisplayStyles.cs
@@ -1,0 +1,62 @@
+﻿namespace Yafc.UI;
+
+/// <summary>
+/// Contains the display parameters for FactorioObjectIcons.
+/// </summary>
+/// <param name="Size">The icon size. The production tables use size 3.</param>
+/// <param name="MilestoneDisplay">The <see cref="Yafc.MilestoneDisplay"/> option to use when drawing the icon.</param>
+/// <param name="UseScaleSetting">Whether or not to obey the <see cref="Model.ProjectPreferences.iconScale"/> setting.</param>
+public record IconDisplayStyle(float Size, MilestoneDisplay MilestoneDisplay, bool UseScaleSetting) {
+    /// <summary>
+    /// Gets the default icon style: Size 2, <see cref="MilestoneDisplay.Normal"/>, and not scaled.
+    /// </summary>
+    public static IconDisplayStyle Default { get; } = new(2, MilestoneDisplay.Normal, false);
+}
+
+/// <summary>
+/// Contains the display parameters for FactorioObjectButtons. Buttons with a background color draw a scaled icon
+/// (<c><see cref="IconDisplayStyle.UseScaleSetting"/> = <see langword="true"/></c>) by default.
+/// </summary>
+/// <param name="Size">The icon size. The production tables use size 3.</param>
+/// <param name="MilestoneDisplay">The <see cref="MilestoneDisplay"/> option to use when drawing the icon.</param>
+/// <param name="BackgroundColor">The background color to display behind the icon.</param>
+public record ButtonDisplayStyle(float Size, MilestoneDisplay MilestoneDisplay, SchemeColor BackgroundColor) : IconDisplayStyle(Size, MilestoneDisplay, true) {
+    /// <summary>
+    /// Creates a new <see cref="ButtonDisplayStyle"/> for buttons that do not have a background color. These buttons will not obey the <see cref="Model.ProjectPreferences.iconScale"/> setting.
+    /// </summary>
+    /// <param name="size">The icon size. The production tables use size 3.</param>
+    /// <param name="milestoneDisplay">The <see cref="MilestoneDisplay"/> option to use when drawing the icon.</param>
+    public ButtonDisplayStyle(float size, MilestoneDisplay milestoneDisplay) : this(size, milestoneDisplay, SchemeColor.None) => UseScaleSetting = false;
+
+    /// <summary>
+    /// Gets the default button style: Size 2, <see cref="MilestoneDisplay.Normal"/>, no background, and not scaled.
+    /// </summary>
+    public static new ButtonDisplayStyle Default { get; } = new(2, MilestoneDisplay.Normal);
+    /// <summary>
+    /// Gets the button style for the <see cref="SelectObjectPanel{T}"/>s: Size 2.5, <see cref="MilestoneDisplay.Contained"/>, and scaled.
+    /// </summary>
+    /// <param name="backgroundColor">The background color to use for this button.</param>
+    public static ButtonDisplayStyle SelectObjectPanel(SchemeColor backgroundColor) => new(2.5f, MilestoneDisplay.Contained, backgroundColor);
+    /// <summary>
+    /// Gets the button style for production table buttons with a background: Size 2.5, <see cref="MilestoneDisplay.Contained"/>, and scaled.
+    /// </summary>
+    /// <param name="backgroundColor">The background color to use for this button.</param>
+    public static ButtonDisplayStyle ProductionTableScaled(SchemeColor backgroundColor) => new(3, MilestoneDisplay.Contained, backgroundColor);
+    /// <summary>
+    /// Gets the button style for production table buttons with no background: Size 2.5, <see cref="MilestoneDisplay.Contained"/>, and not scaled.
+    /// </summary>
+    public static ButtonDisplayStyle ProductionTableUnscaled { get; } = new(3, MilestoneDisplay.Contained);
+    /// <summary>
+    /// Gets the button style for small buttons in the Never Enough Items Explorer: Size 3, <see cref="MilestoneDisplay.Contained"/>, and not scaled.
+    /// </summary>
+    public static ButtonDisplayStyle NeieSmall { get; } = new(3, MilestoneDisplay.Contained);
+    /// <summary>
+    /// Gets the button style for large buttons in the Never Enough Items Explorer: Size 4, <see cref="MilestoneDisplay.Contained"/>, and not scaled.
+    /// </summary>
+    public static ButtonDisplayStyle NeieLarge { get; } = new(4, MilestoneDisplay.Contained);
+    /// <summary>
+    /// Gets the button style for the Milestones display buttons: Size 3, <see cref="MilestoneDisplay.None"/>, and scaled.
+    /// </summary>
+    /// <param name="backgroundColor">The background color to use for this button.</param>
+    public static ButtonDisplayStyle Milestone(SchemeColor backgroundColor) => new(3, MilestoneDisplay.None, backgroundColor);
+}

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -130,10 +130,10 @@ namespace Yafc {
                 if (extraText != null) {
                     gui.AllocateSpacing();
                     gui.allocator = RectAllocator.RightRow;
-                    gui.BuildText(extraText, color: color);
+                    gui.BuildText(extraText, TextBlockDisplayStyle.Default(color));
                 }
                 _ = gui.RemainingRow();
-                gui.BuildText(obj == null ? "None" : obj.locName, wrap: true, color: color);
+                gui.BuildText(obj == null ? "None" : obj.locName, TextBlockDisplayStyle.WrappedText with { Color = color });
             }
 
             return gui.BuildFactorioObjectButton(gui.lastRect, obj);
@@ -205,13 +205,14 @@ namespace Yafc {
         /// <param name="goods">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
         /// <param name="amount">Display this value and unit.</param>
         /// <param name="useScale">If <see langword="true"/>, this icon will be displayed at <see cref="ProjectPreferences.iconScale"/>, instead of at 100% scale.</param>
-        public static Click BuildFactorioObjectWithAmount(this ImGui gui, FactorioObject? goods, DisplayAmount amount, SchemeColor bgColor = SchemeColor.None, SchemeColor textColor = SchemeColor.None, bool useScale = true, ObjectTooltipOptions tooltipOptions = default) {
+        public static Click BuildFactorioObjectWithAmount(this ImGui gui, FactorioObject? goods, DisplayAmount amount, SchemeColor bgColor = SchemeColor.None, TextBlockDisplayStyle? textDisplayStyle = null, bool useScale = true, ObjectTooltipOptions tooltipOptions = default) {
+            textDisplayStyle ??= new(Alignment: RectAlignment.Middle);
             using (gui.EnterFixedPositioning(3f, 3f, default)) {
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
                 Click clicked = gui.BuildFactorioObjectButton(goods, 3f, MilestoneDisplay.Contained, bgColor, useScale, tooltipOptions);
                 if (goods != null) {
-                    gui.BuildText(DataUtils.FormatAmount(amount.Value, amount.Unit), Font.text, false, RectAlignment.Middle, textColor);
+                    gui.BuildText(DataUtils.FormatAmount(amount.Value, amount.Unit), textDisplayStyle);
                     if (InputSystem.Instance.control && gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver) {
                         ShowPrecisionValueTooltip(gui, amount, goods);
                     }
@@ -241,7 +242,7 @@ namespace Yafc {
             }
             gui.ShowTooltip(gui.lastRect, x => {
                 _ = x.BuildFactorioObjectButtonWithText(goods);
-                x.BuildText(text, wrap: true);
+                x.BuildText(text, TextBlockDisplayStyle.WrappedText);
             }, 10f);
         }
 

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -60,8 +60,8 @@ namespace Yafc {
             }
         }
 
-        public static bool BuildFloatInput(this ImGui gui, DisplayAmount amount, Padding padding, bool setInitialFocus = false) {
-            if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, Icon.None, true, padding, setInitialFocus: setInitialFocus)
+        public static bool BuildFloatInput(this ImGui gui, DisplayAmount amount, TextBoxDisplayStyle displayStyle, bool setInitialFocus = false) {
+            if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, displayStyle, true, setInitialFocus)
                 && DataUtils.TryParseAmount(newText, out float newValue, amount.Unit)) {
                 amount.Value = newValue;
                 return true;
@@ -270,11 +270,8 @@ namespace Yafc {
             group.SetWidth(3f);
             GoodsWithAmountEvent evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectButton(obj, 3f, MilestoneDisplay.Contained, color, useScale, tooltipOptions);
 
-            if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColorGroup.Secondary)) {
-                if (DataUtils.TryParseAmount(newText, out float newAmount, amount.Unit)) {
-                    amount.Value = newAmount;
-                    return GoodsWithAmountEvent.TextEditing;
-                }
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput)) {
+                return GoodsWithAmountEvent.TextEditing;
             }
 
             if (allowScroll && gui.action == ImGuiAction.MouseScroll && gui.ConsumeEvent(gui.lastRect)) {

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -272,7 +272,7 @@ namespace Yafc {
             newAmount = amount;
             GoodsWithAmountEvent evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectButton(obj, 3f, MilestoneDisplay.Contained, color, useScale, tooltipOptions);
 
-            if (gui.BuildTextInput(DataUtils.FormatAmount(amount, unit), out string newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColor.Secondary)) {
+            if (gui.BuildTextInput(DataUtils.FormatAmount(amount, unit), out string newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColorGroup.Secondary)) {
                 if (DataUtils.TryParseAmount(newText, out newAmount, unit)) {
                     evt = GoodsWithAmountEvent.TextEditing;
                 }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -40,7 +40,7 @@ namespace Yafc {
                     name = name + " (" + target.target.type + ")";
                 }
 
-                gui.BuildText(name, Font.header, true);
+                gui.BuildText(name, new TextBlockDisplayStyle(Font.header, true));
                 var milestoneMask = Milestones.Instance.GetMilestoneResult(target.target);
                 if (milestoneMask.HighestBitSet() > 0) {
                     float spacing = MathF.Min((22f / Milestones.Instance.currentMilestones.Length) - 1f, 0f);
@@ -75,7 +75,7 @@ namespace Yafc {
             const int itemsPerRow = 9;
             int count = objects.Count;
             if (count == 0) {
-                gui.BuildText("Nothing", color: SchemeColor.BackgroundTextFaint);
+                gui.BuildText("Nothing", TextBlockDisplayStyle.HintText);
                 return;
             }
 
@@ -118,7 +118,7 @@ namespace Yafc {
         private void BuildItem(ImGui gui, IFactorioObjectWrapper item) {
             using (gui.EnterRow()) {
                 gui.BuildFactorioObjectIcon(item.target);
-                gui.BuildText(item.text, wrap: true);
+                gui.BuildText(item.text, TextBlockDisplayStyle.WrappedText);
             }
         }
 
@@ -150,21 +150,21 @@ namespace Yafc {
                 }
 
                 if (target.locDescr != null) {
-                    gui.BuildText(target.locDescr, wrap: true);
+                    gui.BuildText(target.locDescr, TextBlockDisplayStyle.WrappedText);
                 }
 
                 if (!target.IsAccessible()) {
-                    gui.BuildText("This " + target.type + " is inaccessible, or it is only accessible through mod or map script. Middle click to open dependency analyzer to investigate.", wrap: true);
+                    gui.BuildText("This " + target.type + " is inaccessible, or it is only accessible through mod or map script. Middle click to open dependency analyzer to investigate.", TextBlockDisplayStyle.WrappedText);
                 }
                 else if (!target.IsAutomatable()) {
-                    gui.BuildText("This " + target.type + " cannot be fully automated. This means that it requires either manual crafting, or manual labor such as cutting trees", wrap: true);
+                    gui.BuildText("This " + target.type + " cannot be fully automated. This means that it requires either manual crafting, or manual labor such as cutting trees", TextBlockDisplayStyle.WrappedText);
                 }
                 else {
-                    gui.BuildText(CostAnalysis.GetDisplayCost(target), wrap: true);
+                    gui.BuildText(CostAnalysis.GetDisplayCost(target), TextBlockDisplayStyle.WrappedText);
                 }
 
                 if (target.IsAccessibleWithCurrentMilestones() && !target.IsAutomatableWithCurrentMilestones()) {
-                    gui.BuildText("This " + target.type + " cannot be fully automated at current milestones.", wrap: true);
+                    gui.BuildText("This " + target.type + " cannot be fully automated at current milestones.", TextBlockDisplayStyle.WrappedText);
                 }
 
                 if (target.specialType != FactorioObjectSpecialType.Normal) {
@@ -198,7 +198,7 @@ namespace Yafc {
 
             if (entity.mapGenerated) {
                 using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("Generates on map (estimated density: " + (entity.mapGenDensity <= 0f ? "unknown" : DataUtils.FormatAmount(entity.mapGenDensity, UnitOfMeasure.None)) + ")", wrap: true);
+                    gui.BuildText("Generates on map (estimated density: " + (entity.mapGenDensity <= 0f ? "unknown" : DataUtils.FormatAmount(entity.mapGenDensity, UnitOfMeasure.None)) + ")", TextBlockDisplayStyle.WrappedText);
                 }
             }
 
@@ -218,7 +218,7 @@ namespace Yafc {
                         if (crafter.allowedEffects != AllowedEffects.None) {
                             gui.BuildText("Module slots: " + crafter.moduleSlots);
                             if (crafter.allowedEffects != AllowedEffects.All) {
-                                gui.BuildText("Only allowed effects: " + crafter.allowedEffects, wrap: true);
+                                gui.BuildText("Only allowed effects: " + crafter.allowedEffects, TextBlockDisplayStyle.WrappedText);
                             }
                         }
                     }
@@ -245,16 +245,16 @@ namespace Yafc {
                     }
 
                     if (entity.energy.emissions != 0f) {
-                        var emissionColor = SchemeColor.BackgroundText;
+                        TextBlockDisplayStyle emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.BackgroundText);
                         if (entity.energy.emissions < 0f) {
-                            emissionColor = SchemeColor.Green;
-                            gui.BuildText("This building absorbs pollution", color: emissionColor);
+                            emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Green);
+                            gui.BuildText("This building absorbs pollution", emissionStyle);
                         }
                         else if (entity.energy.emissions >= 20f) {
-                            emissionColor = SchemeColor.Error;
-                            gui.BuildText("This building contributes to global warning!", color: emissionColor);
+                            emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Error);
+                            gui.BuildText("This building contributes to global warning!", emissionStyle);
                         }
-                        gui.BuildText("Emissions: " + DataUtils.FormatAmount(entity.energy.emissions, UnitOfMeasure.None), color: emissionColor);
+                        gui.BuildText("Emissions: " + DataUtils.FormatAmount(entity.energy.emissions, UnitOfMeasure.None), emissionStyle);
                     }
                 }
             }
@@ -293,7 +293,7 @@ namespace Yafc {
             BuildCommon(goods, gui);
             if (goods.showInExplorers) {
                 using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, wrap: true);
+                    gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, TextBlockDisplayStyle.WrappedText);
                 }
             }
 
@@ -303,7 +303,7 @@ namespace Yafc {
                     BuildIconRow(gui, goods.production, 2);
                     if (tooltipOptions.HintLocations.HasFlag(HintLocations.OnProducingRecipes)) {
                         goods.production.SelectSingle(out string recipeTip);
-                        gui.BuildText(recipeTip, color: SchemeColor.BackgroundTextFaint);
+                        gui.BuildText(recipeTip, TextBlockDisplayStyle.HintText);
                     }
                 }
             }
@@ -321,7 +321,7 @@ namespace Yafc {
                     BuildIconRow(gui, goods.usages, 4);
                     if (tooltipOptions.HintLocations.HasFlag(HintLocations.OnConsumingRecipes)) {
                         goods.usages.SelectSingle(out string recipeTip);
-                        gui.BuildText(recipeTip, color: SchemeColor.BackgroundTextFaint);
+                        gui.BuildText(recipeTip, TextBlockDisplayStyle.HintText);
                     }
                 }
             }
@@ -403,15 +403,15 @@ namespace Yafc {
                     if (waste > 0.01f) {
                         int wasteAmount = MathUtils.Round(waste * 100f);
                         string wasteText = ". (Wasting " + wasteAmount + "% of YAFC cost)";
-                        var color = wasteAmount < 90 ? SchemeColor.BackgroundText : SchemeColor.Error;
+                        TextBlockDisplayStyle style = TextBlockDisplayStyle.WrappedText with { Color = wasteAmount < 90 ? SchemeColor.BackgroundText : SchemeColor.Error };
                         if (recipe.products.Length == 1) {
-                            gui.BuildText("YAFC analysis: There are better recipes to create " + recipe.products[0].goods.locName + wasteText, wrap: true, color: color);
+                            gui.BuildText("YAFC analysis: There are better recipes to create " + recipe.products[0].goods.locName + wasteText, style);
                         }
                         else if (recipe.products.Length > 0) {
-                            gui.BuildText("YAFC analysis: There are better recipes to create each of the products" + wasteText, wrap: true, color: color);
+                            gui.BuildText("YAFC analysis: There are better recipes to create each of the products" + wasteText, style);
                         }
                         else {
-                            gui.BuildText("YAFC analysis: This recipe wastes useful products. Don't do this recipe.", wrap: true, color: color);
+                            gui.BuildText("YAFC analysis: This recipe wastes useful products. Don't do this recipe.", style);
                         }
                     }
                 }
@@ -495,7 +495,7 @@ namespace Yafc {
             BuildRecipe(technology, gui);
             if (technology.hidden && !technology.enabled) {
                 using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("This technology is hidden from the list and cannot be researched.", wrap: true);
+                    gui.BuildText("This technology is hidden from the list and cannot be researched.", TextBlockDisplayStyle.WrappedText);
                 }
             }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -520,7 +520,7 @@ namespace Yafc {
                     using var grid = gui.EnterInlineGrid(3f);
                     foreach (var pack in packs) {
                         grid.Next();
-                        _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount);
+                        _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount, ButtonDisplayStyle.ProductionTableUnscaled);
                     }
                 }
             }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -520,7 +520,7 @@ namespace Yafc {
                     using var grid = gui.EnterInlineGrid(3f);
                     foreach (var pack in packs) {
                         grid.Next();
-                        _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount, UnitOfMeasure.None);
+                        _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount);
                     }
                 }
             }

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -31,7 +31,7 @@ namespace Yafc {
         }
 
         protected void BuildHeader(ImGui gui, string? text, bool closeButton = true) {
-            gui.BuildText(text, Font.header, false, RectAlignment.Middle);
+            gui.BuildText(text, new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
             if (closeButton) {
                 Rect closeButtonRect = new Rect(width - 3f, 0f, 3f, 2f);
                 if (gui.isBuilding) {

--- a/Yafc/Windows/AboutScreen.cs
+++ b/Yafc/Windows/AboutScreen.cs
@@ -8,14 +8,14 @@ namespace Yafc {
 
         protected override void BuildContents(ImGui gui) {
             gui.allocator = RectAllocator.Center;
-            gui.BuildText("Yet Another Factorio Calculator", Font.header, align: RectAlignment.Middle);
-            gui.BuildText("(Community Edition)", align: RectAlignment.Middle);
-            gui.BuildText("Copyright 2020-2021 ShadowTheAge", align: RectAlignment.Middle);
-            gui.BuildText("Copyright 2024 YAFC Community", align: RectAlignment.Middle);
+            gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
+            gui.BuildText("(Community Edition)", TextBlockDisplayStyle.Centered);
+            gui.BuildText("Copyright 2020-2021 ShadowTheAge", TextBlockDisplayStyle.Centered);
+            gui.BuildText("Copyright 2024 YAFC Community", TextBlockDisplayStyle.Centered);
             gui.allocator = RectAllocator.LeftAlign;
             gui.AllocateSpacing(1.5f);
-            gui.BuildText("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.", wrap: true);
-            gui.BuildText("This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.", wrap: true);
+            gui.BuildText("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.", TextBlockDisplayStyle.WrappedText);
+            gui.BuildText("This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.", TextBlockDisplayStyle.WrappedText);
             using (gui.EnterRow(0.3f)) {
                 gui.BuildText("Full license text:");
                 BuildLink(gui, "https://gnu.org/licenses/gpl-3.0.html");

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -45,7 +45,7 @@ namespace Yafc {
                 string text = fobj.locName + " (" + fobj.type + ")";
                 gui.RemainingRow(0.5f).BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint });
             }
-            if (gui.BuildFactorioObjectButton(gui.lastRect, fobj, tooltipOptions: new() { ExtendHeader = true }) == Click.Left) {
+            if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, fobj, tooltipOptions: new() { ExtendHeader = true }) == Click.Left) {
                 Change(fobj);
             }
         }

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -43,7 +43,7 @@ namespace Yafc {
             using (gui.EnterGroup(listPad, RectAllocator.LeftRow)) {
                 gui.BuildFactorioObjectIcon(fobj);
                 string text = fobj.locName + " (" + fobj.type + ")";
-                gui.RemainingRow(0.5f).BuildText(text, null, true, color: fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint);
+                gui.RemainingRow(0.5f).BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint });
             }
             if (gui.BuildFactorioObjectButton(gui.lastRect, fobj, tooltipOptions: new() { ExtendHeader = true }) == Click.Left) {
                 Change(fobj);
@@ -83,7 +83,7 @@ namespace Yafc {
                         text += ", and it is inaccessible";
                     }
 
-                    gui.BuildText(text, wrap: true);
+                    gui.BuildText(text, TextBlockDisplayStyle.WrappedText);
                 }
             }
         }
@@ -112,7 +112,7 @@ namespace Yafc {
                     SelectSingleObjectPanel.Select(Database.objects.explorable, "Select something", Change);
                 }
 
-                gui.BuildText("(Click to change)", color: SchemeColor.BackgroundTextFaint);
+                gui.BuildText("(Click to change)", TextBlockDisplayStyle.HintText);
             }
             using (gui.EnterRow()) {
                 var settings = Project.current.settings;

--- a/Yafc/Windows/ErrorListPanel.cs
+++ b/Yafc/Windows/ErrorListPanel.cs
@@ -15,7 +15,7 @@ namespace Yafc {
 
         private void BuildErrorList(ImGui gui) {
             foreach (var error in errors) {
-                gui.BuildText(error.error, wrap: true, color: error.severity >= ErrorSeverity.MajorDataLoss ? SchemeColor.Error : SchemeColor.BackgroundText);
+                gui.BuildText(error.error, TextBlockDisplayStyle.WrappedText with { Color = error.severity >= ErrorSeverity.MajorDataLoss ? SchemeColor.Error : SchemeColor.BackgroundText });
             }
         }
 

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -147,7 +147,7 @@ namespace Yafc {
             using (gui.EnterGroup(default, RectAllocator.LeftRow)) {
                 gui.BuildIcon(icon);
                 if (element.type == EntryType.CreateDirectory) {
-                    if (gui.BuildTextInput("", out string dirName, elementText, Icon.None, true, new Padding(0.2f, 0.2f))) {
+                    if (gui.BuildTextInput("", out string dirName, elementText, TextBoxDisplayStyle.DefaultTextInput with { Padding = new Padding(0.2f) }, true)) {
                         if (!string.IsNullOrWhiteSpace(dirName) && dirName.IndexOfAny(Path.GetInvalidFileNameChars()) == -1) {
                             string dirPath = Path.Combine(location, dirName);
                             _ = Directory.CreateDirectory(dirPath);

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -43,7 +43,7 @@ namespace Yafc {
         }
 
         protected override void BuildContents(ImGui gui) {
-            gui.BuildText(description, wrap: true);
+            gui.BuildText(description, TextBlockDisplayStyle.WrappedText);
             if (gui.BuildTextInput(location, out string newLocation, null)) {
                 if (Directory.Exists(newLocation)) {
                     SetLocation(newLocation);

--- a/Yafc/Windows/ImageSharePanel.cs
+++ b/Yafc/Windows/ImageSharePanel.cs
@@ -23,7 +23,7 @@ namespace Yafc {
 
         public override void Build(ImGui gui) {
             BuildHeader(gui, "Image generated");
-            gui.BuildText(header, wrap: true);
+            gui.BuildText(header, TextBlockDisplayStyle.WrappedText);
             if (gui.BuildButton("Save as PNG")) {
                 SaveAsPng();
             }

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -124,7 +124,7 @@ namespace Yafc {
                     gui.BuildIcon(element.icon.icon);
                 }
 
-                gui.RemainingRow().BuildText(element.name, color: element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint);
+                gui.RemainingRow().BuildText(element.name, TextBlockDisplayStyle.Default(element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint));
             }
             var evt = gui.BuildButton(gui.lastRect, SchemeColor.PureBackground, SchemeColor.Grey, button: 0);
             if (evt) {
@@ -726,7 +726,7 @@ namespace Yafc {
             ShowTooltip(gui, rect, x => {
                 pageView.BuildPageTooltip(x, page.content);
                 if (isMiddleEdit) {
-                    x.BuildText("Middle mouse button to edit", Font.text, true, color: SchemeColor.BackgroundTextFaint);
+                    x.BuildText("Middle mouse button to edit", TextBlockDisplayStyle.WrappedText with { Color = SchemeColor.BackgroundTextFaint });
                 }
             });
         }

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -32,7 +32,7 @@ namespace Yafc {
         public override void Build(ImGui gui) {
             BuildHeader(gui, title);
             if (message != null) {
-                gui.BuildText(message, wrap: true);
+                gui.BuildText(message, TextBlockDisplayStyle.WrappedText);
             }
 
             gui.AllocateSpacing(2f);

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -26,7 +26,7 @@ namespace Yafc {
         private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             using (gui.EnterRow()) {
                 var settings = Project.current.settings;
-                gui.BuildFactorioObjectIcon(element, MilestoneDisplay.None, 3f);
+                gui.BuildFactorioObjectIcon(element, new IconDisplayStyle(3f, MilestoneDisplay.None, false));
                 gui.BuildText(element.locName, maxWidth: width - 16.6f); // Experimentally determined width of the non-text parts of the editor.
                 if (gui.BuildButton(Icon.Close, size: 1f)) {
                     _ = settings.RecordUndo().milestones.Remove(element);

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -44,7 +44,7 @@ namespace Yafc {
             milestoneList.Build(gui);
             gui.BuildText(
                 "Hint: You can reorder milestones. When an object is locked behind a milestone, the first inaccessible milestone will be shown. Also when there is a choice between different milestones, first will be chosen",
-                wrap: true, color: SchemeColor.BackgroundTextFaint);
+                TextBlockDisplayStyle.WrappedText with { Color = SchemeColor.BackgroundTextFaint });
             using (gui.EnterRow()) {
                 if (gui.BuildButton("Auto sort milestones", SchemeColor.Grey)) {
                     ErrorCollector collector = new ErrorCollector();

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -9,7 +9,7 @@ namespace Yafc {
         private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             var settings = Project.current.settings;
             bool unlocked = settings.Flags(element).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
-            if (gui.BuildFactorioObjectButton(element, 3f, display: MilestoneDisplay.None, bgColor: unlocked ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
+            if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.Milestone(unlocked ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
                 if (!unlocked) {
                     var massUnlock = Milestones.Instance.GetMilestoneResult(element);
                     int subIndex = 0;

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -43,10 +43,10 @@ namespace Yafc {
             gui.AllocateSpacing(2f);
             milestonesWidget.Build(gui);
             gui.AllocateSpacing(2f);
-            gui.BuildText("For your convenience, YAFC will show objects you DON'T have access to based on this selection", wrap: true);
+            gui.BuildText("For your convenience, YAFC will show objects you DON'T have access to based on this selection", TextBlockDisplayStyle.WrappedText);
             gui.BuildText("These are called 'Milestones'. By default all science packs are added as milestones, but this does not have to be this way! " +
                           "You can define your own milestones: Any item, recipe, entity or technology may be added as a milestone. For example you can add advanced " +
-                          "electronic circuits as a milestone, and YAFC will display everything that is locked behind those circuits", wrap: true);
+                          "electronic circuits as a milestone, and YAFC will display everything that is locked behind those circuits", TextBlockDisplayStyle.WrappedText);
             using (gui.EnterRow()) {
                 if (gui.BuildButton("Edit milestones", SchemeColor.Grey)) {
                     MilestonesEditor.Show();

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -181,11 +181,11 @@ namespace Yafc {
                     _ = gui.BuildFactorioObjectButton(entry.recipe, 4f, MilestoneDisplay.Contained);
                     using (gui.EnterRow()) {
                         gui.BuildIcon(Icon.Time);
-                        gui.BuildText(DataUtils.FormatAmount(entry.recipe.time, UnitOfMeasure.Second), align: RectAlignment.Middle);
+                        gui.BuildText(DataUtils.FormatAmount(entry.recipe.time, UnitOfMeasure.Second), TextBlockDisplayStyle.Centered);
                     }
                     float bh = CostAnalysis.GetBuildingHours(recipe, entry.recipeFlow);
                     if (bh > 20) {
-                        gui.BuildText(DataUtils.FormatAmount(bh, UnitOfMeasure.None, suffix: "bh"), align: RectAlignment.Middle);
+                        gui.BuildText(DataUtils.FormatAmount(bh, UnitOfMeasure.None, suffix: "bh"), TextBlockDisplayStyle.Centered);
                         _ = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, "Building-hours.\nAmount of building-hours required for all researches assuming crafting speed of 1");
                     }
                 }
@@ -201,7 +201,7 @@ namespace Yafc {
                     }
 
                     gui.allocator = textAlloc;
-                    gui.BuildText(recipe.locName, wrap: true);
+                    gui.BuildText(recipe.locName, TextBlockDisplayStyle.WrappedText);
                 }
                 if (recipe.ingredients.Length + recipe.products.Length <= 8) {
                     using (gui.EnterRow()) {
@@ -284,7 +284,7 @@ namespace Yafc {
                     footerDrawn = true;
                     gui.BuildText(entry.entryStatus == EntryStatus.Special ? "Show special recipes (barreling / voiding)" :
                         entry.entryStatus == EntryStatus.NotAccessibleWithCurrentMilestones ? "There are more recipes, but they are locked based on current milestones" :
-                        "There are more recipes but they are inaccessible", wrap: true);
+                        "There are more recipes but they are inaccessible", TextBlockDisplayStyle.WrappedText);
                     if (gui.BuildButton("Show more recipes")) {
                         ChangeShowStatus(status);
                     }
@@ -348,7 +348,7 @@ namespace Yafc {
                 gui.BuildText(CostAnalysis.GetDisplayCost(current));
                 string? amount = CostAnalysis.Instance.GetItemAmount(current);
                 if (amount != null) {
-                    gui.BuildText(amount, wrap: true);
+                    gui.BuildText(amount, TextBlockDisplayStyle.WrappedText);
                 }
             }
 

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -118,7 +118,7 @@ namespace Yafc {
                 return;
             }
             foreach (var ingredient in recipe.ingredients) {
-                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
                     if (ingredient.variants != null) {
                         gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton<Goods>(ingredient.variants, DataUtils.DefaultOrdering, SetItem, "Accepted fluid variants"));
                     }
@@ -136,7 +136,7 @@ namespace Yafc {
             }
             for (int i = recipe.products.Length - 1; i >= 0; i--) {
                 var product = recipe.products[i];
-                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
                     changing = product.goods;
                 }
             }
@@ -146,7 +146,7 @@ namespace Yafc {
             using var grid = gui.EnterInlineGrid(3f, 0f, maxElemCount);
             foreach (var item in list) {
                 grid.Next();
-                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
                     changing = item.target as Goods;
                 }
             }
@@ -178,7 +178,7 @@ namespace Yafc {
             using (gui.EnterGroup(new Padding(0.5f), production ? RectAllocator.LeftRow : RectAllocator.RightRow, textColor)) {
                 using (gui.EnterFixedPositioning(4f, 0f, default)) {
                     gui.allocator = RectAllocator.Stretch;
-                    _ = gui.BuildFactorioObjectButton(entry.recipe, 4f, MilestoneDisplay.Contained);
+                    _ = gui.BuildFactorioObjectButton(entry.recipe, ButtonDisplayStyle.NeieLarge);
                     using (gui.EnterRow()) {
                         gui.BuildIcon(Icon.Time);
                         gui.BuildText(DataUtils.FormatAmount(entry.recipe.time, UnitOfMeasure.Second), TextBlockDisplayStyle.Centered);
@@ -256,7 +256,7 @@ namespace Yafc {
                     using var grid = gui.EnterInlineGrid(3f);
                     foreach (var fuelUsage in current.fuelFor) {
                         grid.Next();
-                        _ = gui.BuildFactorioObjectButton(fuelUsage, 3f, MilestoneDisplay.Contained);
+                        _ = gui.BuildFactorioObjectButton(fuelUsage, ButtonDisplayStyle.NeieSmall);
                     }
                 }
                 if (gui.isBuilding) {
@@ -305,7 +305,7 @@ namespace Yafc {
                 if (status == EntryStatus.NotAccessibleWithCurrentMilestones) {
                     var latest = Milestones.Instance.GetHighest(entry.recipe, false);
                     if (latest != prevLatestMilestone) {
-                        _ = gui.BuildFactorioObjectButtonWithText(latest, size: 3f, display: MilestoneDisplay.None);
+                        _ = gui.BuildFactorioObjectButtonWithText(latest, iconDisplayStyle: new(3, MilestoneDisplay.None, false));
                         prevLatestMilestone = latest;
                     }
                 }
@@ -335,14 +335,14 @@ namespace Yafc {
 
                 for (int i = recent.Count - 1; i >= 0; i--) {
                     var elem = recent[i];
-                    if (gui.BuildFactorioObjectButton(elem, 3f) == Click.Left) {
+                    if (gui.BuildFactorioObjectButton(elem, ButtonDisplayStyle.NeieSmall) == Click.Left) {
                         changing = elem;
                     }
                 }
             }
             using (gui.EnterGroup(new Padding(0.5f), RectAllocator.LeftRow)) {
                 gui.spacing = 0.2f;
-                gui.BuildFactorioObjectIcon(current, size: 3f);
+                gui.BuildFactorioObjectIcon(current, ButtonDisplayStyle.NeieSmall);
                 gui.BuildText(current.locName, Font.subheader);
                 gui.allocator = RectAllocator.RightAlign;
                 gui.BuildText(CostAnalysis.GetDisplayCost(current));
@@ -352,7 +352,7 @@ namespace Yafc {
                 }
             }
 
-            if (gui.BuildFactorioObjectButton(gui.lastRect, current, SchemeColor.Grey) == Click.Left) {
+            if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, current, SchemeColor.Grey) == Click.Left) {
                 SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
             }
 

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -118,7 +118,7 @@ namespace Yafc {
                 return;
             }
             foreach (var ingredient in recipe.ingredients) {
-                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, UnitOfMeasure.None) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount) == Click.Left) {
                     if (ingredient.variants != null) {
                         gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton<Goods>(ingredient.variants, DataUtils.DefaultOrdering, SetItem, "Accepted fluid variants"));
                     }
@@ -136,7 +136,7 @@ namespace Yafc {
             }
             for (int i = recipe.products.Length - 1; i >= 0; i--) {
                 var product = recipe.products[i];
-                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount, UnitOfMeasure.None) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount) == Click.Left) {
                     changing = product.goods;
                 }
             }
@@ -146,7 +146,7 @@ namespace Yafc {
             using var grid = gui.EnterInlineGrid(3f, 0f, maxElemCount);
             foreach (var item in list) {
                 grid.Next();
-                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount, UnitOfMeasure.None) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount) == Click.Left) {
                     changing = item.target as Goods;
                 }
             }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -41,7 +41,7 @@ namespace Yafc {
             using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
                 gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
                 DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, new Padding(0.5f)) && amount.Value >= 0) {
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
                     settings.RecordUndo().PollutionCostModifier = amount.Value;
                     gui.Rebuild();
                 }
@@ -50,7 +50,7 @@ namespace Yafc {
             using (gui.EnterRowWithHelpIcon("Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.")) {
                 gui.BuildText("Display scale for linkable icons", topOffset: 0.5f);
                 DisplayAmount amount = new(prefs.iconScale, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, new Padding(0.5f)) && amount.Value > 0 && amount.Value <= 1) {
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value > 0 && amount.Value <= 1) {
                     prefs.RecordUndo().iconScale = amount.Value;
                     gui.Rebuild();
                 }
@@ -153,7 +153,7 @@ namespace Yafc {
                     }
                 }
                 gui.BuildText("per second");
-                _ = gui.BuildFloatInput(unit, new Padding(.5f));
+                _ = gui.BuildFloatInput(unit, TextBoxDisplayStyle.DefaultTextInput);
             }
             gui.AllocateSpacing(1f);
 

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -40,16 +40,18 @@ namespace Yafc {
 
             using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
                 gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
-                if (gui.BuildFloatInput(settings.PollutionCostModifier, out float pollutionCostModifier, UnitOfMeasure.Percent, new Padding(0.5f))) {
-                    settings.RecordUndo().PollutionCostModifier = pollutionCostModifier;
+                DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, new Padding(0.5f))) {
+                    settings.RecordUndo().PollutionCostModifier = amount.Value;
                     gui.Rebuild();
                 }
             }
 
             using (gui.EnterRowWithHelpIcon("Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.")) {
                 gui.BuildText("Display scale for linkable icons", topOffset: 0.5f);
-                if (gui.BuildFloatInput(prefs.iconScale, out float iconScale, UnitOfMeasure.Percent, new Padding(0.5f)) && iconScale > 0 && iconScale <= 1) {
-                    prefs.RecordUndo().iconScale = iconScale;
+                DisplayAmount amount = new(prefs.iconScale, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, new Padding(0.5f)) && amount.Value > 0 && amount.Value <= 1) {
+                    prefs.RecordUndo().iconScale = amount.Value;
                     gui.Rebuild();
                 }
             }
@@ -130,15 +132,14 @@ namespace Yafc {
         }
 
         private void BuildUnitPerTime(ImGui gui, bool fluid, ProjectPreferences preferences) {
-            float unit = fluid ? preferences.fluidUnit : preferences.itemUnit;
-            float newUnit = unit;
+            DisplayAmount unit = fluid ? preferences.fluidUnit : preferences.itemUnit;
             if (gui.BuildRadioButton("Simple Amount" + preferences.GetPerTimeUnit().suffix, unit == 0f)) {
-                newUnit = 0f;
+                unit = 0f;
             }
 
             using (gui.EnterRow()) {
                 if (gui.BuildRadioButton("Custom: 1 unit equals", unit != 0f)) {
-                    newUnit = 1f;
+                    unit = 1f;
                 }
 
                 gui.AllocateSpacing();
@@ -152,20 +153,18 @@ namespace Yafc {
                     }
                 }
                 gui.BuildText("per second");
-                if (gui.BuildTextInput(DataUtils.FormatAmount(unit, UnitOfMeasure.None), out string updated, null, Icon.None, true) &&
-                    DataUtils.TryParseAmount(updated, out float parsed, UnitOfMeasure.None)) {
-                    newUnit = parsed;
-                }
+                _ = gui.BuildFloatInput(unit, new Padding(.5f));
             }
             gui.AllocateSpacing(1f);
 
-            if (newUnit != unit) {
-                _ = preferences.RecordUndo(true);
-                if (fluid) {
-                    preferences.fluidUnit = newUnit;
+            if (fluid) {
+                if (preferences.fluidUnit != unit.Value) {
+                    preferences.RecordUndo(true).fluidUnit = unit.Value;
                 }
-                else {
-                    preferences.itemUnit = newUnit;
+            }
+            else {
+                if (preferences.itemUnit != unit.Value) {
+                    preferences.RecordUndo(true).itemUnit = unit.Value;
                 }
             }
         }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -41,7 +41,7 @@ namespace Yafc {
             using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
                 gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
                 DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, new Padding(0.5f))) {
+                if (gui.BuildFloatInput(amount, new Padding(0.5f)) && amount.Value >= 0) {
                     settings.RecordUndo().PollutionCostModifier = amount.Value;
                     gui.Rebuild();
                 }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -26,7 +26,7 @@ namespace Yafc {
 
         private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
             _ = gui.BuildTextInput(name, out name, "Input name", setInitialFocus: editingPage == null);
-            if (gui.BuildFactorioObjectButton(icon, 4f, MilestoneDisplay.None, SchemeColor.Grey) == Click.Left) {
+            if (gui.BuildFactorioObjectButton(icon, new ButtonDisplayStyle(4f, MilestoneDisplay.None, SchemeColor.Grey) with { UseScaleSetting = false }) == Click.Left) {
                 SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
             }
 

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -29,7 +29,8 @@ namespace Yafc {
         }
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
-            Click click = gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, true, new() { ExtendHeader = extendHeader });
+            SchemeColor bgColor = results.Contains(element) ? SchemeColor.Primary : SchemeColor.None;
+            Click click = gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(bgColor), new() { ExtendHeader = extendHeader });
 
             if (checkMark(element)) {
                 gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -52,7 +52,7 @@ namespace Yafc {
                 if (gui.BuildButton("OK")) {
                     CloseWithResult(results);
                 }
-                gui.BuildText("Hint: ctrl+click to select multiple", color: SchemeColor.BackgroundTextFaint);
+                gui.BuildText("Hint: ctrl+click to select multiple", TextBlockDisplayStyle.HintText);
             }
         }
 

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -34,7 +34,7 @@ namespace Yafc {
             => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
-            if (gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, useScale: true, tooltipOptions: new() { ExtendHeader = extendHeader }) == Click.Left) {
+            if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ExtendHeader = extendHeader }) == Click.Left) {
                 CloseWithResult(element);
             }
         }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -47,7 +47,7 @@ namespace Yafc {
             BuildHeader(gui, "Shopping list");
             gui.BuildText(
                 "Total cost of all objects: " + DataUtils.FormatAmount(shoppingCost, UnitOfMeasure.None, "¥") + ", buildings: " +
-                DataUtils.FormatAmount(totalBuildings, UnitOfMeasure.None) + ", modules: " + DataUtils.FormatAmount(totalModules, UnitOfMeasure.None), align: RectAlignment.Middle);
+                DataUtils.FormatAmount(totalBuildings, UnitOfMeasure.None) + ", modules: " + DataUtils.FormatAmount(totalModules, UnitOfMeasure.None), TextBlockDisplayStyle.Centered);
             gui.AllocateSpacing(1f);
             list.Build(gui);
             using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
@@ -85,7 +85,7 @@ namespace Yafc {
         }
 
         private void ExportBlueprintDropdown(ImGui gui) {
-            gui.BuildText("Blueprint string will be copied to clipboard", wrap: true);
+            gui.BuildText("Blueprint string will be copied to clipboard", TextBlockDisplayStyle.WrappedText);
             if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator) && gui.BuildFactorioObjectButtonWithText(combinator) == Click.Left && gui.CloseDropdown()) {
                 _ = BlueprintUtilities.ExportConstantCombinators("Shopping list", ExportGoods<Goods>());
             }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -17,10 +17,10 @@ namespace Yafc {
 
         private void ElementDrawer(ImGui gui, (FactorioObject obj, float count) element, int index) {
             using (gui.EnterRow()) {
-                gui.BuildFactorioObjectIcon(element.obj, MilestoneDisplay.Contained);
+                gui.BuildFactorioObjectIcon(element.obj, new IconDisplayStyle(2, MilestoneDisplay.Contained, false));
                 gui.RemainingRow().BuildText(DataUtils.FormatAmount(element.count, UnitOfMeasure.None, "x") + ": " + element.obj.locName);
             }
-            _ = gui.BuildFactorioObjectButton(gui.lastRect, element.obj);
+            _ = gui.BuildFactorioObjectButtonBackground(gui.lastRect, element.obj);
         }
 
         public static void Show(Dictionary<FactorioObject, int> counts) {

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -89,22 +89,22 @@ namespace Yafc {
 
         private void BuildError(ImGui gui) {
             if (errorMod != null) {
-                gui.BuildText("Error While loading mod " + errorMod, Font.text, align: RectAlignment.Middle, color: SchemeColor.Error);
+                gui.BuildText("Error While loading mod " + errorMod, TextBlockDisplayStyle.Centered with { Color = SchemeColor.Error });
             }
 
             gui.allocator = RectAllocator.Stretch;
-            gui.BuildText(errorMessage, Font.text, color: SchemeColor.ErrorText, wrap: true);
+            gui.BuildText(errorMessage, TextBlockDisplayStyle.ErrorText);
             gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
         }
 
         protected override void BuildContents(ImGui gui) {
             gui.spacing = 1.5f;
-            gui.BuildText("Yet Another Factorio Calculator", Font.header, align: RectAlignment.Middle);
+            gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
             if (loading) {
-                gui.BuildText(currentLoad1, align: RectAlignment.Middle);
-                gui.BuildText(currentLoad2, align: RectAlignment.Middle);
+                gui.BuildText(currentLoad1, TextBlockDisplayStyle.Centered);
+                gui.BuildText(currentLoad2, TextBlockDisplayStyle.Centered);
                 gui.AllocateSpacing(15f);
-                gui.BuildText(tip, wrap: true, align: RectAlignment.Middle);
+                gui.BuildText(tip, new TextBlockDisplayStyle(WrapText: true, Alignment: RectAlignment.Middle));
                 gui.SetNextRebuild(Ui.time + 30);
             }
             else if (errorMessage != null) {
@@ -178,15 +178,15 @@ namespace Yafc {
 
         private void ProjectErrorMoreInfo(ImGui gui) {
             gui.allocator = RectAllocator.LeftAlign;
-            gui.BuildText("Check that these mods load in Factorio", wrap: true);
-            gui.BuildText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, you need to load those in Factorio and then close the game because Factorio writes some files only when exiting", wrap: true);
-            gui.BuildText("Check that Factorio loads mods from the same folder as YAFC", wrap: true);
-            gui.BuildText("If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, don't have required dependencies, or (especially) have several versions", wrap: true);
+            gui.BuildText("Check that these mods load in Factorio", TextBlockDisplayStyle.WrappedText);
+            gui.BuildText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, you need to load those in Factorio and then close the game because Factorio writes some files only when exiting", TextBlockDisplayStyle.WrappedText);
+            gui.BuildText("Check that Factorio loads mods from the same folder as YAFC", TextBlockDisplayStyle.WrappedText);
+            gui.BuildText("If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, don't have required dependencies, or (especially) have several versions", TextBlockDisplayStyle.WrappedText);
             if (gui.BuildLink("If that doesn't help either, create a github issue")) {
                 Ui.VisitLink(AboutScreen.Github);
             }
 
-            gui.BuildText("For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.", wrap: true);
+            gui.BuildText("For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.", TextBlockDisplayStyle.WrappedText);
         }
 
         private void DoLanguageList(ImGui gui, Dictionary<string, string> list, bool enabled) {
@@ -205,13 +205,13 @@ namespace Yafc {
         private void LanguageSelection(ImGui gui) {
             gui.spacing = 0f;
             gui.allocator = RectAllocator.LeftAlign;
-            gui.BuildText("Mods may not support your language, using English as a fallback.", wrap: true);
+            gui.BuildText("Mods may not support your language, using English as a fallback.", TextBlockDisplayStyle.WrappedText);
             gui.AllocateSpacing(0.5f);
 
             DoLanguageList(gui, languageMapping, true);
             if (!Program.hasOverriddenFont) {
                 gui.AllocateSpacing(0.5f);
-                gui.BuildText("To select languages with non-european glyphs you need to override used font first. Download or locate a font that has your language glyphs.", wrap: true);
+                gui.BuildText("To select languages with non-european glyphs you need to override used font first. Download or locate a font that has your language glyphs.", TextBlockDisplayStyle.WrappedText);
                 gui.AllocateSpacing(0.5f);
             }
             DoLanguageList(gui, languagesRequireFontOverride, Program.hasOverriddenFont);
@@ -222,14 +222,14 @@ namespace Yafc {
             }
 
             if (Preferences.Instance.overrideFont != null) {
-                gui.BuildText(Preferences.Instance.overrideFont, wrap: true);
+                gui.BuildText(Preferences.Instance.overrideFont, TextBlockDisplayStyle.WrappedText);
                 if (gui.BuildLink("Reset font to default")) {
                     Preferences.Instance.overrideFont = null;
                     languageScroll.RebuildContents();
                     Preferences.Instance.Save();
                 }
             }
-            gui.BuildText("Selecting font to override require YAFC restart to take effect", wrap: true);
+            gui.BuildText("Selecting font to override require YAFC restart to take effect", TextBlockDisplayStyle.WrappedText);
         }
 
         private async void SelectFont() {
@@ -277,7 +277,7 @@ namespace Yafc {
         }
 
         private void BuildPathSelect(ImGui gui, ref string path, string description, string placeholder, EditType editType) {
-            gui.BuildText(description, wrap: true);
+            gui.BuildText(description, TextBlockDisplayStyle.WrappedText);
             gui.spacing = 0.5f;
             using (gui.EnterGroup(default, RectAllocator.RightRow)) {
                 if (gui.BuildButton("...")) {

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -18,7 +18,7 @@ namespace Yafc {
             using var grid = gui.EnterInlineGrid(3f, 1f);
             foreach (var goal in contents.goals) {
                 grid.Next();
-                _ = gui.BuildFactorioObjectWithAmount(goal.item, new(goal.amount, goal.item.flowUnitOfMeasure));
+                _ = gui.BuildFactorioObjectWithAmount(goal.item, new(goal.amount, goal.item.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableUnscaled);
             }
         }
 
@@ -37,7 +37,7 @@ namespace Yafc {
                         var elem = goal[i];
                         grid.Next();
                         DisplayAmount amount = new(elem.amount, elem.item.flowUnitOfMeasure);
-                        if (gui.BuildFactorioObjectWithEditableAmount(elem.item, amount) == GoodsWithAmountEvent.TextEditing) {
+                        if (gui.BuildFactorioObjectWithEditableAmount(elem.item, amount, ButtonDisplayStyle.ProductionTableUnscaled) == GoodsWithAmountEvent.TextEditing) {
                             if (amount.Value != 0f) {
                                 elem.amount = amount.Value;
                             }
@@ -90,7 +90,7 @@ namespace Yafc {
                         }
                     }
                     grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, new(recipe.recipesPerSecond, UnitOfMeasure.PerSecond), color) == Click.Left) {
+                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, new(recipe.recipesPerSecond, UnitOfMeasure.PerSecond), ButtonDisplayStyle.ProductionTableScaled(color)) == Click.Left) {
                         selectedRecipe = recipe;
                     }
                 }

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -27,7 +27,7 @@ namespace Yafc {
             string pageName = "Auto planner";
 
             void Page1(ImGui gui, ref bool valid) {
-                gui.BuildText("This is an experimental feature and may lack functionality. Unfortunately, after some prototyping it wasn't very useful to work with. More research required.", wrap: true, color: SchemeColor.Error);
+                gui.BuildText("This is an experimental feature and may lack functionality. Unfortunately, after some prototyping it wasn't very useful to work with. More research required.", TextBlockDisplayStyle.ErrorText);
                 gui.BuildText("Enter page name:");
                 _ = gui.BuildTextInput(pageName, out pageName, null);
                 gui.AllocateSpacing(2f);
@@ -56,7 +56,7 @@ namespace Yafc {
                     grid.Next();
                 }
                 gui.AllocateSpacing(2f);
-                gui.BuildText("Review active milestones, as they will restrict recipes that are considered:", wrap: true);
+                gui.BuildText("Review active milestones, as they will restrict recipes that are considered:", TextBlockDisplayStyle.WrappedText);
                 new MilestonesWidget().Build(gui);
                 gui.AllocateSpacing(2f);
                 valid = !string.IsNullOrEmpty(pageName) && goal.Count > 0;

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -18,7 +18,7 @@ namespace Yafc {
             using var grid = gui.EnterInlineGrid(3f, 1f);
             foreach (var goal in contents.goals) {
                 grid.Next();
-                _ = gui.BuildFactorioObjectWithAmount(goal.item, goal.amount, goal.item.flowUnitOfMeasure);
+                _ = gui.BuildFactorioObjectWithAmount(goal.item, new(goal.amount, goal.item.flowUnitOfMeasure));
             }
         }
 
@@ -36,10 +36,10 @@ namespace Yafc {
                     for (int i = 0; i < goal.Count; i++) {
                         var elem = goal[i];
                         grid.Next();
-                        var evt = gui.BuildFactorioObjectWithEditableAmount(elem.item, elem.amount, elem.item.flowUnitOfMeasure, out float newAmount);
-                        if (evt == GoodsWithAmountEvent.TextEditing) {
-                            if (newAmount != 0f) {
-                                elem.amount = newAmount;
+                        DisplayAmount amount = new(elem.amount, elem.item.flowUnitOfMeasure);
+                        if (gui.BuildFactorioObjectWithEditableAmount(elem.item, amount) == GoodsWithAmountEvent.TextEditing) {
+                            if (amount.Value != 0f) {
+                                elem.amount = amount.Value;
                             }
                             else {
                                 goal.RemoveAt(i--);
@@ -90,7 +90,7 @@ namespace Yafc {
                         }
                     }
                     grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, recipe.recipesPerSecond, UnitOfMeasure.PerSecond, color) == Click.Left) {
+                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, new(recipe.recipesPerSecond, UnitOfMeasure.PerSecond), color) == Click.Left) {
                         selectedRecipe = recipe;
                     }
                 }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -125,8 +125,9 @@ namespace Yafc {
                 using (gui.EnterFixedPositioning(3f, 2f, default)) {
                     gui.allocator = RectAllocator.LeftRow;
                     gui.BuildText("x");
-                    if (gui.BuildFloatInput(entry.multiplier, out float newMultiplier, UnitOfMeasure.None, default) && newMultiplier >= 0) {
-                        entry.SetMultiplier(newMultiplier);
+                    DisplayAmount amount = entry.multiplier;
+                    if (gui.BuildFloatInput(amount, default) && amount.Value >= 0) {
+                        entry.SetMultiplier(amount.Value);
                     }
                 }
             }
@@ -167,7 +168,7 @@ namespace Yafc {
                 var moveHandle = gui.statePosition;
                 moveHandle.Height = 5f;
 
-                if (gui.BuildFactorioObjectWithAmount(goods, view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure, view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(goods, new(view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure), view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
                     view.ApplyFilter(goods);
                 }
 
@@ -180,7 +181,7 @@ namespace Yafc {
             public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
                 float amount = data.GetAmount(goods);
                 if (amount != 0) {
-                    if (gui.BuildFactorioObjectWithAmount(goods, data.GetAmount(goods), goods.flowUnitOfMeasure) == Click.Left) {
+                    if (gui.BuildFactorioObjectWithAmount(goods, new(data.GetAmount(goods), goods.flowUnitOfMeasure)) == Click.Left) {
                         view.ApplyFilter(goods);
                     }
                 }
@@ -205,7 +206,7 @@ namespace Yafc {
                             view.AddOrRemoveColumn(goods);
                         }
                         else if (evt == ButtonEvent.MouseOver) {
-                            ImmediateWidgets.ShowPrecisionValueTooltip(gui, amount, goods.flowUnitOfMeasure, goods);
+                            ImmediateWidgets.ShowPrecisionValueTooltip(gui, new(amount, goods.flowUnitOfMeasure), goods);
                         }
                     }
                 }
@@ -302,7 +303,7 @@ namespace Yafc {
                 using var inlineGrid = gui.EnterInlineGrid(3f, 1f);
                 foreach (var (goods, amount) in model.sortedFlow) {
                     inlineGrid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(goods, amount, goods.flowUnitOfMeasure, model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
+                    if (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods.flowUnitOfMeasure), model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
                         AddOrRemoveColumn(goods);
                     }
                 }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -168,7 +168,7 @@ namespace Yafc {
                 var moveHandle = gui.statePosition;
                 moveHandle.Height = 5f;
 
-                if (gui.BuildFactorioObjectWithAmount(goods, new(view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure), view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(goods, new(view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
                     view.ApplyFilter(goods);
                 }
 
@@ -181,7 +181,7 @@ namespace Yafc {
             public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
                 float amount = data.GetAmount(goods);
                 if (amount != 0) {
-                    if (gui.BuildFactorioObjectWithAmount(goods, new(data.GetAmount(goods), goods.flowUnitOfMeasure)) == Click.Left) {
+                    if (gui.BuildFactorioObjectWithAmount(goods, new(data.GetAmount(goods), goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
                         view.ApplyFilter(goods);
                     }
                 }
@@ -303,7 +303,7 @@ namespace Yafc {
                 using var inlineGrid = gui.EnterInlineGrid(3f, 1f);
                 foreach (var (goods, amount) in model.sortedFlow) {
                     inlineGrid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods.flowUnitOfMeasure), model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
+                    if (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
                         AddOrRemoveColumn(goods);
                     }
                 }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -140,7 +140,7 @@ namespace Yafc {
                         gui.BuildIcon(element.icon.icon);
                     }
 
-                    gui.RemainingRow().BuildText(element.name, color: element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint);
+                    gui.RemainingRow().BuildText(element.name, TextBlockDisplayStyle.Default(element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint));
                 }
 
                 if (gui.BuildButton(gui.lastRect, SchemeColor.BackgroundAlt, SchemeColor.Background)) {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -182,13 +182,8 @@ namespace Yafc {
                         }, DataUtils.FavoriteModule);
                         break;
 
-                    case GoodsWithAmountEvent.TextEditing:
-                        int amountInt = MathUtils.Floor(amount.Value);
-                        if (amountInt < 0) {
-                            amountInt = 0;
-                        }
-
-                        rowCustomModule.RecordUndo().fixedCount = amountInt;
+                    case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
+                        rowCustomModule.RecordUndo().fixedCount = (int)amount.Value;
                         break;
                 }
 

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -166,27 +166,30 @@ namespace Yafc {
             var list = beacon != null ? modules!.beaconList : modules!.list;// null-forgiving: Both calls are from places where we know modules is not null
             foreach (RecipeRowCustomModule rowCustomModule in list) {
                 grid.Next();
-                var evt = gui.BuildFactorioObjectWithEditableAmount(rowCustomModule.module, rowCustomModule.fixedCount, UnitOfMeasure.None, out float newAmount);
-                if (evt == GoodsWithAmountEvent.LeftButtonClick) {
-                    SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
-                        if (sel == null) {
-                            _ = modules.RecordUndo();
-                            list.Remove(rowCustomModule);
-                        }
-                        else {
-                            rowCustomModule.RecordUndo().module = sel;
+                DisplayAmount amount = rowCustomModule.fixedCount;
+                switch (gui.BuildFactorioObjectWithEditableAmount(rowCustomModule.module, amount)) {
+                    case GoodsWithAmountEvent.LeftButtonClick:
+                        SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
+                            if (sel == null) {
+                                _ = modules.RecordUndo();
+                                list.Remove(rowCustomModule);
+                            }
+                            else {
+                                rowCustomModule.RecordUndo().module = sel;
+                            }
+
+                            gui.Rebuild();
+                        }, DataUtils.FavoriteModule);
+                        break;
+
+                    case GoodsWithAmountEvent.TextEditing:
+                        int amountInt = MathUtils.Floor(amount.Value);
+                        if (amountInt < 0) {
+                            amountInt = 0;
                         }
 
-                        gui.Rebuild();
-                    }, DataUtils.FavoriteModule);
-                }
-                else if (evt == GoodsWithAmountEvent.TextEditing) {
-                    int amountInt = MathUtils.Floor(newAmount);
-                    if (amountInt < 0) {
-                        amountInt = 0;
-                    }
-
-                    rowCustomModule.RecordUndo().fixedCount = amountInt;
+                        rowCustomModule.RecordUndo().fixedCount = amountInt;
+                        break;
                 }
 
                 if (beacon == null) {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -30,7 +30,7 @@ namespace Yafc {
             BuildHeader(gui, "Module customization");
             if (template != null) {
                 using (gui.EnterRow()) {
-                    if (gui.BuildFactorioObjectButton(template.icon) == Click.Left) {
+                    if (gui.BuildFactorioObjectButton(template.icon, ButtonDisplayStyle.Default) == Click.Left) {
                         SelectSingleObjectPanel.SelectWithNone(Database.objects.all, "Select icon", x => {
                             template.RecordUndo().icon = x;
                             Rebuild();
@@ -46,7 +46,7 @@ namespace Yafc {
                 for (int i = 0; i < template.filterEntities.Count; i++) {
                     var entity = template.filterEntities[i];
                     grid.Next();
-                    gui.BuildFactorioObjectIcon(entity, MilestoneDisplay.Contained);
+                    gui.BuildFactorioObjectIcon(entity, new(2, MilestoneDisplay.Contained, false));
                     if (gui.BuildMouseOverIcon(Icon.Close, SchemeColor.Error)) {
                         template.RecordUndo().filterEntities.RemoveAt(i);
                     }
@@ -167,7 +167,7 @@ namespace Yafc {
             foreach (RecipeRowCustomModule rowCustomModule in list) {
                 grid.Next();
                 DisplayAmount amount = rowCustomModule.fixedCount;
-                switch (gui.BuildFactorioObjectWithEditableAmount(rowCustomModule.module, amount)) {
+                switch (gui.BuildFactorioObjectWithEditableAmount(rowCustomModule.module, amount, ButtonDisplayStyle.ProductionTableUnscaled)) {
                     case GoodsWithAmountEvent.LeftButtonClick:
                         SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
                             if (sel == null) {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -93,7 +93,7 @@ namespace Yafc {
                         SelectBeacon(gui);
                     }
 
-                    gui.BuildText("Input the amount of modules, not the amount of beacons. Single beacon can hold " + modules.beacon.moduleSlots + " modules.", wrap: true);
+                    gui.BuildText("Input the amount of modules, not the amount of beacons. Single beacon can hold " + modules.beacon.moduleSlots + " modules.", TextBlockDisplayStyle.WrappedText);
                     DrawRecipeModules(gui, modules.beacon, ref effects);
                 }
 

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -123,7 +123,7 @@ namespace Yafc {
                 using (gui.EnterRow()) {
                     gui.BuildText("Beacons per building: ");
                     DisplayAmount amount = modules.beaconsPerBuilding;
-                    if (gui.BuildFloatInput(amount, new Padding(0.5f, 0f)) && (int)amount.Value > 0) {
+                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && (int)amount.Value > 0) {
                         modules.RecordUndo().beaconsPerBuilding = (int)amount.Value;
                     }
                 }
@@ -190,21 +190,21 @@ namespace Yafc {
             using (gui.EnterRow()) {
                 gui.BuildText("Mining productivity bonus (project-wide setting): ");
                 DisplayAmount amount = new(Project.current.settings.miningProductivity, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, new Padding(.5f, 0)) && amount.Value >= 0) {
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
                     Project.current.settings.RecordUndo().miningProductivity = amount.Value;
                 }
             }
             using (gui.EnterRow()) {
                 gui.BuildText("Research speed bonus (project-wide setting): ");
                 DisplayAmount amount = new(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, new Padding(.5f, 0)) && amount.Value >= 0) {
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
                     Project.current.settings.RecordUndo().researchSpeedBonus = amount.Value;
                 }
             }
             using (gui.EnterRow()) {
                 gui.BuildText("Research productivity bonus (project-wide setting): ");
                 DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, new Padding(.5f, 0)) && amount.Value >= 0) {
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
                     Project.current.settings.RecordUndo().researchProductivity = amount.Value;
                 }
             }

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -25,7 +25,7 @@ namespace Yafc {
         private void ListDrawer(ImGui gui, KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> element, int index) {
             (EntityCrafter crafter, BeaconOverrideConfiguration config) = element;
             DisplayAmount amount = config.beaconCount;
-            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount, allowScroll: false);
+            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount, ButtonDisplayStyle.ProductionTableUnscaled, allowScroll: false);
             gui.DrawIcon(new(gui.lastRect.X, gui.lastRect.Y, 1.25f, 1.25f), config.beacon.icon, SchemeColor.Source);
             gui.DrawIcon(new(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), config.beaconModule.icon, SchemeColor.Source);
             switch (click) {
@@ -140,7 +140,7 @@ namespace Yafc {
                 using (gui.EnterRow()) {
                     foreach ((EntityCrafter crafter, BeaconOverrideConfiguration beaconInfo) in modules.overrideCrafterBeacons) {
                         DisplayAmount amount = beaconInfo.beaconCount;
-                        GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount);
+                        GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount, ButtonDisplayStyle.ProductionTableUnscaled);
                         gui.DrawIcon(new Rect(gui.lastRect.TopLeft, new Vector2(1.25f, 1.25f)), beaconInfo.beacon.icon, SchemeColor.Source);
                         gui.DrawIcon(new Rect(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), beaconInfo.beaconModule.icon, SchemeColor.Source);
                         switch (click) {

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -24,7 +24,8 @@ namespace Yafc {
         /// </summary>
         private void ListDrawer(ImGui gui, KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> element, int index) {
             (EntityCrafter crafter, BeaconOverrideConfiguration config) = element;
-            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, config.beaconCount, UnitOfMeasure.None, out float newAmount, allowScroll: false);
+            DisplayAmount amount = config.beaconCount;
+            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount, allowScroll: false);
             gui.DrawIcon(new(gui.lastRect.X, gui.lastRect.Y, 1.25f, 1.25f), config.beacon.icon, SchemeColor.Source);
             gui.DrawIcon(new(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), config.beaconModule.icon, SchemeColor.Source);
             switch (click) {
@@ -49,7 +50,7 @@ namespace Yafc {
                     });
                     break;
                 case GoodsWithAmountEvent.TextEditing:
-                    modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)newAmount;
+                    modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)amount.Value;
                     break;
             }
             overrideList.data = [.. modules.overrideCrafterBeacons];
@@ -121,9 +122,9 @@ namespace Yafc {
 
                 using (gui.EnterRow()) {
                     gui.BuildText("Beacons per building: ");
-                    if (gui.BuildTextInput(modules.beaconsPerBuilding.ToString(), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
-                        int.TryParse(newText, out int newAmount) && newAmount > 0) {
-                        modules.RecordUndo().beaconsPerBuilding = newAmount;
+                    DisplayAmount amount = modules.beaconsPerBuilding;
+                    if (gui.BuildFloatInput(amount, new Padding(0.5f, 0f)) && (int)amount.Value > 0) {
+                        modules.RecordUndo().beaconsPerBuilding = (int)amount.Value;
                     }
                 }
                 gui.BuildText("Please note that beacons themselves are not part of the calculation", wrap: true);
@@ -138,7 +139,8 @@ namespace Yafc {
                 }
                 using (gui.EnterRow()) {
                     foreach ((EntityCrafter crafter, BeaconOverrideConfiguration beaconInfo) in modules.overrideCrafterBeacons) {
-                        GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, beaconInfo.beaconCount, UnitOfMeasure.None, out float newAmount);
+                        DisplayAmount amount = beaconInfo.beaconCount;
+                        GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount);
                         gui.DrawIcon(new Rect(gui.lastRect.TopLeft, new Vector2(1.25f, 1.25f)), beaconInfo.beacon.icon, SchemeColor.Source);
                         gui.DrawIcon(new Rect(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), beaconInfo.beaconModule.icon, SchemeColor.Source);
                         switch (click) {
@@ -167,7 +169,7 @@ namespace Yafc {
                                 }, noneTooltip: "Click here to remove the current override.");
                                 return;
                             case GoodsWithAmountEvent.TextEditing:
-                                modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)newAmount;
+                                modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)amount.Value;
                                 return;
                         }
                     }
@@ -187,23 +189,23 @@ namespace Yafc {
             gui.AllocateSpacing();
             using (gui.EnterRow()) {
                 gui.BuildText("Mining productivity bonus (project-wide setting): ");
-                if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.miningProductivity, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
-                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent) && newAmount >= 0) {
-                    Project.current.settings.RecordUndo().miningProductivity = newAmount;
+                DisplayAmount amount = new(Project.current.settings.miningProductivity, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, new Padding(.5f, 0)) && amount.Value >= 0) {
+                    Project.current.settings.RecordUndo().miningProductivity = amount.Value;
                 }
             }
             using (gui.EnterRow()) {
                 gui.BuildText("Research speed bonus (project-wide setting): ");
-                if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
-                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent) && newAmount >= 0) {
-                    Project.current.settings.RecordUndo().researchSpeedBonus = newAmount;
+                DisplayAmount amount = new(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, new Padding(.5f, 0)) && amount.Value >= 0) {
+                    Project.current.settings.RecordUndo().researchSpeedBonus = amount.Value;
                 }
             }
             using (gui.EnterRow()) {
                 gui.BuildText("Research productivity bonus (project-wide setting): ");
-                if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.researchProductivity, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
-                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent) && newAmount >= 0) {
-                    Project.current.settings.RecordUndo().researchProductivity = newAmount;
+                DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, new Padding(.5f, 0)) && amount.Value >= 0) {
+                    Project.current.settings.RecordUndo().researchProductivity = amount.Value;
                 }
             }
 

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -74,7 +74,7 @@ namespace Yafc {
                 gui.BuildText("Use best modules");
             }
             else {
-                gui.BuildText("Modules payback estimate: " + DataUtils.FormatTime(payback), wrap: true);
+                gui.BuildText("Modules payback estimate: " + DataUtils.FormatTime(payback), TextBlockDisplayStyle.WrappedText);
             }
         }
 
@@ -93,7 +93,7 @@ namespace Yafc {
 
             gui.AllocateSpacing();
             gui.BuildText("Filler module:", Font.subheader);
-            gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", wrap: true);
+            gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", TextBlockDisplayStyle.WrappedText);
             if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule) == Click.Left) {
                 SelectSingleObjectPanel.SelectWithNone(Database.allModules, "Select filler module", select => { modules.RecordUndo().fillerModule = select; });
             }
@@ -127,7 +127,7 @@ namespace Yafc {
                         modules.RecordUndo().beaconsPerBuilding = (int)amount.Value;
                     }
                 }
-                gui.BuildText("Please note that beacons themselves are not part of the calculation", wrap: true);
+                gui.BuildText("Please note that beacons themselves are not part of the calculation", TextBlockDisplayStyle.WrappedText);
 
                 gui.AllocateSpacing();
                 gui.BuildText("Override beacons:", Font.subheader);

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -49,7 +49,7 @@ namespace Yafc {
                         }
                     });
                     break;
-                case GoodsWithAmountEvent.TextEditing:
+                case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
                     modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)amount.Value;
                     break;
             }
@@ -168,7 +168,7 @@ namespace Yafc {
                                     }
                                 }, noneTooltip: "Click here to remove the current override.");
                                 return;
-                            case GoodsWithAmountEvent.TextEditing:
+                            case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
                                 modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)amount.Value;
                                 return;
                         }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -25,12 +25,12 @@ namespace Yafc {
             BuildFlow(gui, output, totalOutput);
             if (link.amount != 0) {
                 gui.spacing = 0.5f;
-                gui.BuildText((link.amount > 0 ? "Requested production: " : "Requested consumption: ") + DataUtils.FormatAmount(MathF.Abs(link.amount), link.goods.flowUnitOfMeasure), Font.subheader, color: SchemeColor.GreenAlt);
+                gui.BuildText((link.amount > 0 ? "Requested production: " : "Requested consumption: ") + DataUtils.FormatAmount(MathF.Abs(link.amount), link.goods.flowUnitOfMeasure), new TextBlockDisplayStyle(Font.subheader, Color: SchemeColor.GreenAlt));
             }
             if (link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) && totalInput != totalOutput + link.amount) {
                 float amount = totalInput - totalOutput - link.amount;
                 gui.spacing = 0.5f;
-                gui.BuildText((amount > 0 ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(amount), link.goods.flowUnitOfMeasure), Font.subheader, color: SchemeColor.Error);
+                gui.BuildText((amount > 0 ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(amount), link.goods.flowUnitOfMeasure), new TextBlockDisplayStyle(Font.subheader, Color: SchemeColor.Error));
             }
         }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -197,7 +197,7 @@ namespace Yafc {
                     if (item != null) {
                         if (item.elements.Count == 0) {
                             using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
-                                gui.BuildText(emptyGroupMessage, wrap: true); // set color if the nested row is empty
+                                gui.BuildText(emptyGroupMessage, TextBlockDisplayStyle.WrappedText); // set color if the nested row is empty
                             }
                         }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -281,15 +281,16 @@ goodsHaveNoProduction:;
                 using (var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f)) {
                     group.SetWidth(3f);
                     if (recipe.fixedBuildings > 0) {
-                        var evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, recipe.fixedBuildings, UnitOfMeasure.None, out float newAmount, useScale: false);
+                        DisplayAmount amount = recipe.fixedBuildings;
+                        GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, useScale: false);
                         if (evt == GoodsWithAmountEvent.TextEditing) {
-                            recipe.RecordUndo().fixedBuildings = newAmount;
+                            recipe.RecordUndo().fixedBuildings = amount.Value;
                         }
 
                         click = (Click)evt;
                     }
                     else {
-                        click = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None, useScale: false);
+                        click = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, useScale: false);
                     }
 
                     if (recipe.builtBuildings != null) {
@@ -339,7 +340,7 @@ goodsHaveNoProduction:;
                 var accumulator = recipe.GetVariant(Database.allAccumulators);
                 float requiredMj = recipe.entity?.craftingSpeed * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
                 float requiredAccumulators = requiredMj / accumulator.accumulatorCapacity;
-                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators, UnitOfMeasure.None) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators) == Click.Left) {
                     ShowAccumulatorDropdown(gui, recipe, accumulator);
                 }
             }
@@ -565,7 +566,7 @@ goodsHaveNoProduction:;
 
                 void drawItem(ImGui gui, FactorioObject? item, int count) {
                     grid.Next();
-                    switch (gui.BuildFactorioObjectWithAmount(item, count, UnitOfMeasure.None, useScale: false)) {
+                    switch (gui.BuildFactorioObjectWithAmount(item, count, useScale: false)) {
                         case Click.Left:
                             ShowModuleDropDown(gui, recipe);
                             break;
@@ -584,15 +585,15 @@ goodsHaveNoProduction:;
                 using var grid = imGui.EnterInlineGrid(3f, 1f);
                 foreach (var module in template.list) {
                     grid.Next();
-                    _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, UnitOfMeasure.None);
+                    _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount);
                 }
 
                 if (template.beacon != null) {
                     grid.Next();
-                    _ = imGui.BuildFactorioObjectWithAmount(template.beacon, template.CalcBeaconCount(), UnitOfMeasure.None);
+                    _ = imGui.BuildFactorioObjectWithAmount(template.beacon, template.CalcBeaconCount());
                     foreach (var module in template.beaconList) {
                         grid.Next();
-                        _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, UnitOfMeasure.None);
+                        _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount);
                     }
                 }
             });
@@ -925,15 +926,16 @@ goodsHaveNoProduction:;
             }
 
             ObjectTooltipOptions tooltipOptions = element.amount < 0 ? HintLocations.OnConsumingRecipes : HintLocations.OnProducingRecipes;
-            switch (gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, iconColor, tooltipOptions: tooltipOptions)) {
+            DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
+            switch (gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, iconColor, tooltipOptions: tooltipOptions)) {
                 case GoodsWithAmountEvent.LeftButtonClick:
                     OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, ProductDropdownType.DesiredProduct, null, element.owner);
                     break;
                 case GoodsWithAmountEvent.RightButtonClick:
                     DestroyLink(element);
                     break;
-                case GoodsWithAmountEvent.TextEditing when newAmount != 0:
-                    element.RecordUndo().amount = newAmount;
+                case GoodsWithAmountEvent.TextEditing when amount.Value != 0:
+                    element.RecordUndo().amount = amount.Value;
                     break;
             }
         }
@@ -979,7 +981,7 @@ goodsHaveNoProduction:;
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 
-            switch (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor, tooltipOptions: tooltipOptions)) {
+            switch (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None), iconColor, textColor, tooltipOptions: tooltipOptions)) {
                 case Click.Left when goods is not null:
                     OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
                     break;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -63,7 +63,7 @@ namespace Yafc {
                             }
                             foreach (var (flag, text) in WarningsMeaning) {
                                 if ((row.parameters.warningFlags & flag) != 0) {
-                                    g.BuildText(text, wrap: true);
+                                    g.BuildText(text, TextBlockDisplayStyle.WrappedText);
                                 }
                             }
                         });
@@ -158,7 +158,7 @@ namespace Yafc {
                     gui.textColor = recipe.hierarchyEnabled ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint;
                 }
 
-                gui.BuildText(recipe.recipe.locName, wrap: true);
+                gui.BuildText(recipe.recipe.locName, TextBlockDisplayStyle.WrappedText);
 
                 void unpackNestedTable() {
                     var evacuate = recipe.subgroup.recipes;
@@ -185,7 +185,7 @@ namespace Yafc {
             public override void BuildMenu(ImGui gui) {
                 BuildRecipeButton(gui, view.model);
 
-                gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", wrap: true);
+                gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", TextBlockDisplayStyle.WrappedText);
                 using (gui.EnterRow()) {
                     gui.BuildText("Amount per:");
                     if (gui.BuildLink("second") && gui.CloseDropdown()) {
@@ -579,7 +579,7 @@ goodsHaveNoProduction:;
 
             private void ShowModuleTemplateTooltip(ImGui gui, ModuleTemplate template) => gui.ShowTooltip(imGui => {
                 if (!template.IsCompatibleWith(editingRecipeModules)) {
-                    imGui.BuildText("This module template seems incompatible with the recipe or the building", wrap: true);
+                    imGui.BuildText("This module template seems incompatible with the recipe or the building", TextBlockDisplayStyle.WrappedText);
                 }
 
                 using var grid = imGui.EnterInlineGrid(3f, 1f);
@@ -615,7 +615,7 @@ goodsHaveNoProduction:;
                     }
 
                     if (moduleTemplateList.data.Count > 0) {
-                        dropGui.BuildText("Use module template:", wrap: true, font: Font.subheader);
+                        dropGui.BuildText("Use module template:", Font.subheader);
                         moduleTemplateList.Build(dropGui);
                     }
                     if (dropGui.BuildButton("Configure module templates") && dropGui.CloseDropdown()) {
@@ -784,27 +784,27 @@ goodsHaveNoProduction:;
 
                 if (link != null) {
                     if (!link.flags.HasFlags(ProductionLink.Flags.HasProduction)) {
-                        gui.BuildText("This link has no production (Link ignored)", wrap: true, color: SchemeColor.Error);
+                        gui.BuildText("This link has no production (Link ignored)", TextBlockDisplayStyle.ErrorText);
                     }
 
                     if (!link.flags.HasFlags(ProductionLink.Flags.HasConsumption)) {
-                        gui.BuildText("This link has no consumption (Link ignored)", wrap: true, color: SchemeColor.Error);
+                        gui.BuildText("This link has no consumption (Link ignored)", TextBlockDisplayStyle.ErrorText);
                     }
 
                     if (link.flags.HasFlags(ProductionLink.Flags.ChildNotMatched)) {
-                        gui.BuildText("Nested table link have unmatched production/consumption. These unmatched products are not captured by this link.", wrap: true, color: SchemeColor.Error);
+                        gui.BuildText("Nested table link have unmatched production/consumption. These unmatched products are not captured by this link.", TextBlockDisplayStyle.ErrorText);
                     }
 
                     if (!link.flags.HasFlags(ProductionLink.Flags.HasProductionAndConsumption) && link.owner.owner is RecipeRow recipeRow && recipeRow.FindLink(link.goods, out _)) {
-                        gui.BuildText("Nested tables have their own set of links that DON'T connect to parent links. To connect this product to the outside, remove this link", wrap: true, color: SchemeColor.Error);
+                        gui.BuildText("Nested tables have their own set of links that DON'T connect to parent links. To connect this product to the outside, remove this link", TextBlockDisplayStyle.ErrorText);
                     }
 
                     if (link.flags.HasFlags(ProductionLink.Flags.LinkRecursiveNotMatched)) {
                         if (link.notMatchedFlow <= 0f) {
-                            gui.BuildText("YAFC was unable to satisfy this link (Negative feedback loop). This doesn't mean that this link is the problem, but it is part of the loop.", wrap: true, color: SchemeColor.Error);
+                            gui.BuildText("YAFC was unable to satisfy this link (Negative feedback loop). This doesn't mean that this link is the problem, but it is part of the loop.", TextBlockDisplayStyle.ErrorText);
                         }
                         else {
-                            gui.BuildText("YAFC was unable to satisfy this link (Overproduction). You can allow overproduction for this link to solve the error.", wrap: true, color: SchemeColor.Error);
+                            gui.BuildText("YAFC was unable to satisfy this link (Overproduction). You can allow overproduction for this link to solve the error.", TextBlockDisplayStyle.ErrorText);
                         }
                     }
                 }
@@ -853,7 +853,7 @@ goodsHaveNoProduction:;
                 }
 
                 if (numberOfShownRecipes > 1) {
-                    gui.BuildText("Hint: ctrl+click to add multiple", wrap: true, color: SchemeColor.BackgroundTextFaint);
+                    gui.BuildText("Hint: ctrl+click to add multiple", TextBlockDisplayStyle.HintText);
                 }
 
                 if (link != null && gui.BuildCheckBox("Allow overproduction", link.algorithm == LinkAlgorithm.AllowOverProduction, out bool newValue)) {
@@ -866,10 +866,10 @@ goodsHaveNoProduction:;
 
                 if (link != null && link.owner == context) {
                     if (link.amount != 0) {
-                        gui.BuildText(goods.locName + " is a desired product and cannot be unlinked.", wrap: true);
+                        gui.BuildText(goods.locName + " is a desired product and cannot be unlinked.", TextBlockDisplayStyle.WrappedText);
                     }
                     else {
-                        gui.BuildText(goods.locName + " production is currently linked. This means that YAFC will try to match production with consumption.", wrap: true);
+                        gui.BuildText(goods.locName + " production is currently linked. This means that YAFC will try to match production with consumption.", TextBlockDisplayStyle.WrappedText);
                     }
 
                     if (type == ProductDropdownType.DesiredProduct) {
@@ -887,10 +887,10 @@ goodsHaveNoProduction:;
                 }
                 else if (goods != null) {
                     if (link != null) {
-                        gui.BuildText(goods.locName + " production is currently linked, but the link is outside this nested table. Nested tables can have its own separate set of links", wrap: true);
+                        gui.BuildText(goods.locName + " production is currently linked, but the link is outside this nested table. Nested tables can have its own separate set of links", TextBlockDisplayStyle.WrappedText);
                     }
                     else {
-                        gui.BuildText(goods.locName + " production is currently NOT linked. This means that YAFC will make no attempt to match production with consumption.", wrap: true);
+                        gui.BuildText(goods.locName + " production is currently NOT linked. This means that YAFC will make no attempt to match production with consumption.", TextBlockDisplayStyle.WrappedText);
                     }
 
                     if (gui.BuildButton("Create link").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
@@ -981,7 +981,7 @@ goodsHaveNoProduction:;
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 
-            switch (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None), iconColor, textColor, tooltipOptions: tooltipOptions)) {
+            switch (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None), iconColor, TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions)) {
                 case Click.Left when goods is not null:
                     OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
                     break;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -283,7 +283,7 @@ goodsHaveNoProduction:;
                     if (recipe.fixedBuildings > 0) {
                         DisplayAmount amount = recipe.fixedBuildings;
                         GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, useScale: false);
-                        if (evt == GoodsWithAmountEvent.TextEditing) {
+                        if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
                             recipe.RecordUndo().fixedBuildings = amount.Value;
                         }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -294,10 +294,9 @@ goodsHaveNoProduction:;
                     }
 
                     if (recipe.builtBuildings != null) {
-                        if (gui.BuildTextInput(DataUtils.FormatAmount(Convert.ToSingle(recipe.builtBuildings), UnitOfMeasure.None), out string newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColorGroup.Grey)) {
-                            if (DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.None)) {
-                                recipe.RecordUndo().builtBuildings = Convert.ToInt32(newAmount);
-                            }
+                        DisplayAmount amount = recipe.builtBuildings.Value;
+                        if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }) && amount.Value >= 0) {
+                            recipe.RecordUndo().builtBuildings = (int)amount.Value;
                         }
                     }
                 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -293,7 +293,7 @@ goodsHaveNoProduction:;
                     }
 
                     if (recipe.builtBuildings != null) {
-                        if (gui.BuildTextInput(DataUtils.FormatAmount(Convert.ToSingle(recipe.builtBuildings), UnitOfMeasure.None), out string newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColor.Grey)) {
+                        if (gui.BuildTextInput(DataUtils.FormatAmount(Convert.ToSingle(recipe.builtBuildings), UnitOfMeasure.None), out string newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColorGroup.Grey)) {
                             if (DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.None)) {
                                 recipe.RecordUndo().builtBuildings = Convert.ToInt32(newAmount);
                             }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -100,7 +100,7 @@ namespace Yafc {
         private class RecipeColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Recipe", 13f, 13f, 30f, widthStorage: nameof(Preferences.recipeColumnWidth)) {
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 gui.spacing = 0.5f;
-                switch (gui.BuildFactorioObjectButton(recipe.recipe, 3f)) {
+                switch (gui.BuildFactorioObjectButton(recipe.recipe, ButtonDisplayStyle.ProductionTableUnscaled)) {
                     case Click.Left:
                         gui.ShowDropDown(delegate (ImGui imgui) {
                             view.DrawRecipeTagSelect(imgui, recipe);
@@ -282,7 +282,7 @@ goodsHaveNoProduction:;
                     group.SetWidth(3f);
                     if (recipe.fixedBuildings > 0) {
                         DisplayAmount amount = recipe.fixedBuildings;
-                        GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, useScale: false);
+                        GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled);
                         if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
                             recipe.RecordUndo().fixedBuildings = amount.Value;
                         }
@@ -290,7 +290,7 @@ goodsHaveNoProduction:;
                         click = (Click)evt;
                     }
                     else {
-                        click = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, useScale: false);
+                        click = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, ButtonDisplayStyle.ProductionTableUnscaled);
                     }
 
                     if (recipe.builtBuildings != null) {
@@ -339,7 +339,7 @@ goodsHaveNoProduction:;
                 var accumulator = recipe.GetVariant(Database.allAccumulators);
                 float requiredMj = recipe.entity?.craftingSpeed * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
                 float requiredAccumulators = requiredMj / accumulator.accumulatorCapacity;
-                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators) == Click.Left) {
+                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators, ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
                     ShowAccumulatorDropdown(gui, recipe, accumulator);
                 }
             }
@@ -565,7 +565,7 @@ goodsHaveNoProduction:;
 
                 void drawItem(ImGui gui, FactorioObject? item, int count) {
                     grid.Next();
-                    switch (gui.BuildFactorioObjectWithAmount(item, count, useScale: false)) {
+                    switch (gui.BuildFactorioObjectWithAmount(item, count, ButtonDisplayStyle.ProductionTableUnscaled)) {
                         case Click.Left:
                             ShowModuleDropDown(gui, recipe);
                             break;
@@ -584,15 +584,15 @@ goodsHaveNoProduction:;
                 using var grid = imGui.EnterInlineGrid(3f, 1f);
                 foreach (var module in template.list) {
                     grid.Next();
-                    _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount);
+                    _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, ButtonDisplayStyle.ProductionTableUnscaled);
                 }
 
                 if (template.beacon != null) {
                     grid.Next();
-                    _ = imGui.BuildFactorioObjectWithAmount(template.beacon, template.CalcBeaconCount());
+                    _ = imGui.BuildFactorioObjectWithAmount(template.beacon, template.CalcBeaconCount(), ButtonDisplayStyle.ProductionTableUnscaled);
                     foreach (var module in template.beaconList) {
                         grid.Next();
-                        _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount);
+                        _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, ButtonDisplayStyle.ProductionTableUnscaled);
                     }
                 }
             });
@@ -770,7 +770,7 @@ goodsHaveNoProduction:;
                     using (var grid = gui.EnterInlineGrid(3f)) {
                         foreach (var variant in variants) {
                             grid.Next();
-                            if (gui.BuildFactorioObjectButton(variant, 3f, MilestoneDisplay.Contained, variant == goods ? SchemeColor.Primary : SchemeColor.None, tooltipOptions: HintLocations.OnProducingRecipes) == Click.Left &&
+                            if (gui.BuildFactorioObjectButton(variant, ButtonDisplayStyle.ProductionTableScaled(variant == goods ? SchemeColor.Primary : SchemeColor.None), tooltipOptions: HintLocations.OnProducingRecipes) == Click.Left &&
                                 variant != goods) {
                                 recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
                                 _ = gui.CloseDropdown();
@@ -926,7 +926,7 @@ goodsHaveNoProduction:;
 
             ObjectTooltipOptions tooltipOptions = element.amount < 0 ? HintLocations.OnConsumingRecipes : HintLocations.OnProducingRecipes;
             DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
-            switch (gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, iconColor, tooltipOptions: tooltipOptions)) {
+            switch (gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions)) {
                 case GoodsWithAmountEvent.LeftButtonClick:
                     OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, ProductDropdownType.DesiredProduct, null, element.owner);
                     break;
@@ -980,7 +980,7 @@ goodsHaveNoProduction:;
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 
-            switch (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None), iconColor, TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions)) {
+            switch (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None), ButtonDisplayStyle.ProductionTableScaled(iconColor), TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions)) {
                 case Click.Left when goods is not null:
                     OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
                     break;
@@ -1094,7 +1094,7 @@ goodsHaveNoProduction:;
             bool click = false;
 
             using (gui.EnterRow()) {
-                click |= gui.BuildFactorioObjectButton(belt) == Click.Left;
+                click |= gui.BuildFactorioObjectButton(belt, ButtonDisplayStyle.Default) == Click.Left;
                 gui.BuildText(DataUtils.FormatAmount(beltCount, UnitOfMeasure.None));
                 if (buildingsPerHalfBelt > 0f) {
                     gui.BuildText("(Buildings per half belt: " + DataUtils.FormatAmount(buildingsPerHalfBelt, UnitOfMeasure.None) + ")");
@@ -1104,7 +1104,7 @@ goodsHaveNoProduction:;
             using (gui.EnterRow()) {
                 int capacity = prefs.inserterCapacity;
                 float inserterBase = inserter.inserterSwingTime * amount / capacity;
-                click |= gui.BuildFactorioObjectButton(inserter) == Click.Left;
+                click |= gui.BuildFactorioObjectButton(inserter, ButtonDisplayStyle.Default) == Click.Left;
                 string text = DataUtils.FormatAmount(inserterBase, UnitOfMeasure.None);
                 if (buildingCount > 1) {
                     text += " (" + DataUtils.FormatAmount(inserterBase / buildingCount, UnitOfMeasure.None) + "/building)";
@@ -1114,9 +1114,9 @@ goodsHaveNoProduction:;
                 if (capacity > 1) {
                     float withBeltSwingTime = inserter.inserterSwingTime + (2f * (capacity - 1.5f) / belt.beltItemsPerSecond);
                     float inserterToBelt = amount * withBeltSwingTime / capacity;
-                    click |= gui.BuildFactorioObjectButton(belt) == Click.Left;
+                    click |= gui.BuildFactorioObjectButton(belt, ButtonDisplayStyle.Default) == Click.Left;
                     gui.AllocateSpacing(-1.5f);
-                    click |= gui.BuildFactorioObjectButton(inserter) == Click.Left;
+                    click |= gui.BuildFactorioObjectButton(inserter, ButtonDisplayStyle.Default) == Click.Left;
                     text = DataUtils.FormatAmount(inserterToBelt, UnitOfMeasure.None, "~");
                     if (buildingCount > 1) {
                         text += " (" + DataUtils.FormatAmount(inserterToBelt / buildingCount, UnitOfMeasure.None) + "/b)";

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -203,7 +203,7 @@ namespace Yafc {
             base.BuildHeader(gui);
 
             gui.allocator = RectAllocator.Center;
-            gui.BuildText("Production Sheet Summary", Font.header, false, RectAlignment.Middle);
+            gui.BuildText("Production Sheet Summary", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
             gui.allocator = RectAllocator.LeftAlign;
         }
 

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -105,7 +105,7 @@ namespace Yafc {
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
                 DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
-                GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, iconColor);
+                GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, ButtonDisplayStyle.ProductionTableScaled(iconColor));
                 if (evt == GoodsWithAmountEvent.TextEditing && amount.Value != 0) {
                     SetProviderAmount(element, page, amount.Value);
                 }
@@ -132,7 +132,7 @@ namespace Yafc {
 
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
-                _ = gui.BuildFactorioObjectWithAmount(flow.goods, new(-flow.amount, flow.goods.flowUnitOfMeasure), iconColor);
+                _ = gui.BuildFactorioObjectWithAmount(flow.goods, new(-flow.amount, flow.goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(iconColor));
             }
 
             private static void SetProviderAmount(ProductionLink element, ProjectPage page, float newAmount) {

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -104,9 +104,10 @@ namespace Yafc {
 
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
-                GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, iconColor);
-                if (evt == GoodsWithAmountEvent.TextEditing && newAmount != 0) {
-                    SetProviderAmount(element, page, newAmount);
+                DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
+                GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, iconColor);
+                if (evt == GoodsWithAmountEvent.TextEditing && amount.Value != 0) {
+                    SetProviderAmount(element, page, amount.Value);
                 }
                 else if (evt == GoodsWithAmountEvent.LeftButtonClick) {
                     SetProviderAmount(element, page, YafcRounding(goodInfo.sum));
@@ -131,7 +132,7 @@ namespace Yafc {
 
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
-                _ = gui.BuildFactorioObjectWithAmount(flow.goods, -flow.amount, flow.goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor);
+                _ = gui.BuildFactorioObjectWithAmount(flow.goods, new(-flow.amount, flow.goods.flowUnitOfMeasure), iconColor);
             }
 
             private static void SetProviderAmount(ProductionLink element, ProjectPage page, float newAmount) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes: 
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version
+Date:
+    Bugfixes:
+        - Refuse to accept negative numbers in several places where they don't make sense.
+----------------------------------------------------------------------------------------------------------------------
 Version 0.8.0
 Date: August 3rd 2024
     Features:

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,9 @@ Version
 Date:
     Bugfixes:
         - Refuse to accept negative numbers in several places where they don't make sense.
+    Internal changes:
+        - Refactor a lot of the drawing code to increase both UI consistency and consistency in being able to pass
+          options to methods that should accept them.
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.8.0
 Date: August 3rd 2024


### PR DESCRIPTION
This is my proposal for improving the too-many-parameters problem brought up in https://github.com/shpaass/yafc-ce/pull/220#discussion_r1698797472. It combines parameters that routinely appear together, provides easy access to common combinations, and eliminates most situations where a caller can't pass all the appropriate options.

The intentional user-visible changes are:
- Refuse to accept negative numbers for things like fixed and built building count.
- Reduce the leading padding from 0.8 to 0.5 in all text input boxes that didn't already use 0.5. (Except the 'create directory' text box in the filesystem window, which still uses 0.2 x 0.2.)
- Change the `MilestoneDisplay.Normal` icons in the NEIE to `Contained` instead. (see [ImmediateWidget.cs:12-24](https://github.com/shpaass/yafc-ce/blob/412f62c9aad6d87a0047def1037e77aa03d43ea5/Yafc/Widgets/ImmediateWidgets.cs#L12-L24))