### PR TITLE
fix: Prevent silent solver failures.

### DIFF
--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -152,7 +152,7 @@ match:
             if (recipeRow.entity != null) {
                 recipeRow.fuel = GetSelectedFuel(selectedFuel, recipeRow)
                     ?? GetFuelForSpentFuel(spentFuel, recipeRow)
-                    ?? recipeRow.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
+                    ?? recipeRow.entity.energy?.fuels.AutoSelect(DataUtils.FavoriteFuel);
             }
 
             foreach (Ingredient ingredient in recipeRow.recipe.ingredients) {
@@ -186,7 +186,7 @@ match:
 
         private static Goods? GetSelectedFuel(Goods? selectedFuel, [NotNull] RecipeRow recipeRow) =>
             // Skipping AutoSelect since there will only be one result at most.
-            recipeRow.entity?.energy.fuels.FirstOrDefault(e => e == selectedFuel);
+            recipeRow.entity?.energy?.fuels.FirstOrDefault(e => e == selectedFuel);
 
         /// <summary>
         /// Get all <see cref="RecipeRow"/>s contained in this <see cref="ProductionTable"/>, in a depth-first ordering. (The same as in the UI when all nested tables are expanded.)

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -66,7 +66,7 @@ namespace Yafc.Model {
                 float energyPerUnitOfFuel = 0f;
 
                 // Special case for fuel
-                if (fuel != null) {
+                if (energy != null && fuel != null) {
                     var fluid = fuel.fluid;
                     energyPerUnitOfFuel = fuel.fuelValue;
 
@@ -101,6 +101,7 @@ namespace Yafc.Model {
                 else {
                     fuelUsagePerSecondPerBuilding = energyUsage;
                     warningFlags |= WarningFlags.FuelNotSpecified;
+                    energy ??= new EntityEnergy { type = EntityEnergyType.Void };
                 }
 
                 // Special case for generators

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -746,15 +746,19 @@ goodsHaveNoProduction:;
 
             void dropDownContent(ImGui gui) {
                 if (type == ProductDropdownType.Fuel && recipe?.entity != null) {
-                    if ((recipe.entity.energy?.fuels.Length ?? 0) == 0) {
+                    EntityEnergy? energy = recipe.entity.energy;
+
+                    if (energy == null || energy.fuels.Length == 0) {
                         gui.BuildText("This entity has no known fuels");
                     }
-                    else if (recipe.entity.energy!.fuels.Length > 1 || recipe.entity.energy.fuels[0] != recipe.fuel) {
-                        Func<Goods, string> fuelDisplayFunc = recipe.entity.energy.type == EntityEnergyType.FluidHeat
+                    else if (energy.fuels.Length > 1 || energy.fuels[0] != recipe.fuel) {
+                        Func<Goods, string> fuelDisplayFunc = energy.type == EntityEnergyType.FluidHeat
                              ? g => DataUtils.FormatAmount(g.fluid?.heatValue ?? 0, UnitOfMeasure.Megajoule)
                              : g => DataUtils.FormatAmount(g.fuelValue, UnitOfMeasure.Megajoule);
+
                         BuildFavorites(gui, recipe.fuel, "Add fuel to favorites");
-                        gui.BuildInlineObjectListAndButton(recipe.entity.energy.fuels, DataUtils.FavoriteFuel, fuel => recipe.RecordUndo().fuel = fuel, "Select fuel", extra: fuelDisplayFunc);
+                        gui.BuildInlineObjectListAndButton(energy.fuels, DataUtils.FavoriteFuel,
+                            fuel => recipe.RecordUndo().fuel = fuel, "Select fuel", extra: fuelDisplayFunc);
                     }
                 }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -746,10 +746,10 @@ goodsHaveNoProduction:;
 
             void dropDownContent(ImGui gui) {
                 if (type == ProductDropdownType.Fuel && recipe?.entity != null) {
-                    if (recipe.entity.energy.fuels.Length == 0) {
+                    if ((recipe.entity.energy?.fuels.Length ?? 0) == 0) {
                         gui.BuildText("This entity has no known fuels");
                     }
-                    else if (recipe.entity.energy.fuels.Length > 1 || recipe.entity.energy.fuels[0] != recipe.fuel) {
+                    else if (recipe.entity.energy!.fuels.Length > 1 || recipe.entity.energy.fuels[0] != recipe.fuel) {
                         Func<Goods, string> fuelDisplayFunc = recipe.entity.energy.type == EntityEnergyType.FluidHeat
                              ? g => DataUtils.FormatAmount(g.fluid?.heatValue ?? 0, UnitOfMeasure.Megajoule)
                              : g => DataUtils.FormatAmount(g.fuelValue, UnitOfMeasure.Megajoule);

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Date:
           the launch-settings from the most-recently opened project.
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
+        - Crafters with no enery_source no longer make Yafc refuse to solve the page.
     Internal changes:
         - Add .git-blame-ignore revs. It doesn't work with Visual Studio, but it might be useful in CLI or other IDEs.
         - Add the ability for tests to load lua and run tests that need parts of a Yafc project.


### PR DESCRIPTION
Crafters with no energy source would halt the solver with silently-ignored exceptions. Turn them into user-visible errors, and let the solver do its best with the information it has.

I discovered this while playing with [Exotic Industries](https://mods.factorio.com/mod/exotic-industries). With this [mod-fix](https://github.com/user-attachments/files/16860059/exotic-industries.prototypes.computer_age.computer_age.lua.zip) and [project](https://github.com/user-attachments/files/16860069/silent-non-solve.zip), the solver will silently refuse to deal with the page. (Remove the "Bio matter: insulated wire" tech, and the solver will come back to life.) With this fix, Yafc will display an error on the "Bio matter: insulated wire" tech, and will solve the page.

(The fix a mod developer should make is to uncomment the commented line in the mod-fix, but silent errors are bad UX, even if the error is someone else's fault.)