### PR TITLE
Pass the spent fuel link with the spent fuel, not the input fuel link.

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -421,7 +421,7 @@ namespace Yafc.Model {
                 }
 
                 if (!handledFuel) {
-                    yield return hierarchyEnabled ? (spentFuel, fuelUsagePerSecond, links.fuel) : (null, 0, null);
+                    yield return hierarchyEnabled ? (spentFuel, fuelUsagePerSecond, links.spentFuel) : (null, 0, null);
                 }
             }
         }


### PR DESCRIPTION
This fixes #250 by passing the correct ProductionLink for a dedicated spent fuel 'product'.