### PR TITLE
Move the Legacy Summary and Import from clipboard buttons

### DIFF
--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -277,7 +277,7 @@ namespace Yafc.UI {
                 case SDL.SDL_Scancode.SDL_SCANCODE_END:
                     SetCaret(int.MaxValue, shift ? selectionAnchor : int.MaxValue);
                     break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_V when ctrl && ImGuiUtils.HasClipboard():
+                case SDL.SDL_Scancode.SDL_SCANCODE_V when ctrl && ImGuiUtils.HasClipboardText():
                     _ = TextInput(SDL.SDL_GetClipboardText());
                     break;
                 case SDL.SDL_Scancode.SDL_SCANCODE_C when ctrl && selectionAnchor != caret:

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -277,7 +277,7 @@ namespace Yafc.UI {
                 case SDL.SDL_Scancode.SDL_SCANCODE_END:
                     SetCaret(int.MaxValue, shift ? selectionAnchor : int.MaxValue);
                     break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_V when ctrl && SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE:
+                case SDL.SDL_Scancode.SDL_SCANCODE_V when ctrl && ImGuiUtils.HasClipboard():
                     _ = TextInput(SDL.SDL_GetClipboardText());
                     break;
                 case SDL.SDL_Scancode.SDL_SCANCODE_C when ctrl && selectionAnchor != caret:

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -34,7 +34,7 @@ namespace Yafc.UI {
         public static readonly Padding DefaultIconPadding = new Padding(0.3f);
 
         /// <summary>Returns true when the clipboard holds content</summary>
-        public static bool HasClipboard() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE;
+        public static bool HasClipboardText() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE;
 
         public static ButtonEvent BuildButton(this ImGui gui, Rect rect, SchemeColor normal, SchemeColor over, SchemeColor down = SchemeColor.None, uint button = SDL.SDL_BUTTON_LEFT) {
             if (button == 0) {

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -33,6 +33,9 @@ namespace Yafc.UI {
         public static readonly Padding DefaultScreenPadding = new Padding(5f, 2f);
         public static readonly Padding DefaultIconPadding = new Padding(0.3f);
 
+        /// <summary>Returns true when the clipboard holds content</summary>
+        public static bool HasClipboard() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE;
+
         public static ButtonEvent BuildButton(this ImGui gui, Rect rect, SchemeColor normal, SchemeColor over, SchemeColor down = SchemeColor.None, uint button = SDL.SDL_BUTTON_LEFT) {
             if (button == 0) {
                 button = (uint)InputSystem.Instance.mouseDownButton;

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -408,7 +408,7 @@ namespace Yafc {
                 SelectSingleObjectPanel.Select(Database.objects.explorable, "Open Dependency Explorer", DependencyExplorer.Show);
             }
 
-            if (gui.BuildContextMenuButton("Import page from clipboard", disabled: !ImGuiUtils.HasClipboard()) && gui.CloseDropdown()) {
+            if (gui.BuildContextMenuButton("Import page from clipboard", disabled: !ImGuiUtils.HasClipboardText()) && gui.CloseDropdown()) {
                 ProjectPageSettingsPanel.LoadProjectPageFromClipboard();
             }
 

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -242,8 +242,8 @@ namespace Yafc {
                     gui.ShowDropDown(gui.lastRect, SettingsDropdown, new Padding(0f, 0f, 0f, 0.5f));
                 }
 
-                if (gui.BuildButton(Icon.Plus)) {
-                    gui.ShowDropDown(gui.lastRect, CreatePageDropdown, new Padding(0f, 0f, 0f, 0.5f));
+                if (gui.BuildButton(Icon.Plus).WithTooltip(gui, "Create production sheet (Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T) + ")")) {
+                    ProductionTableView.CreateProductionSheet();
                 }
 
                 gui.allocator = RectAllocator.RightRow;
@@ -310,19 +310,6 @@ namespace Yafc {
             }
 
             return page;
-        }
-
-        private void CreatePageDropdown(ImGui gui) {
-            foreach (var (type, view) in registeredPageViews) {
-                view.CreateModelDropdown(gui, type, project);
-            }
-
-            if (SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE) {
-                gui.AllocateSpacing();
-                if (gui.BuildContextMenuButton("Import page from clipboard") && gui.CloseDropdown()) {
-                    ProjectPageSettingsPanel.LoadProjectPageFromClipboard();
-                }
-            }
         }
 
         public void BuildSubHeader(ImGui gui, string text) {
@@ -409,12 +396,20 @@ namespace Yafc {
                 ShowSummaryTab();
             }
 
+            if (gui.BuildContextMenuButton("Summary (Legacy)") && gui.CloseDropdown()) {
+                ProjectPageSettingsPanel.Show(null, (name, icon) => Instance.AddProjectPage(name, icon, typeof(ProductionSummary), true, true));
+            }
+
             if (gui.BuildContextMenuButton("Never Enough Items Explorer", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_N)) && gui.CloseDropdown()) {
                 ShowNeie();
             }
 
             if (gui.BuildContextMenuButton("Dependency Explorer") && gui.CloseDropdown()) {
                 SelectSingleObjectPanel.Select(Database.objects.explorable, "Open Dependency Explorer", DependencyExplorer.Show);
+            }
+
+            if (gui.BuildContextMenuButton("Import page from clipboard", disabled: !ImGuiUtils.HasClipboard()) && gui.CloseDropdown()) {
+                ProjectPageSettingsPanel.LoadProjectPageFromClipboard();
             }
 
             BuildSubHeader(gui, "Extra");

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -242,7 +242,9 @@ namespace Yafc {
                     gui.ShowDropDown(gui.lastRect, SettingsDropdown, new Padding(0f, 0f, 0f, 0.5f));
                 }
 
-                if (gui.BuildButton(Icon.Plus).WithTooltip(gui, "Create production sheet (Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T) + ")")) {
+                if (gui.BuildButton(Icon.Plus).WithTooltip(gui, "Create production sheet (Ctrl+" +
+                    ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T) + ")")) {
+
                     ProductionTableView.CreateProductionSheet();
                 }
 

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -97,14 +97,14 @@ namespace Yafc {
             }
         }
 
+        /*
         public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
-            /*
             if (gui.BuildContextMenuButton("Auto planner (Alpha)"))
             {
                 close = true;
                 WizardPanel.Show("New auto planner", CreateAutoPlannerWizard);
             }
-            */
         }
+        */
     }
 }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -311,12 +311,6 @@ namespace Yafc {
             base.Rebuild(visualOnly);
         }
 
-        public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
-            if (gui.BuildContextMenuButton("Create production summary (Legacy)") && gui.CloseDropdown()) {
-                ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionSummary), true, true));
-            }
-        }
-
         protected override void BuildPageTooltip(ImGui gui, ProductionSummary contents) {
 
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -646,11 +646,6 @@ goodsHaveNoProduction:;
 
         public override float CalculateWidth() => flatHierarchyBuilder.width;
 
-        public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
-            if (gui.BuildContextMenuButton("Create production sheet", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T)) && gui.CloseDropdown()) {
-                CreateProductionSheet();
-            }
-        }
         public static void CreateProductionSheet() => ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true));
 
         private static readonly IComparer<Goods> DefaultVariantOrdering = new DataUtils.FactorioObjectComparer<Goods>((x, y) => (y.ApproximateFlow() / MathF.Abs(y.Cost())).CompareTo(x.ApproximateFlow() / MathF.Abs(x.Cost())));

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -71,8 +71,6 @@ namespace Yafc {
             gui.DrawPanel(viewport, bodyContent);
         }
 
