### PR TITLE
Variant ingredients could not be selected

### DIFF
--- a/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
+++ b/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace Yafc.Model.Tests.Model;
+
+[Collection("LuaDependentTests")]
+public class SelectableVariantsTests {
+    [Fact]
+    public void CanSelectVariantFuel_VariantFuelChanges() {
+        Project project = LuaDependentTestHelper.GetProjectForLua();
+
+        ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
+        ProductionTable table = (ProductionTable)page.content;
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "generator.electricity"), DataUtils.DeterministicComparer);
+        RecipeRow row = table.GetAllRecipes().Single();
+
+        // Solve is not necessary in this test, but I'm calling it in case we decide to hide the fuel on disabled recipes.
+        table.Solve((ProjectPage)table.owner).Wait();
+        Assert.Equal("steam@165", row.FuelInformation.Goods.name);
+
+        row.fuel = row.FuelInformation.Variants[1];
+        table.Solve((ProjectPage)table.owner).Wait();
+        Assert.Equal("steam@500", row.FuelInformation.Goods.name);
+    }
+
+    [Fact]
+    public void CanSelectVariantFuelWithFavorites_VariantFuelChanges() {
+        Project project = LuaDependentTestHelper.GetProjectForLua();
+        project.preferences.ToggleFavorite(Database.fluids.all.Single(c => c.name == "steam@500"));
+
+        ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
+        ProductionTable table = (ProductionTable)page.content;
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "generator.electricity"), DataUtils.DeterministicComparer);
+        RecipeRow row = table.GetAllRecipes().Single();
+
+        // Solve is not necessary in this test, but I'm calling it in case we decide to hide the fuel on disabled recipes.
+        table.Solve((ProjectPage)table.owner).Wait();
+        Assert.Equal("steam@500", row.FuelInformation.Goods.name);
+
+        row.fuel = row.FuelInformation.Variants[0];
+        table.Solve((ProjectPage)table.owner).Wait();
+        Assert.Equal("steam@165", row.FuelInformation.Goods.name);
+    }
+
+    [Fact]
+    public void CanSelectVariantIngredient_VariantIngredientChanges() {
+        Project project = LuaDependentTestHelper.GetProjectForLua();
+
+        ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
+        ProductionTable table = (ProductionTable)page.content;
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "steam_void"), DataUtils.DeterministicComparer);
+        RecipeRow row = table.GetAllRecipes().Single();
+
+        // Solve is necessary here: Disabled recipes have null ingredients (and products), and Solve is the call that updates hierarchyEnabled.
+        table.Solve((ProjectPage)table.owner).Wait();
+        Assert.Equal("steam@165", row.Ingredients.Single().Goods.name);
+
+        row.ChangeVariant(row.Ingredients.Single().Goods, row.Ingredients.Single().Variants[1]);
+        table.Solve((ProjectPage)table.owner).Wait();
+        Assert.Equal("steam@500", row.Ingredients.Single().Goods.name);
+    }
+
+    // No corresponding CanSelectVariantIngredientWithFavorites: Favorites control fuel selection, but not ingredient selection.
+}

--- a/Yafc.Model.Tests/Model/SelectableVariantsTests.lua
+++ b/Yafc.Model.Tests/Model/SelectableVariantsTests.lua
@@ -1,0 +1,100 @@
+data = {
+  raw = {
+    recipe = {
+      steam_void = {
+        type = "recipe",
+        name = "steam_void",
+        category = "oil-processing",
+        energy_required = 5,
+        ingredients = {
+          {
+            type = "fluid",
+            name = "steam",
+            amount = 50,
+          },
+        },
+      },
+    },
+    fluid = {
+      steam = {
+        type = "fluid",
+        name = "steam",
+        default_temperature = 15,
+        max_temperature = 1000,
+        heat_capacity = "0.2KJ",
+        gas_temperature = 15,
+        auto_barrel = False,
+        icon = "",
+      }
+    },
+    boiler = {
+      boiler = {
+        type = "boiler",
+        name = "boiler",
+        mode = "output-to-separate-pipe",
+        target_temperature = 165,
+        output_fluid_box = {
+          filter = "steam",
+        },
+        energy_consumption = "1.8MW",
+        energy_source = {
+          type = "burner",
+          fuel_category = "chemical",
+        },
+      },
+      ["heat-exchanger"] = {
+        type = "boiler",
+        name = "heat-exchanger",
+        mode = "output-to-separate-pipe",
+        target_temperature = 500,
+        output_fluid_box = {
+          filter = "steam",
+        },
+        energy_consumption = "10MW",
+        energy_source = {
+          type = "heat",
+          max_temperature = 1000,
+          specific_heat = "1MJ",
+        },
+      },
+    },
+    generator = {
+      ["steam-engine"] = {
+        type = "generator",
+        name = "steam-engine",
+        fluid_usage_per_tick = 0.5,
+        maximum_temperature = 165,
+        fluid_box = {
+          filter = "steam",
+          minimum_temperature = 100,
+        },
+        energy_source = {
+          type = "electric",
+        },
+      },
+      ["steam-turbine"] = {
+        type = "generator",
+        name = "steam-turbine",
+        fluid_usage_per_tick = 1,
+        maximum_temperature = 500,
+        burns_fluid = False,
+        fluid_box = {
+          filter = "steam",
+        },
+        energy_source = {
+          type = "electric",
+        },
+      },
+    },
+  },
+}
+defines.prototypes = {
+  entity = {
+    boiler = 0,
+    generator = 0,
+  },
+  item = { },
+  fluid = {
+    fluid = 0,
+  },
+}

--- a/Yafc.Model.Tests/Yafc.Model.Tests.csproj
+++ b/Yafc.Model.Tests/Yafc.Model.Tests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Model\ProductionTableContentTests.lua" />
+    <EmbeddedResource Include="Model\SelectableVariantsTests.lua" />
   </ItemGroup>
 
 </Project>

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -394,9 +394,9 @@ namespace Yafc.Model {
                 return hierarchyEnabled ? @internal() : Enumerable.Repeat<RecipeRowIngredient>((null, 0, null, null), recipe.ingredients.Length);
 
                 IEnumerable<RecipeRowIngredient> @internal() {
-                    int i = 0;
-                    foreach (Ingredient ingredient in recipe.ingredients) {
-                        yield return (ingredient.goods, ingredient.amount * (float)recipesPerSecond, links.ingredients[i++], ingredient.variants);
+                    for (int i = 0; i < recipe.ingredients.Length; i++) {
+                        Ingredient ingredient = recipe.ingredients[i];
+                        yield return (links.ingredientGoods[i], ingredient.amount * (float)recipesPerSecond, links.ingredients[i], ingredient.variants);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #260, and adds some tests that will help prevent it from happening again. No changelog entry because this was introduced after 0.8.1.

Besides the unit tests, I also confirmed the UI correctly handled fluid variant selection for both fuel and ingredients, and that the links behaved correctly in the supplied project page.