### PR TITLE
Should not prefer inaccessible recipes: Apply cost penalty

### DIFF
--- a/Yafc.Model/Analysis/Analysis.cs
+++ b/Yafc.Model/Analysis/Analysis.cs
@@ -68,10 +68,6 @@ namespace Yafc.Model {
             return CostAnalysis.Get(atCurrentMilestones).flow[recipe];
         }
 
-        public static float ProductCost(this Recipe recipe, bool atCurrentMilestones = false) {
-            return CostAnalysis.Get(atCurrentMilestones).recipeProductCost[recipe];
-        }
-
         public static float RecipeWaste(this Recipe recipe, bool atCurrentMilestones = false) {
             return CostAnalysis.Get(atCurrentMilestones).recipeWastePercentage[recipe];
         }

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -32,7 +32,6 @@ namespace Yafc.Model {
 
         public Mapping<FactorioObject, float> cost;
         public Mapping<Recipe, float> recipeCost;
-        public Mapping<RecipeOrTechnology, float> recipeProductCost;
         public Mapping<FactorioObject, float> flow;
         public Mapping<Recipe, float> recipeWastePercentage;
         public Goods[]? importantItems;
@@ -103,7 +102,6 @@ namespace Yafc.Model {
             }
 
             var export = Database.objects.CreateMapping<float>();
-            var recipeProductionCost = Database.recipesAndTechnologies.CreateMapping<float>();
             recipeCost = Database.recipes.CreateMapping<float>();
             flow = Database.objects.CreateMapping<float>();
             var lastVariable = Database.goods.CreateMapping<Variable>();
@@ -300,10 +298,6 @@ namespace Yafc.Model {
 {
                         export[o] += export[ingredient.goods] * ingredient.amount;
                     }
-
-                    foreach (var product in recipe.products) {
-                        recipeProductionCost[recipe] += product.amount * export[product.goods];
-                    }
                 }
                 else if (o is Entity entity) {
                     float minimal = float.PositiveInfinity;
@@ -316,7 +310,6 @@ namespace Yafc.Model {
                 }
             }
             cost = export;
-            recipeProductCost = recipeProductionCost;
 
             recipeWastePercentage = Database.recipes.CreateMapping<float>();
             if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -468,10 +468,10 @@ match:
                         RecipeRow? ownerRecipe = link.owner.owner as RecipeRow;
                         while (ownerRecipe != null) {
                             if (link.notMatchedFlow > 0f) {
-                                ownerRecipe.parameters.warningFlags |= WarningFlags.OverproductionRequired;
+                                ownerRecipe.parameters = ownerRecipe.parameters.WithFlag(WarningFlags.OverproductionRequired);
                             }
                             else {
-                                ownerRecipe.parameters.warningFlags |= WarningFlags.DeadlockCandidate;
+                                ownerRecipe.parameters = ownerRecipe.parameters.WithFlag(WarningFlags.DeadlockCandidate);
                             }
 
                             ownerRecipe = ownerRecipe.owner.owner as RecipeRow;
@@ -483,10 +483,10 @@ match:
                         foreach (var link in linkList) {
                             if (link.flags.HasFlags(ProductionLink.Flags.LinkRecursiveNotMatched)) {
                                 if (link.notMatchedFlow > 0f) {
-                                    recipe.parameters.warningFlags |= WarningFlags.OverproductionRequired;
+                                    recipe.parameters = recipe.parameters.WithFlag(WarningFlags.OverproductionRequired);
                                 }
                                 else {
-                                    recipe.parameters.warningFlags |= WarningFlags.DeadlockCandidate;
+                                    recipe.parameters = recipe.parameters.WithFlag(WarningFlags.DeadlockCandidate);
                                 }
                             }
                         }
@@ -544,12 +544,12 @@ match:
             for (int i = 0; i < recipes.Count; i++) {
                 var recipe = recipes[i];
                 if (recipe.buildingCount > recipe.builtBuildings) {
-                    recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
+                    recipe.parameters = recipe.parameters.WithFlag(WarningFlags.ExceedsBuiltCount);
                     builtCountExceeded = true;
                 }
                 else if (recipe.subgroup != null) {
                     if (recipe.subgroup.CheckBuiltCountExceeded()) {
-                        recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
+                        recipe.parameters = recipe.parameters.WithFlag(WarningFlags.ExceedsBuiltCount);
                         builtCountExceeded = true;
                     }
                 }

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -212,6 +212,7 @@ namespace Yafc.Model {
         public int reactorSizeX { get; set; } = 2;
         public int reactorSizeY { get; set; } = 2;
         public float PollutionCostModifier { get; set; } = 0;
+        public float InaccessibleRecipePenalty { get; set; } = 100;
         public event Action<bool>? changed;
         protected internal override void ThisChanged(bool visualOnly) {
             changed?.Invoke(visualOnly);

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -31,14 +31,8 @@ namespace Yafc.Model {
         public int beaconCount;
     }
 
-    internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBuilding, float productivity, WarningFlags warningFlags, ModuleEffects activeEffects, UsedModule modules) {
+    internal sealed record RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBuilding, float productivity, WarningFlags warningFlags, ModuleEffects activeEffects, UsedModule modules) {
         public const float MIN_RECIPE_TIME = 1f / 60;
-        public float recipeTime { get; } = recipeTime;
-        public float fuelUsagePerSecondPerBuilding { get; } = fuelUsagePerSecondPerBuilding;
-        public float productivity { get; } = productivity;
-        public WarningFlags warningFlags { get; internal set; } = warningFlags;
-        public ModuleEffects activeEffects { get; } = activeEffects;
-        public UsedModule modules { get; } = modules;
 
         public static RecipeParameters Empty = new(0, 0, 0, 0, default, default);
 
@@ -182,5 +176,7 @@ namespace Yafc.Model {
 
             return new RecipeParameters(recipeTime, fuelUsagePerSecondPerBuilding, productivity, warningFlags, activeEffects, modules);
         }
+
+        internal RecipeParameters WithFlag(WarningFlags additionalFlag) => this with { warningFlags = warningFlags | additionalFlag };
     }
 }

--- a/Yafc.UI/Core/ExceptionScreen.cs
+++ b/Yafc.UI/Core/ExceptionScreen.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using SDL2;
 using Serilog;
 
@@ -33,7 +34,7 @@ namespace Yafc.UI {
             exists = false;
         }
 
-        protected override void BuildContents(ImGui gui) {
+        protected override Task BuildContents(ImGui gui) {
             gui.BuildText(ex.GetType().Name, Font.header);
             gui.BuildText(ex.Message, new TextBlockDisplayStyle(Font.subheader, true));
             gui.BuildText(ex.StackTrace, TextBlockDisplayStyle.WrappedText);
@@ -50,6 +51,8 @@ namespace Yafc.UI {
                     _ = SDL.SDL_SetClipboardText(ex.Message + "\n\n" + ex.StackTrace);
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using System.Threading.Tasks;
 using SDL2;
 using Serilog;
 
@@ -201,12 +202,12 @@ namespace Yafc.UI {
             ShowDropDown(simpleDropDown);
         }
 
-        private void Build(ImGui gui) {
+        private async void Build(ImGui gui) {
             if (closed) {
                 return;
             }
 
-            BuildContents(gui);
+            await BuildContents(gui);
             if (dropDown != null) {
                 dropDown.Build(gui);
                 if (!dropDown.active) {
@@ -222,7 +223,7 @@ namespace Yafc.UI {
             }
         }
 
-        protected abstract void BuildContents(ImGui gui);
+        protected abstract Task BuildContents(ImGui gui);
         public virtual void Dispose() => rootGui.Dispose();
 
         internal ImGui.DragOverlay GetDragOverlay() => draggingOverlay ??= new ImGui.DragOverlay();

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using SDL2;
 using Serilog;
 
@@ -35,12 +36,12 @@ namespace Yafc.UI {
             base.Create();
         }
 
-        protected override void BuildContents(ImGui gui) {
-            BuildContent(gui);
+        protected override async Task BuildContents(ImGui gui) {
+            await BuildContent(gui);
             gui.SetContextRect(new Rect(default, size));
         }
 
-        protected abstract void BuildContent(ImGui gui);
+        protected abstract Task BuildContent(ImGui gui);
 
         protected override void OnRepaint() {
             rootGui.Rebuild();

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -63,6 +63,9 @@ namespace Yafc.UI {
                 if (displayStyle.Icon != Icon.None) {
                     gui.BuildIcon(displayStyle.Icon, lineSize, (SchemeColor)displayStyle.ColorGroup + 3);
                 }
+                if (displayStyle.Prefix != null) {
+                    gui.BuildText(displayStyle.Prefix);
+                }
 
                 textRect = gui.RemainingRow(0.3f).AllocateRect(0, lineSize, RectAlignment.MiddleFullRow);
             }

--- a/Yafc.UI/ImGui/TextDisplayStyles.cs
+++ b/Yafc.UI/ImGui/TextDisplayStyles.cs
@@ -43,7 +43,8 @@ public record TextBlockDisplayStyle(Font? Font = null, bool WrapText = false, Re
 /// <param name="Padding">The <see cref="UI.Padding"/> to place between the text and the edges of the editable area. (The box area not used by <paramref name="Icon"/>.)</param>
 /// <param name="Alignment">The <see cref="RectAlignment"/> to apply when drawing the text within the edit box.</param>
 /// <param name="ColorGroup">The <see cref="SchemeColorGroup"/> to use when drawing the edit box.</param>
-public record TextBoxDisplayStyle(Icon Icon, Padding Padding, RectAlignment Alignment, SchemeColorGroup ColorGroup) {
+/// <param name="Prefix">The text to display inside the textbox, before the value.</param>
+public record TextBoxDisplayStyle(Icon Icon, Padding Padding, RectAlignment Alignment, SchemeColorGroup ColorGroup, string? Prefix = null) {
     /// <summary>
     /// Gets the default display style, used for the Preferences screen and calls to <see cref="ImGui.BuildTextInput(string?, out string, string?, Icon, bool, bool)"/>.
     /// </summary>

--- a/Yafc/Windows/AboutScreen.cs
+++ b/Yafc/Windows/AboutScreen.cs
@@ -1,4 +1,5 @@
-﻿using Yafc.UI;
+﻿using System.Threading.Tasks;
+using Yafc.UI;
 
 namespace Yafc {
     public class AboutScreen : WindowUtility {
@@ -6,7 +7,7 @@ namespace Yafc {
 
         public AboutScreen(Window parent) : base(ImGuiUtils.DefaultScreenPadding) => Create("About YAFC-CE", 50, parent);
 
-        protected override void BuildContents(ImGui gui) {
+        protected override Task BuildContents(ImGui gui) {
             gui.allocator = RectAllocator.Center;
             gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
             gui.BuildText("(Community Edition)", TextBlockDisplayStyle.Centered);
@@ -66,6 +67,8 @@ namespace Yafc {
             gui.allocator = RectAllocator.Center;
             gui.BuildText("Factorio name, content and materials are trademarks and copyrights of Wube Software");
             BuildLink(gui, "https://factorio.com/");
+
+            return Task.CompletedTask;
         }
 
         private void BuildLink(ImGui gui, string url, string? text = null) {

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Threading.Tasks;
 using SDL2;
 using Yafc.UI;
 
@@ -42,7 +43,7 @@ namespace Yafc {
             previousFocus = InputSystem.Instance.SetDefaultKeyboardFocus(this);
         }
 
-        protected override void BuildContents(ImGui gui) {
+        protected override Task BuildContents(ImGui gui) {
             gui.BuildText(description, TextBlockDisplayStyle.WrappedText);
             if (gui.BuildTextInput(location, out string newLocation, null)) {
                 if (Directory.Exists(newLocation)) {
@@ -62,6 +63,8 @@ namespace Yafc {
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         private void BuildSelectButton(ImGui gui) {

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -56,6 +56,18 @@ namespace Yafc {
                 }
             }
 
+            using (gui.EnterRowWithHelpIcon($"""
+                    Yafc considers all enabled recipes on your production sheets, even if they are inaccessible. The cost of inaccessible recipes will be multiplied by this amount, to discourage Yafc from using them.
+                    For example, an inaccessible ¥100 recipe will be treated as if it costs ¥{DataUtils.FormatAmount(100 * settings.InaccessibleRecipePenalty, UnitOfMeasure.None)}.
+                    """)) {
+                gui.BuildText("Cost penalty for inaccessible recipes:", topOffset: 0.5f);
+                DisplayAmount amount = new(settings.InaccessibleRecipePenalty, UnitOfMeasure.None);
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput with { Prefix = "×" }) && amount.Value >= 1) {
+                    settings.RecordUndo().InaccessibleRecipePenalty = amount.Value;
+                    gui.Rebuild();
+                }
+            }
+
             ChooseObject(gui, "Default belt:", Database.allBelts, prefs.defaultBelt, s => {
                 prefs.RecordUndo().defaultBelt = s;
                 gui.Rebuild();

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using SDL2;
 using Serilog;
 using Yafc.Model;
@@ -97,7 +98,7 @@ namespace Yafc {
             gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
         }
 
-        protected override void BuildContents(ImGui gui) {
+        protected override Task BuildContents(ImGui gui) {
             gui.spacing = 1.5f;
             gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
             if (loading) {
@@ -185,6 +186,8 @@ namespace Yafc {
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         private void ProjectErrorMoreInfo(ImGui gui) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Date:
           the launch-settings from the most-recently opened project.
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
+        - Milestone-locked and inaccessible recipes will be avoided when multiple recipes are available.
     Internal changes:
         - Add .git-blame-ignore revs. It doesn't work with Visual Studio, but it might be useful in CLI or other IDEs.
         - Add the ability for tests to load lua and run tests that need parts of a Yafc project.


### PR DESCRIPTION
I have two possible implementations of this fix, but neither is perfect. This one usually behaves as expected, but has code that's simply wrong. Non-automatable goods are sometimes treated as if they cost 0, instead of the default Infinity. However, removing that special case creates incorrect "YAFC analysis: There are better recipes to create X. (Wasting 100% of YAFC cost)" messages for recipes with non-automatable goods.