### PR TITLE
fix(#272, 696fd52): Boilers respect the selected input temperature again.

### DIFF
--- a/Yafc.Model.Tests/Model/RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua
+++ b/Yafc.Model.Tests/Model/RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua
@@ -1,0 +1,125 @@
+data = {
+  raw = {
+    recipe = {
+      -- Recipes so Yafc will split water into the required temperatures
+      cold_water = {
+        type = "recipe",
+        name = "cold_water",
+        category = "oil-processing",
+        energy_required = 5,
+        results = {
+          {
+            type = "fluid",
+            name = "water",
+            amount = 50,
+            temperature = 15,
+          },
+        },
+      },
+      warm_water = {
+        type = "recipe",
+        name = "warm_water",
+        category = "oil-processing",
+        energy_required = 5,
+        results = {
+          {
+            type = "fluid",
+            name = "water",
+            amount = 50,
+            temperature = 50,
+          },
+        },
+      },
+      hot_water = {
+        type = "recipe",
+        name = "hot_water",
+        category = "oil-processing",
+        energy_required = 5,
+        results = {
+          {
+            type = "fluid",
+            name = "water",
+            amount = 50,
+            temperature = 90,
+          },
+        },
+      },
+    },
+    item = {
+      coal = {
+        type = "item",
+        name = "coal",
+        fuel_category = "chemical",
+        fuel_value = "4MJ",
+      },
+    },
+    fluid = {
+      water = {
+        type = "fluid",
+        name = "water",
+        default_temperature = 15,
+        max_temperature = 1000,
+        heat_capacity = "0.2KJ",
+        icon = "",
+      },
+      steam = {
+        type = "fluid",
+        name = "steam",
+        default_temperature = 15,
+        max_temperature = 1000,
+        heat_capacity = "0.2KJ",
+        gas_temperature = 15,
+        auto_barrel = False,
+        icon = "",
+      },
+    },
+    boiler = {
+      boiler = {
+        type = "boiler",
+        name = "boiler",
+        mode = "output-to-separate-pipe",
+        target_temperature = 165,
+        fluid_box = {
+          filter = "water",
+        },
+        output_fluid_box = {
+          filter = "steam",
+        },
+        energy_consumption = "1.8MW",
+        energy_source = {
+          type = "burner",
+          fuel_category = "chemical",
+        },
+      },
+      ["heat-exchanger"] = {
+        type = "boiler",
+        name = "heat-exchanger",
+        mode = "output-to-separate-pipe",
+        target_temperature = 500,
+        fluid_box = {
+          filter = "water",
+        },
+        output_fluid_box = {
+          filter = "steam",
+        },
+        energy_consumption = "10MW",
+        energy_source = {
+          type = "heat",
+          max_temperature = 1000,
+          specific_heat = "1MJ",
+        },
+      },
+    },
+  },
+}
+defines.prototypes = {
+  entity = {
+    boiler = 0,
+  },
+  item = {
+    item = 0,
+  },
+  fluid = {
+    fluid = 0,
+  },
+}

--- a/Yafc.Model.Tests/Model/RecipeParametersTests.cs
+++ b/Yafc.Model.Tests/Model/RecipeParametersTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Google.OrTools.ConstraintSolver;
+using Xunit;
+
+namespace Yafc.Model.Tests.Model;
+
+[Collection("LuaDependentTests")]
+public class RecipeParametersTests {
+    [Fact]
+    public void FluidBoilingRecipes_HaveCorrectConsumption() {
+        Project project = LuaDependentTestHelper.GetProjectForLua();
+
+        ProjectPage page = new(project, typeof(ProductionTable));
+        project.pages.Add(page);
+        ProductionTable table = (ProductionTable)page.content;
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "boiler.boiler.steam"), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "boiler.heat-exchanger.steam"), DataUtils.DeterministicComparer);
+
+        List<Fluid> water = Database.fluidVariants["Fluid.water"];
+
+        RecipeRow boiler = table.recipes[0];
+        RecipeRow heatExchanger = table.recipes[1];
+        boiler.fixedBuildings = 1;
+        heatExchanger.fixedBuildings = 1;
+        table.Solve((ProjectPage)table.owner).Wait(); // Initial Solve to set RecipeRow.Ingredients
+
+        for (int i = 0; i < 3; i++) {
+            boiler.ChangeVariant(boiler.Ingredients.Single().Goods, water[i]);
+            heatExchanger.ChangeVariant(boiler.Ingredients.Single().Goods, water[i]);
+
+            table.Solve((ProjectPage)table.owner).Wait();
+
+            // boil 60, 78.26, 120 water per second from 15, 50, 90° to 165°
+            float expectedBoilerAmount = 1800 / .2f / (165 - water[i].temperature);
+            // boil 103.09, 111.11, 121.95 water per second from 15, 50, 90° to 500°
+            float expectedHeatExchangerAmount = 10000 / .2f / (500 - water[i].temperature);
+            // Equation is boiler power (KW) / heat capacity (KJ/unit°C) / temperature change (°C) => unit/s
+
+            Assert.Equal(.45f, boiler.FuelInformation.Amount, .45f * .0001f); // Always .45 coal per second
+            Assert.Equal(expectedBoilerAmount, boiler.Ingredients.Single().Amount, expectedBoilerAmount * .0001f);
+            Assert.Equal(expectedBoilerAmount, boiler.Products.Single().Amount, expectedBoilerAmount * .0001f);
+
+            Assert.Equal(10, heatExchanger.FuelInformation.Amount); // Always 10 MW heat
+            Assert.Equal(expectedHeatExchangerAmount, heatExchanger.Ingredients.Single().Amount, expectedHeatExchangerAmount * .0001f);
+            Assert.Equal(expectedHeatExchangerAmount, heatExchanger.Products.Single().Amount, expectedHeatExchangerAmount * .0001f);
+        }
+    }
+}

--- a/Yafc.Model.Tests/Yafc.Model.Tests.csproj
+++ b/Yafc.Model.Tests/Yafc.Model.Tests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Model\ProductionTableContentTests.lua" />
+    <EmbeddedResource Include="Model\RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua" />
     <EmbeddedResource Include="Model\SelectableVariantsTests.lua" />
   </ItemGroup>
 

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Yafc.Model {
     [Flags]
@@ -120,7 +121,7 @@ namespace Yafc.Model {
                     var fluid = recipe.ingredients[0].goods.fluid;
                     if (fluid != null) {
                         float inputTemperature = fluid.temperature;
-                        foreach (Fluid variant in fluid.variants ?? []) {
+                        foreach (Fluid variant in row.variants.OfType<Fluid>()) {
                             if (variant.originalName == fluid.originalName) {
                                 inputTemperature = variant.temperature;
                             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,12 @@
 //     Internal changes: 
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version: 0.9.1
+Date:
+    Bugfixes:
+        - Fix boiler recipes that accept multiple input temperatures; they respect the selected temperature again.
+          (Note: This is specific to boilers. Factorio does not let assembly machines react to input temperatures.)
+----------------------------------------------------------------------------------------------------------------------
 Version: 0.9.0
 Date: September 6th 2024
     Features:


### PR DESCRIPTION
When used as inputs to be boiled, fluids with multiple temperatures were treated as if they were already at their maximum temperature.

In addition to the new test, I also confirmed that the boiler mechanics for pY showed the same number of buildings for each input temperature here as they did in 0.8.1.