### PR TITLE
Add burnt-fuel product to item menu

### DIFF
--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -141,13 +141,18 @@ match:
         /// <param name="ingredientVariantComparer">The comparer to use when deciding which fluid variants to use.</param>
         /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter or lab that can use this fuel, assuming such an entity exists.
         /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler/lab if any are available.</param>
-        public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods> ingredientVariantComparer, Goods? selectedFuel = null) {
+        /// <param name="spentFuel"></param>
+        public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods> ingredientVariantComparer, Goods? selectedFuel = null, Goods? spentFuel = null) {
             RecipeRow recipeRow = new RecipeRow(this, recipe);
             this.RecordUndo().recipes.Add(recipeRow);
             EntityCrafter? selectedFuelCrafter = selectedFuel?.fuelFor.OfType<EntityCrafter>().Where(e => e.recipes.Contains(recipe)).AutoSelect(DataUtils.FavoriteCrafter);
-            recipeRow.entity = selectedFuelCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
+            EntityCrafter? spentFuelRecipeCrafter = GetSpentFuelCrafter(recipe, spentFuel);
+
+            recipeRow.entity = selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
             if (recipeRow.entity != null) {
-                recipeRow.fuel = recipeRow.entity.energy.fuels.FirstOrDefault(e => e == selectedFuel) ?? recipeRow.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
+                recipeRow.fuel = recipeRow.entity.energy.fuels.FirstOrDefault(e => e == selectedFuel)
+                    ?? GetFuelForSpentFuel(spentFuel, recipeRow)
+                    ?? recipeRow.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
             }
 
             foreach (Ingredient ingredient in recipeRow.recipe.ingredients) {
@@ -155,6 +160,23 @@ match:
                     _ = recipeRow.variants.Add(ingredient.variants.AutoSelect(ingredientVariantComparer)!); // null-forgiving: variants is never empty, and AutoSelect never returns null from a non-empty collection (of non-null items).
                 }
             }
+        }
+
+        private static EntityCrafter? GetSpentFuelCrafter(RecipeOrTechnology recipe, Goods? spentFuel) {
+            if (spentFuel is null) {
+                return null;
+            }
+            return recipe.crafters
+                .Where(c => c.energy.fuels.OfType<Item>().Any(e => e.fuelResult == spentFuel))
+                .AutoSelect(DataUtils.FavoriteCrafter);
+        }
+
+        private static Goods? GetFuelForSpentFuel(Goods? spentFuel, [NotNull] RecipeRow recipeRow) {
+            if (spentFuel is null) {
+                return null;
+            }
+            return recipeRow.entity?.energy.fuels.Where(e => spentFuel.miscSources.Contains(e))
+                .AutoSelect(DataUtils.FavoriteFuel);
         }
 
         /// <summary>

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -145,12 +145,12 @@ match:
         public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods> ingredientVariantComparer, Goods? selectedFuel = null, Goods? spentFuel = null) {
             RecipeRow recipeRow = new RecipeRow(this, recipe);
             this.RecordUndo().recipes.Add(recipeRow);
-            EntityCrafter? selectedFuelCrafter = selectedFuel?.fuelFor.OfType<EntityCrafter>().Where(e => e.recipes.Contains(recipe)).AutoSelect(DataUtils.FavoriteCrafter);
+            EntityCrafter? selectedFuelCrafter = GetSelectedFuelCrafter(recipe, selectedFuel);
             EntityCrafter? spentFuelRecipeCrafter = GetSpentFuelCrafter(recipe, spentFuel);
 
             recipeRow.entity = selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
             if (recipeRow.entity != null) {
-                recipeRow.fuel = recipeRow.entity.energy.fuels.FirstOrDefault(e => e == selectedFuel)
+                recipeRow.fuel = GetSelectedFuel(selectedFuel, recipeRow)
                     ?? GetFuelForSpentFuel(spentFuel, recipeRow)
                     ?? recipeRow.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
             }
@@ -161,6 +161,11 @@ match:
                 }
             }
         }
+
+        private static EntityCrafter? GetSelectedFuelCrafter(RecipeOrTechnology recipe, Goods? selectedFuel) =>
+            selectedFuel?.fuelFor.OfType<EntityCrafter>()
+                .Where(e => e.recipes.Contains(recipe))
+                .AutoSelect(DataUtils.FavoriteCrafter);
 
         private static EntityCrafter? GetSpentFuelCrafter(RecipeOrTechnology recipe, Goods? spentFuel) {
             if (spentFuel is null) {
@@ -178,6 +183,10 @@ match:
             return recipeRow.entity?.energy.fuels.Where(e => spentFuel.miscSources.Contains(e))
                 .AutoSelect(DataUtils.FavoriteFuel);
         }
+
+        private static Goods? GetSelectedFuel(Goods? selectedFuel, [NotNull] RecipeRow recipeRow) =>
+            // Skipping AutoSelect since there will only be one result at most.
+            recipeRow.entity?.energy.fuels.FirstOrDefault(e => e == selectedFuel);
 
         /// <summary>
         /// Get all <see cref="RecipeRow"/>s contained in this <see cref="ProductionTable"/>, in a depth-first ordering. (The same as in the UI when all nested tables are expanded.)

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -734,7 +734,9 @@ goodsHaveNoProduction:;
             }
 
             Recipe[] allProduction = variants == null ? goods.production : variants.SelectMany(x => x.production).Distinct().ToArray();
