### PR TITLE
Add an auto balance button to the new Summary page.

### DIFF
--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -66,10 +66,11 @@ namespace Yafc.Model {
             contentChanged?.Invoke(visualOnly);
         }
 
-        private void CheckSolve() {
+        private Task CheckSolve() {
             if (active && IsSolutionStale()) {
-                RunSolveJob();
+                return RunSolveJob();
             }
+            return Task.CompletedTask;
         }
 
         public bool IsSolutionStale() {
@@ -98,10 +99,10 @@ namespace Yafc.Model {
             }
         }
 
-        private async void RunSolveJob() {
+        public async Task RunSolveJob() {
             modelError = await ExternalSolve();
             contentChanged?.Invoke(false);
-            CheckSolve();
+            await CheckSolve();
         }
     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,9 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version
 Date:
+    Features:
+        - Add an "Auto balance" button to the summary page, allowing quick balancing of inputs and outputs across
+          multi-page projects. Known issue: The button requires multiple clicks, which appears to be related to #169.
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This closes #175. I was unable to eliminate the issues where I had to click "Auto balance" multiple times, but I suspect it's related to #169. Hopefully this change will make it easier to reproduce, and thus fix, that bug.

There are attempts to detect negative feedback conditions, and they sometimes work, but the usual exit condition is the `if (updateOrder.Count == 0)` "no more updates available" test, even when more updates will become available once the pages finish recalculating.