### PR TITLE
Remove Save functionality and provide a 'cleanup callback'

### DIFF
--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -85,26 +85,23 @@ namespace Yafc {
     /// Represents a panel that can generate a result. (But doesn't have to, if the user selects a close or cancel button.)
     /// </summary>
     /// <typeparam name="T">The type of result the panel can generate.</typeparam>
-    public abstract class PseudoScreen<T> : PseudoScreen {
-        protected PseudoScreen(float width = 40f) : base(width) { }
+    public abstract class PseudoScreenWithResult<T> : PseudoScreen {
+        protected PseudoScreenWithResult(float width = 40f) : base(width) { }
         /// <summary>
         /// If not <see langword="null"/>, called after the panel is closed. The parameters are <c>hasResult</c> and <c>result</c>: If a result is available, the first parameter will
         /// be <see langword="true"/>, and the second parameter will have the result. The result may be <see langword="null"/>, depending on the kind of panel that was displayed.
         /// </summary>
-        protected Action<bool, T?>? complete;
+        /// <remarks>Note that the <see cref="PseudoScreen.Save()"/> will be called after invoking this callback.</remarks>
+        protected Action<bool, T?>? completionCallback;
 
         protected void CloseWithResult(T? result) {
-            var completionCallback = complete;
-            complete = null;
-            Close(true);
             completionCallback?.Invoke(true, result);
+            base.Close(true);
         }
 
         protected override void Close(bool save = true) {
-            var completionCallback = complete;
-            complete = null;
-            base.Close(save);
             completionCallback?.Invoke(false, default);
+            base.Close(save);
         }
     }
 }

--- a/Yafc/Windows/ImageSharePanel.cs
+++ b/Yafc/Windows/ImageSharePanel.cs
@@ -17,6 +17,7 @@ namespace Yafc {
             this.name = name;
             ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface.surface);
             header = name + " (" + surfaceData.w + "x" + surfaceData.h + ")";
+            cleanupCallback = surface.Dispose;
 
             _ = MainScreen.Instance.ShowPseudoScreen(this);
         }
@@ -53,11 +54,6 @@ namespace Yafc {
             if (path != null) {
                 surface?.SavePng(path);
             }
-        }
-
-        protected override void Close(bool save = true) {
-            base.Close(save);
-            surface?.Dispose();
         }
     }
 }

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Yafc.UI;
 
 namespace Yafc {
-    public class MessageBox : PseudoScreen<bool> {
+    public class MessageBox : PseudoScreenWithResult<bool> {
         private readonly string title;
         private readonly string message;
         private readonly string yes;
@@ -17,7 +17,7 @@ namespace Yafc {
         }
 
         public static void Show(Action<bool, bool>? result, string title, string message, string yes, string? no) {
-            MessageBox instance = new MessageBox(title, message, yes, no) { complete = result };
+            MessageBox instance = new MessageBox(title, message, yes, no) { completionCallback = result };
             _ = MainScreen.Instance.ShowPseudoScreen(instance);
         }
 

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -8,17 +8,20 @@ namespace Yafc {
         private static readonly MilestonesEditor Instance = new MilestonesEditor();
         private readonly VirtualScrollList<FactorioObject> milestoneList;
 
-        public MilestonesEditor() : base(50) => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
+        public MilestonesEditor() : base(50) {
+            milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
+            cleanupCallback = () => {
+                // Force rebuild the panel to update its contents and show the possibly-modified milestones.
+                MilestonesPanel.Rebuild();
+
+                // Recalculate the project with the  possibly-modified milestones.
+                Milestones.Instance.Compute(Project.current, new());
+            };
+        }
 
         public override void Open() {
             base.Open();
             milestoneList.data = Project.current.settings.milestones;
-        }
-
-        protected override void Close(bool save = true) {
-            MilestonesPanel.Rebuild();
-            Milestones.Instance.Compute(Project.current, new());
-            base.Close(save);
         }
 
         public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -60,9 +60,6 @@ namespace Yafc {
 
         protected override void ReturnPressed() => Close();
 
-        /// <summary>
-        /// Called by <see cref="MilestonesEditor.Close(bool)"/> to force this panel to update its contents and show the possibly-modified milestones.
-        /// </summary>
         internal static new void Rebuild() => instance?.RebuildContents();
     }
 }

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -10,7 +10,7 @@ namespace Yafc {
     /// Represents a panel that can generate a result by selecting zero or more <see cref="FactorioObject"/>s. (But doesn't have to, if the user selects a close or cancel button.)
     /// </summary>
     /// <typeparam name="T">The type of result the panel can generate.</typeparam>
-    public abstract class SelectObjectPanel<T> : PseudoScreen<T> {
+    public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
         private readonly SearchableList<FactorioObject?> list;
         private string header = null!; // null-forgiving: set by Select
         private Rect searchBox;
@@ -51,7 +51,7 @@ namespace Yafc {
             this.list.data = data;
             this.header = header;
             Rebuild();
-            complete = (hasResult, result) => {
+            completionCallback = (hasResult, result) => {
                 if (hasResult) {
                     mapResult(result, obj => {
                         if (obj is U u) {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -5,7 +5,7 @@ using Yafc.Model;
 using Yafc.UI;
 
 namespace Yafc {
-    public class ModuleCustomizationScreen : PseudoScreen<ModuleTemplateBuilder> {
+    public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBuilder> {
         private static readonly ModuleCustomizationScreen Instance = new ModuleCustomizationScreen();
 
         private RecipeRow? recipe;
@@ -16,7 +16,7 @@ namespace Yafc {
             Instance.template = null;
             Instance.recipe = recipe;
             Instance.modules = recipe.modules?.GetBuilder();
-            Instance.complete = (hasResult, builder) => {
+            Instance.completionCallback = (hasResult, builder) => {
                 if (hasResult) {
                     recipe.RecordUndo().modules = builder?.Build(recipe);
                 }
@@ -28,7 +28,7 @@ namespace Yafc {
             Instance.recipe = null;
             Instance.template = template;
             Instance.modules = template.template.GetBuilder();
-            Instance.complete = (hasResult, builder) => {
+            Instance.completionCallback = (hasResult, builder) => {
                 if (hasResult) {
                     template.RecordUndo().template = builder!.Build(template);
                 }


### PR DESCRIPTION
The Save() function was never overridden, and instead the Close() function was to perform some additional cleanups or recalculations. So even though #184 states that it would be nice to implement a proper save functionality, this is seemingly not needed (anymore). As all screens that do have results (to save) are using the `PseudoScreenWithResult` class.

I have made the difference between these 2 classes more distinct by renaming one to `PseudoScreenWithResult` (as mentioned above), and cleaned up the (ab)use of them in two separate commits.

Handling results and cleaning up can now be easily implemented by using the correct class and its callback(s), as the  new `cleanupCallback` acts in a similar fashion as the `PseudoScreenWithResult.completionCallback`.

Implements #184