-        public abstract void CreateModelDropdown(ImGui gui1, Type type, Project project);
-
         public virtual bool ControlKey(SDL.SDL_Scancode code) => false;
 
         public MemoryDrawingSurface GenerateFullPageScreenshot() {

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -399,8 +399,5 @@ namespace Yafc {
             bodyContent.Rebuild();
             scrollArea.Rebuild();
         }
-
-        public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
-        }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Date:
         - Add 'Produce it as a spent fuel' recipe selection.
         - You can now open projects from a Windows context-menu. If the project was not opened before, then Yafc uses
           the launch-settings from the most-recently opened project.
+        - Move the Legacy Summary and Import from clipboard buttons to the main/hamburger menu.
     Bugfixes:
         - Several fixes to the legacy summary page, including a regression in 0.8.1.
         - Crafters with no enery_source no longer make Yafc refuse to solve the page.


### PR DESCRIPTION
The buttons are moved to the main/hamburger menu. The 'left over' plus icon is now used to create a new production tab.

![image](https://github.com/user-attachments/assets/21e19181-f2cd-4a0d-8d2a-0a856b789c58) ![image](https://github.com/user-attachments/assets/ab6713fb-5d74-4a6e-b1f4-d6f8db83678d)


Besides this, I removed the now obsolete abstract function (`CreateModelDropdown`) to add a function to the dropdown items, and the other code that was used to create the dropdown menu.

Fixes #225 