-            Recipe[] fuelUseList = goods.fuelFor.OfType<EntityCrafter>().SelectMany(e => e.recipes).OfType<Recipe>().Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
+            Recipe[] fuelUseList = goods.fuelFor.OfType<EntityCrafter>()
+                .SelectMany(e => e.recipes).OfType<Recipe>()
+                .Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
             Recipe[] spentFuelRecipes = goods.miscSources.OfType<Item>()
                 .SelectMany(e => e.fuelFor.OfType<EntityCrafter>())
                 .SelectMany(e => e.recipes).OfType<Recipe>()
@@ -838,12 +840,26 @@ goodsHaveNoProduction:;
                 }
 
                 if (type >= ProductDropdownType.Product && goods.usages.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(goods.usages, DataUtils.DefaultRecipeOrdering, addRecipe, "Add consumption recipe", type >= ProductDropdownType.Product ? 6 : 3, true, recipeExists);
+                    gui.BuildInlineObjectListAndButton(
+                        goods.usages,
+                        DataUtils.DefaultRecipeOrdering,
+                        addRecipe,
+                        "Add consumption recipe",
+                        6,
+                        true,
+                        recipeExists);
                     numberOfShownRecipes += goods.usages.Length;
                 }
 
                 if (type >= ProductDropdownType.Product && fuelUseList.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(fuelUseList, DataUtils.AlreadySortedRecipe, (x) => { selectedFuel = goods; addRecipe(x); }, "Add fuel usage", type >= ProductDropdownType.Product ? 6 : 3, true, recipeExists);
+                    gui.BuildInlineObjectListAndButton(
+                        fuelUseList,
+                        DataUtils.AlreadySortedRecipe,
+                        (x) => { selectedFuel = goods; addRecipe(x); },
+                        "Add fuel usage",
+                        6,
+                        true,
+                        recipeExists);
                     numberOfShownRecipes += fuelUseList.Length;
                 }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -702,6 +702,7 @@ goodsHaveNoProduction:;
             }
 
             Goods? selectedFuel = null;
+            Goods? spentFuel = null;
             async void addRecipe(RecipeOrTechnology rec) {
                 if (variants == null) {
                     CreateLink(context, goods);
@@ -719,7 +720,7 @@ goodsHaveNoProduction:;
                     }
                 }
                 if (!allRecipes.Contains(rec) || (await MessageBox.Show("Recipe already exists", $"Add a second copy of {rec.locName}?", "Add a copy", "Cancel")).choice) {
-                    context.AddRecipe(rec, DefaultVariantOrdering, selectedFuel);
+                    context.AddRecipe(rec, DefaultVariantOrdering, selectedFuel, spentFuel);
                 }
             }
 
@@ -734,6 +735,10 @@ goodsHaveNoProduction:;
 
             Recipe[] allProduction = variants == null ? goods.production : variants.SelectMany(x => x.production).Distinct().ToArray();
             Recipe[] fuelUseList = goods.fuelFor.OfType<EntityCrafter>().SelectMany(e => e.recipes).OfType<Recipe>().Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
+            Recipe[] spentFuelRecipes = goods.miscSources.OfType<Item>()
+                .SelectMany(e => e.fuelFor.OfType<EntityCrafter>())
+                .SelectMany(e => e.recipes).OfType<Recipe>()
+                .Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
 
             targetGui.ShowDropDown(rect, dropDownContent, new Padding(1f), 25f);
 
@@ -818,6 +823,18 @@ goodsHaveNoProduction:;
                             gui.ShowTooltip(iconRect, "Create new production table for " + goods.locName);
                         }
                     }
+                }
+
+                if (type <= ProductDropdownType.Ingredient && spentFuelRecipes.Length > 0) {
+                    gui.BuildInlineObjectListAndButton(
+                        spentFuelRecipes,
+                        DataUtils.AlreadySortedRecipe,
+                        (x) => { spentFuel = goods; addRecipe(x); },
+                        "Produce it as a spent fuel",
+                        3,
+                        true,
+                        recipeExists);
+                    numberOfShownRecipes += spentFuelRecipes.Length;
                 }
 
                 if (type >= ProductDropdownType.Product && goods.usages.Length > 0) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Date:
         - Add a setting to force software rendering if hardware rendering does not work on your system.
         - Switch tabs using Ctrl+PgUp / Ctrl+PgDown
         - Reorder tabs using Ctrl+Shift+PgUp / Ctrl+Shift+PgDown
+        - Add 'Produce it as a spent fuel' recipe selection.
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
     Internal changes:


### PR DESCRIPTION
Fixes  #251

Adds fuel products (like ash, empty fuel cells etc) as a possible target recipe. For example, you can click on an empty fuel cell, and get "Heat generation" as suggested recipe, that will use a nuclear reactor with fuel cells as source to produce empty fuel cells as burnt result.

![afbeelding](https://github.com/user-attachments/assets/69d3ff74-3135-4a6b-a73e-d552acd2bdd4)

->

![afbeelding](https://github.com/user-attachments/assets/e122d9e4-b371-427d-9978-e7eb62f5732f)

QA:
Opening any item menu (screenshot above) should perform without lag (even ash that has almost every recipe in the game in it). ->passing
Any consumption recipe (or desired product) with fuel source should show "Produce it as a spent fuel" option. -> passing
Selecting the said production recipe should result in a new recipe row that uses the appropriate fuel and crafting entity that results in the requested item -> passing.