### PR TITLE
More options for fixed amounts

### DIFF
--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Yafc.Model {
     public interface IModuleFiller {
@@ -13,20 +15,7 @@ namespace Yafc.Model {
     /// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
     /// <param name="beaconModule">The module to place in the beacon.</param>
     [Serializable]
-    public record BeaconOverrideConfiguration(EntityBeacon beacon, int beaconCount, Module beaconModule) {
-        /// <summary>
-        /// Gets or sets the beacon to use for this crafter.
-        /// </summary>
-        public EntityBeacon beacon { get; set; } = beacon;
-        /// <summary>
-        /// Gets or sets the number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.
-        /// </summary>
-        public int beaconCount { get; set; } = beaconCount;
-        /// <summary>
-        /// Gets or sets the module to place in the beacon.
-        /// </summary>
-        public Module beaconModule { get; set; } = beaconModule;
-    }
+    public record BeaconOverrideConfiguration(EntityBeacon beacon, int beaconCount, Module beaconModule);
 
     /// <summary>
     /// The result of applying the various beacon preferences to a crafter; this may result in a desired configuration where the beacon or module is not specified.
@@ -39,17 +28,46 @@ namespace Yafc.Model {
         public static implicit operator BeaconConfiguration(BeaconOverrideConfiguration beaconConfiguration) => new(beaconConfiguration.beacon, beaconConfiguration.beaconCount, beaconConfiguration.beaconModule);
     }
 
+    /// <summary>
+    /// The settings (used by root <see cref="ProductionTable"/>s) for what modules and beacons should be used for a recipe, in the absence of any per-<see cref="RecipeRow"/> settings.
+    /// </summary>
+    /// <remarks>This class handles its own <see cref="DataUtils.RecordUndo{T}(T, bool)"/> calls.</remarks>
     [Serializable]
     public class ModuleFillerParameters : ModelObject<ModelObject>, IModuleFiller {
-        public ModuleFillerParameters(ModelObject owner) : base(owner) { }
+        private bool _fillMiners;
+        private float _autoFillPayback;
+        private Module? _fillerModule;
+        private EntityBeacon? _beacon;
+        private Module? _beaconModule;
+        private int _beaconsPerBuilding = 8;
 
-        public bool fillMiners { get; set; }
-        public float autoFillPayback { get; set; }
-        public Module? fillerModule { get; set; }
-        public EntityBeacon? beacon { get; set; }
-        public Module? beaconModule { get; set; }
-        public int beaconsPerBuilding { get; set; } = 8;
-        public SortedList<EntityCrafter, BeaconOverrideConfiguration> overrideCrafterBeacons { get; } = new(DataUtils.DeterministicComparer);
+        public ModuleFillerParameters(ModelObject owner) : base(owner) => overrideCrafterBeacons.OverrideSettingChanging += ModuleFillerParametersChanging;
+
+        public bool fillMiners {
+            get => _fillMiners;
+            set => ChangeModuleFillerParameters(ref _fillMiners, value);
+        }
+        public float autoFillPayback {
+            get => _autoFillPayback;
+            set => ChangeModuleFillerParameters(ref _autoFillPayback, value);
+        }
+        public Module? fillerModule {
+            get => _fillerModule;
+            set => ChangeModuleFillerParameters(ref _fillerModule, value);
+        }
+        public EntityBeacon? beacon {
+            get => _beacon;
+            set => ChangeModuleFillerParameters(ref _beacon, value);
+        }
+        public Module? beaconModule {
+            get => _beaconModule;
+            set => ChangeModuleFillerParameters(ref _beaconModule, value);
+        }
+        public int beaconsPerBuilding {
+            get => _beaconsPerBuilding;
+            set => ChangeModuleFillerParameters(ref _beaconsPerBuilding, value);
+        }
+        public OverrideCrafterBeacons overrideCrafterBeacons { get; } = [];
 
         [Obsolete("Moved to project settings", true)]
         public int miningProductivity {
@@ -58,6 +76,31 @@ namespace Yafc.Model {
                     rootProject.settings.miningProductivity = value * 0.01f;
                 }
             }
+        }
+
+        private void ChangeModuleFillerParameters<T>(ref T field, T value) {
+            Action? action = ModuleFillerParametersChanging();
+            field = value;
+            action?.Invoke();
+        }
+
+        private Action? ModuleFillerParametersChanging(EntityCrafter? crafter = null) {
+            if (SerializationMap.IsDeserializing) { return null; } // Deserializing; don't do anything fancy.
+
+            this.RecordUndo();
+            ModelObject parent = owner;
+            while (parent.ownerObject is not ProjectPage and not null) {
+                parent = parent.ownerObject;
+            }
+            ProductionTable table = (ProductionTable)parent;
+
+            Action? result = null;
+            foreach (RecipeRow recipe in table.GetAllRecipes()) {
+                if (crafter == null || crafter == recipe.entity) {
+                    result += recipe.ModuleFillerParametersChanging();
+                }
+            }
+            return result;
         }
 
         /// <summary>
@@ -128,5 +171,89 @@ namespace Yafc.Model {
                 used.modules = new[] { (module, fillerLimit, false) };
             }
         }
+    }
+
+    /// <summary>
+    /// An observable dictionary, that will raise <see cref="OverrideSettingChanging"/> when the settings for a crafter are about to about to change.
+    /// </summary>
+    public class OverrideCrafterBeacons : IDictionary<EntityCrafter, BeaconOverrideConfiguration> {
+        private readonly SortedList<EntityCrafter, BeaconOverrideConfiguration> storage = new(DataUtils.DeterministicComparer);
+
+        /// <summary>
+        /// Raised before changing (including adding/removing) the value associated with a particular crafter.
+        /// The return value, if not <see langword="null"/>, will be called after the change has been performed.
+        /// </summary>
+        internal event Func<EntityCrafter, Action?>? OverrideSettingChanging;
+
+        /// <inheritdoc/>
+        public BeaconOverrideConfiguration this[EntityCrafter key] {
+            get => storage[key];
+            set {
+                Action? action = OverrideSettingChanging?.Invoke(key);
+                storage[key] = value;
+                action?.Invoke();
+            }
+        }
+
+        /// <inheritdoc/>
+        public ICollection<EntityCrafter> Keys => storage.Keys;
+
+        /// <inheritdoc/>
+        public ICollection<BeaconOverrideConfiguration> Values => storage.Values;
+
+        /// <inheritdoc/>
+        public int Count => storage.Count;
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.IsReadOnly => false;
+
+        /// <inheritdoc/>
+        public void Add(EntityCrafter key, BeaconOverrideConfiguration value) {
+            Action? action = OverrideSettingChanging?.Invoke(key);
+            storage.Add(key, value);
+            action?.Invoke();
+        }
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Add(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item)
+            => Add(item.Key, item.Value);
+
+        /// <inheritdoc/>
+        public void Clear() => storage.Clear();
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Contains(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item)
+            => ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).Contains(item);
+
+        /// <inheritdoc/>
+        public bool ContainsKey(EntityCrafter key) => storage.ContainsKey(key);
+
+        /// <inheritdoc/>
+        void ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.CopyTo(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>[] array, int arrayIndex)
+            => ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).CopyTo(array, arrayIndex);
+
+        /// <inheritdoc/>
+        public IEnumerator<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>> GetEnumerator() => storage.GetEnumerator();
+
+        /// <inheritdoc/>
+        public bool Remove(EntityCrafter key) {
+            Action? action = OverrideSettingChanging?.Invoke(key);
+            bool result = storage.Remove(key);
+            action?.Invoke();
+            return result;
+        }
+
+        /// <inheritdoc/>
+        bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Remove(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item) {
+            Action? action = OverrideSettingChanging?.Invoke(item.Key);
+            bool result = ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).Remove(item);
+            action?.Invoke();
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetValue(EntityCrafter key, [MaybeNullWhen(false)] out BeaconOverrideConfiguration value) => storage.TryGetValue(key, out value);
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => storage.GetEnumerator();
     }
 }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -173,12 +173,41 @@ namespace Yafc.Model {
     }
 
     public class RecipeRow : ModelObject<ProductionTable>, IModuleFiller, IGroupedElement<ProductionTable> {
+        private float _fixedBuildings;
+
         public RecipeOrTechnology recipe { get; }
         // Variable parameters
         public EntityCrafter? entity { get; set; }
         public Goods? fuel { get; set; }
         public RecipeLinks links { get; internal set; }
-        public float fixedBuildings { get; set; }
+        /// <summary>
+        /// If not zero, the fixed building count entered by the user, or the number of buildings required to generate the specified fixed consumption/production.
+        /// Read <see cref="fixedFuel"/>, <see cref="fixedIngredient"/>, and <see cref="fixedProduct"/> to determine which value was fixed in the UI.
+        /// This property is set/modified so the solver gets the correct answer without testing the values of those properties.
+        /// </summary>
+        public float fixedBuildings {
+            get => _fixedBuildings;
+            set {
+                _fixedBuildings = value;
+                if (value == 0) {
+                    fixedFuel = false;
+                    fixedIngredient = null;
+                    fixedProduct = null;
+                }
+            }
+        }
+        /// <summary>
+        /// If <see langword="true"/>, <see cref="fixedBuildings"/> is set to control the fuel consumption.
+        /// </summary>
+        public bool fixedFuel { get; set; }
+        /// <summary>
+        /// If not <see langword="null"/>, <see cref="fixedBuildings"/> is set to control the consumption of this ingredient.
+        /// </summary>
+        public Goods? fixedIngredient { get; set; }
+        /// <summary>
+        /// If not <see langword="null"/>, <see cref="fixedBuildings"/> is set to control the production of this product.
+        /// </summary>
+        public Goods? fixedProduct { get; set; }
         public int? builtBuildings { get; set; }
         /// <summary>
         /// If <see langword="true"/>, the enabled checkbox for this recipe is checked.

--- a/Yafc.Model/Model/ProjectModuleTemplate.cs
+++ b/Yafc.Model/Model/ProjectModuleTemplate.cs
@@ -3,11 +3,11 @@
 namespace Yafc.Model {
     public class ProjectModuleTemplate : ModelObject<Project> {
         public ProjectModuleTemplate(Project owner, string name) : base(owner) {
-            template = new ModuleTemplate(this);
+            template = new ModuleTemplateBuilder().Build(this);
             this.name = name;
         }
 
-        public ModuleTemplate template { get; }
+        public ModuleTemplate template { get; set; }
         public FactorioObject? icon { get; set; }
         public string name { get; set; }
         public List<Entity> filterEntities { get; } = [];

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -14,6 +14,9 @@ namespace Yafc.Model {
         private bool suspended;
         private bool scheduled;
         internal void CreateUndoSnapshot(ModelObject target, bool visualOnly) {
+            if (SerializationMap.IsDeserializing) {
+                throw new InvalidOperationException("Do not record an undo event while deserializing.");
+            }
             if (changedList.Count == 0) {
                 version++;
                 if (!suspended && !scheduled) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -280,7 +280,7 @@ goodsHaveNoProduction:;
                 Click click;
                 using (var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f)) {
                     group.SetWidth(3f);
-                    if (recipe.fixedBuildings > 0) {
+                    if (recipe.fixedBuildings > 0 && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
                         DisplayAmount amount = recipe.fixedBuildings;
                         GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled);
                         if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
@@ -369,9 +369,19 @@ goodsHaveNoProduction:;
 
                 gui.AllocateSpacing(0.5f);
 
+                if (recipe.fixedBuildings > 0f && (recipe.fixedFuel || recipe.fixedIngredient != null || recipe.fixedProduct != null)) {
+                    ButtonEvent evt = gui.BuildButton("Clear fixed recipe multiplier");
+                    if (willResetFixed) {
+                        evt.WithTooltip(gui, "Shortcut: right-click");
+                    }
+                    if (evt && gui.CloseDropdown()) {
+                        recipe.RecordUndo().fixedBuildings = 0f;
+                    }
+                }
+
                 using (gui.EnterRowWithHelpIcon("Tell YAFC how many buildings it must use when solving this page.\nUse this to ask questions like 'What does it take to handle the output of ten miners?'")) {
                     gui.allocator = RectAllocator.RemainingRow;
-                    if (recipe.fixedBuildings > 0f) {
+                    if (recipe.fixedBuildings > 0f && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
                         ButtonEvent evt = gui.BuildButton("Clear fixed building count");
                         if (willResetFixed) {
                             evt.WithTooltip(gui, "Shortcut: right-click");
@@ -382,6 +392,9 @@ goodsHaveNoProduction:;
                     }
                     else if (gui.BuildButton("Set fixed building count") && gui.CloseDropdown()) {
                         recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0f ? 1f : recipe.buildingCount;
+                        recipe.fixedFuel = false;
+                        recipe.fixedIngredient = null;
+                        recipe.fixedProduct = null;
                     }
                 }
 
@@ -764,7 +777,6 @@ goodsHaveNoProduction:;
                     }
                 }
 
-
                 if (variants != null) {
                     gui.BuildText("Accepted fluid variants:");
                     using (var grid = gui.EnterInlineGrid(3f)) {
@@ -773,6 +785,9 @@ goodsHaveNoProduction:;
                             if (gui.BuildFactorioObjectButton(variant, ButtonDisplayStyle.ProductionTableScaled(variant == goods ? SchemeColor.Primary : SchemeColor.None), tooltipOptions: HintLocations.OnProducingRecipes) == Click.Left &&
                                 variant != goods) {
                                 recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
+                                if (recipe!.fixedIngredient == goods) {
+                                    recipe.fixedIngredient = variant;
+                                }
                                 _ = gui.CloseDropdown();
                             }
                         }
@@ -808,6 +823,7 @@ goodsHaveNoProduction:;
                     }
                 }
 
+                #region Recipe selection
                 int numberOfShownRecipes = 0;
                 if (goods.name == SpecialNames.ResearchUnit) {
                     if (gui.BuildButton("Add technology") && gui.CloseDropdown()) {
@@ -854,7 +870,9 @@ goodsHaveNoProduction:;
                 if (numberOfShownRecipes > 1) {
                     gui.BuildText("Hint: ctrl+click to add multiple", TextBlockDisplayStyle.HintText);
                 }
+                #endregion
 
+                #region Link management
                 if (link != null && gui.BuildCheckBox("Allow overproduction", link.algorithm == LinkAlgorithm.AllowOverProduction, out bool newValue)) {
                     link.RecordUndo().algorithm = newValue ? LinkAlgorithm.AllowOverProduction : LinkAlgorithm.Match;
                 }
@@ -896,6 +914,74 @@ goodsHaveNoProduction:;
                         CreateLink(context, goods);
                     }
                 }
+                #endregion
+
+                #region Fixed production/consumption
+                if (goods != null && recipe != null) {
+                    if (recipe.fixedBuildings == 0
+                        || (type == ProductDropdownType.Fuel && !recipe.fixedFuel)
+                        || (type == ProductDropdownType.Ingredient && recipe.fixedIngredient != goods)
+                        || (type == ProductDropdownType.Product && recipe.fixedProduct != goods)) {
+                        string? prompt = type switch {
+                            ProductDropdownType.Fuel => "Set fixed fuel consumption",
+                            ProductDropdownType.Ingredient => "Set fixed ingredient consumption",
+                            ProductDropdownType.Product => "Set fixed production amount",
+                            _ => null
+                        };
+                        if (prompt != null) {
+                            ButtonEvent evt;
+                            if (recipe.fixedBuildings == 0) {
+                                evt = gui.BuildButton(prompt);
+                            }
+                            else {
+                                using (gui.EnterRowWithHelpIcon("This will replace the other fixed amount in this row.")) {
+                                    gui.allocator = RectAllocator.RemainingRow;
+                                    evt = gui.BuildButton(prompt);
+                                }
+                            }
+                            if (evt && gui.CloseDropdown()) {
+                                recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0 ? 1 : recipe.buildingCount;
+                                switch (type) {
+                                    case ProductDropdownType.Fuel:
+                                        recipe.fixedFuel = true;
+                                        recipe.fixedIngredient = null;
+                                        recipe.fixedProduct = null;
+                                        break;
+                                    case ProductDropdownType.Ingredient:
+                                        recipe.fixedFuel = false;
+                                        recipe.fixedIngredient = goods;
+                                        recipe.fixedProduct = null;
+                                        break;
+                                    case ProductDropdownType.Product:
+                                        recipe.fixedFuel = false;
+                                        recipe.fixedIngredient = null;
+                                        recipe.fixedProduct = goods;
+                                        break;
+                                    default:
+                                        break;
+                                }
+                                targetGui.Rebuild();
+                            }
+                        }
+                    }
+
+                    if (recipe.fixedBuildings != 0
+                        && ((type == ProductDropdownType.Fuel && recipe.fixedFuel)
+                        || (type == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
+                        || (type == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
+                        string? prompt = type switch {
+                            ProductDropdownType.Fuel => "Clear fixed fuel consumption",
+                            ProductDropdownType.Ingredient => "Clear fixed ingredient consumption",
+                            ProductDropdownType.Product => "Clear fixed production amount",
+                            _ => null
+                        };
+                        if (prompt != null && gui.BuildButton(prompt) && gui.CloseDropdown()) {
+                            recipe.RecordUndo().fixedBuildings = 0;
+                        }
+                        targetGui.Rebuild();
+                    }
+                }
+                #endregion
 
                 if (goods is Item) {
                     BuildBeltInserterInfo(gui, amount, recipe?.buildingCount ?? 0);
@@ -980,15 +1066,32 @@ goodsHaveNoProduction:;
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 
-            switch (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None), ButtonDisplayStyle.ProductionTableScaled(iconColor), TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions)) {
-                case Click.Left when goods is not null:
+            GoodsWithAmountEvent evt;
+            DisplayAmount displayAmount = new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None);
+
+            if (recipe != null && recipe.fixedBuildings > 0
+                && ((dropdownType == ProductDropdownType.Fuel && recipe.fixedFuel)
+                || (dropdownType == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
+                || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
+                evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions);
+            }
+            else {
+                evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions);
+            }
+
+            switch (evt) {
+                case GoodsWithAmountEvent.LeftButtonClick when goods is not null:
                     OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
                     break;
-                case Click.Right when goods is not null && (link is null || link.owner != context):
+                case GoodsWithAmountEvent.RightButtonClick when goods is not null && (link is null || link.owner != context):
                     CreateLink(context, goods);
                     break;
-                case Click.Right when link?.amount == 0 && link.owner == context:
+                case GoodsWithAmountEvent.RightButtonClick when link?.amount == 0 && link.owner == context:
                     DestroyLink(link);
+                    break;
+                case GoodsWithAmountEvent.TextEditing when displayAmount.Value >= 0:
+                    // The amount is always stored in fixedBuildings. Scale it to match the requested change to this item.
+                    recipe!.RecordUndo().fixedBuildings *= displayAmount.Value / amount;
                     break;
             }
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -524,7 +524,7 @@ goodsHaveNoProduction:;
                             link = null;
                         }
                         grid.Next();
-                        view.BuildGoodsIcon(gui, spentFuel, link, (float)(recipe.parameters.fuelUsagePerSecondPerRecipe * recipe.recipesPerSecond), ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
+                        view.BuildGoodsIcon(gui, spentFuel, link, (float)(recipe.parameters.fuelUsagePerSecondPerRecipe * recipe.recipesPerSecond), ProductDropdownType.SpentFuel, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
                     }
                 }
                 grid.Dispose();
@@ -686,6 +686,7 @@ goodsHaveNoProduction:;
             Fuel,
             Ingredient,
             Product,
+            SpentFuel,
             DesiredIngredient,
         }
 
@@ -846,17 +847,17 @@ goodsHaveNoProduction:;
                     }
                 }
 
-                if (goods.usages.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(goods.usages, DataUtils.DefaultRecipeOrdering, addRecipe, "Add consumption recipe", type >= ProductDropdownType.Product ? 6 : 2, true, recipeExists);
+                if (type >= ProductDropdownType.Product && goods.usages.Length > 0) {
+                    gui.BuildInlineObjectListAndButton(goods.usages, DataUtils.DefaultRecipeOrdering, addRecipe, "Add consumption recipe", type >= ProductDropdownType.Product ? 6 : 3, true, recipeExists);
                     numberOfShownRecipes += goods.usages.Length;
                 }
 
-                if (fuelUseList.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(fuelUseList, DataUtils.AlreadySortedRecipe, (x) => { selectedFuel = goods; addRecipe(x); }, "Add fuel usage", type >= ProductDropdownType.Product ? 6 : 2, true, recipeExists);
+                if (type >= ProductDropdownType.Product && fuelUseList.Length > 0) {
+                    gui.BuildInlineObjectListAndButton(fuelUseList, DataUtils.AlreadySortedRecipe, (x) => { selectedFuel = goods; addRecipe(x); }, "Add fuel usage", type >= ProductDropdownType.Product ? 6 : 3, true, recipeExists);
                     numberOfShownRecipes += fuelUseList.Length;
                 }
 
-                if (Database.allSciencePacks.Contains(goods)
+                if (type >= ProductDropdownType.Product && Database.allSciencePacks.Contains(goods)
                     && gui.BuildButton("Add consumption technology") && gui.CloseDropdown()) {
                     // Select from the technologies that consume this science pack.
                     SelectMultiObjectPanel.Select(Database.technologies.all.Where(t => t.ingredients.Select(i => i.goods).Contains(goods)), "Add technology", addRecipe, checkMark: recipeExists);
@@ -980,6 +981,10 @@ goodsHaveNoProduction:;
                         }
                         targetGui.Rebuild();
                     }
+
+                    if (type == ProductDropdownType.SpentFuel) {
+                        _ = gui.BuildButton("Set fixed fuel consumption instead", SchemeColor.Grey);
+                    }
                 }
                 #endregion
 
@@ -1038,7 +1043,7 @@ goodsHaveNoProduction:;
                     // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
                     iconColor = SchemeColor.Error;
                 }
-                else if (dropdownType >= ProductDropdownType.Product && CheckPossibleOverproducing(link)) {
+                else if (dropdownType is ProductDropdownType.Product or ProductDropdownType.SpentFuel && CheckPossibleOverproducing(link)) {
                     // Actual overproduction occurred in the recipe
                     iconColor = SchemeColor.Magenta;
                 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Add an "Auto balance" button to the summary page, allowing quick balancing of inputs and outputs across
           multi-page projects. Known issue: The button requires multiple clicks, which appears to be related to #169.
         - Add a right-click context menu to the tab header.
+        - Allow fixed amounts on fuel, ingredients, and products, in addition to buildings.
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
     Internal changes:


### PR DESCRIPTION
I've seen a few requests for this on Discord; e.g. "How do I force a recipe to run at a specific amount in YAFC? I want to eat 4.4 Auogs per second." and possibly "I would like to set one [electricity production line each] for biomass, oil and coal."

This allows you to directly set fixed fuel consumption, fixed ingredient consumption, or fixed product production, instead of having to set that indirectly via the fixed building count. Only one item per row may be fixed at any given time. A fixed fuel consumption will be cleared if you change to a crafter that uses a different fuel source (e.g. a burner furnace to an electric furnace). Other than that, changing the crafter, fuel, modules, or beacons will adjust the rest of the row to preserve the specified fixed amount, the same as it currently works for the fixed building amount.

There's a new button on the dropdowns, labeled "Set fixed _description_":
![image](https://github.com/user-attachments/assets/e37c4fdf-73f0-4e54-b62e-6269bc8e7946)
Once selected, the fixed amount can be configured as usual:
![image](https://github.com/user-attachments/assets/4272fdfa-90a8-4217-bf3f-1ec1e9e6981d)
The button on that item will change to "Clear fixed ...", and the corresponding buttons on other items in the row will transfer configuration of the row's fixed amount to that item.