### PR TITLE
Switch tabs using Ctrl+PgUp/Down, reorder tabs using Ctrl+Sh+PgUp/Down

### DIFF
--- a/Docs/Shortcuts.md
+++ b/Docs/Shortcuts.md
@@ -1,0 +1,20 @@
+# YAFC keyboard shortcuts
+
+## Global shortcuts
+
+* **Ctrl+S** — Save changes in project.
+* **Ctrl+F** — Find on page.
+* **Ctrl+Z** — Undo last change
+* **Ctrl+Y** or **Ctrl+Shift+Z** — Redo last undo.
+
+## Navigation shortcuts
+
+* **Ctrl+N** — Show NEIE (the Never Enough Items Explorer).
+
+## Tabs shortcuts
+
+* **Ctrl+T** — New production sheet (new tab).
+* **Ctrl+Tab** or **Ctrl+PgDown** — Switch to next tab.
+* **Ctrl+Shift+Tab** or **Ctrl+PgUp** — Switch to previous tab.
+* **Ctrl+Shift+PgDown** — Move current tab right.
+* **Ctrl+Shift+PgUp** — Move current tab left.

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -180,6 +180,22 @@ namespace Yafc.Model {
                 return naivePreviousVisualIndex < 0 ? displayPages.Count - 1 : naivePreviousVisualIndex;
             }
         }
+
+        /// <summary> Swaps the specified two pages in tab order. </summary>
+        public void ReorderPages(ProjectPage? page1, ProjectPage? page2) {
+            if (page1 is null || page2 is null) {
+                return;
+            }
+
+            _ = this.RecordUndo();
+            var index1 = displayPages.IndexOf(page1.guid);
+            var index2 = displayPages.IndexOf(page2.guid);
+            if (index1 == -1 || index2 == -1 || index1 == index2) {
+                return;
+            }
+            displayPages[index1] = page2.guid;
+            displayPages[index2] = page1.guid;
+        }
     }
 
     public class ProjectSettings(Project project) : ModelObject<Project>(project) {

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -148,29 +148,43 @@ namespace Yafc.UI {
         protected abstract Vector2 MeasureContent(float width, ImGui gui);
 
         public bool KeyDown(SDL.SDL_Keysym key) {
-            switch (key.scancode) {
-                case SDL.SDL_Scancode.SDL_SCANCODE_UP:
+            bool ctrl = InputSystem.Instance.control;
+            bool shift = InputSystem.Instance.shift;
+            switch ((ctrl, shift, key.scancode)) {
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_UP):
                     scrollY -= 3;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_DOWN:
+                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_UP):
+                    scrollY = 0; // ctrl+up = home
+                    return true;
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_DOWN):
                     scrollY += 3;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_LEFT:
+                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_DOWN):
+                    scrollY = maxScroll.Y; // ctrl+down = end
+                    return true;
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_LEFT):
                     scrollX -= 3;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_RIGHT:
+                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_LEFT):
+                    scrollX = 0;
+                    return true;
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_RIGHT):
                     scrollX += 3;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN:
+                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_RIGHT):
+                    scrollX = maxScroll.X;
+                    return true;
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN):
                     scrollY += contentRect.Height;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP:
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP):
                     scrollY -= contentRect.Height;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_HOME:
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_HOME):
                     scrollY = 0;
                     return true;
-                case SDL.SDL_Scancode.SDL_SCANCODE_END:
+                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_END):
                     scrollY = maxScroll.Y;
                     return true;
                 default:

--- a/Yafc/Data/Tips.txt
+++ b/Yafc/Data/Tips.txt
@@ -13,3 +13,4 @@ Tip: Specify <number>/m to produce that many items (or fluid units) per minute, 
 Tip: Specify <number>b to produce that many belts worth of product, for the belt you've selected in the preferences
 Tip: Specify <number>k to multiply the production by 1000. Other SI prefixes work too! (put the prefix before 'b' or '/h')
 Tip: You can enable the dark mode by clicking on the light-bulb icon on the welcome screen.
+Tip: You can switch between tabs using Ctrl+PgUp or Down and reorder them using Ctrl+Shift+PgUp or Down.

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -567,6 +567,7 @@ namespace Yafc {
 
         public bool KeyDown(SDL.SDL_Keysym key) {
             bool ctrl = (key.mod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
+            bool shift = (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
             if (ctrl) {
                 switch (key.scancode) {
                     case SDL.SDL_Scancode.SDL_SCANCODE_S:
@@ -598,7 +599,23 @@ namespace Yafc {
                         ProductionTableView.CreateProductionSheet();
                         break;
                     case SDL.SDL_Scancode.SDL_SCANCODE_TAB:
-                        SetActivePage(project.VisibleNeighborOfPage(activePage, (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) == 0));
+                        SetActivePage(project.VisibleNeighborOfPage(activePage, !shift));
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN:
+                        if (shift) {
+                            project.ReorderPages(activePage, project.VisibleNeighborOfPage(activePage, true));
+                        }
+                        else {
+                            SetActivePage(project.VisibleNeighborOfPage(activePage, true));
+                        }
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP:
+                        if (shift) {
+                            project.ReorderPages(activePage, project.VisibleNeighborOfPage(activePage, false));
+                        }
+                        else {
+                            SetActivePage(project.VisibleNeighborOfPage(activePage, false));
+                        }
                         break;
                     default:
                         if (_activePageView?.ControlKey(key.scancode) != true) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,8 @@ Date:
         - Add a right-click context menu to the tab header.
         - Allow fixed amounts on fuel, ingredients, and products, in addition to buildings.
         - Add a setting to force software rendering if hardware rendering does not work on your system.
+        - Switch tabs using Ctrl+PgUp / Ctrl+PgDown
+        - Reorder tabs using Ctrl+Shift+PgUp / Ctrl+Shift+PgDown
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
     Internal changes:


### PR DESCRIPTION
The keymapping matches web browsers, VS Code and other software with tabs.

This patch also requires that scrolling shortcuts do not accept modifier keys, so ScrollArea.KeyDown is strictened accordingly.