### PR TITLE
[UI] Show warnings for goods on hover in addition to on click

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -638,6 +638,35 @@ namespace Yafc.Model {
         [SkipSerialization] public HashSet<RecipeRow> capturedRecipes { get; } = [];
         internal int solverIndex;
         public float dualValue { get; internal set; }
+
+        public IEnumerable<string> LinkWarnings {
+            get {
+                if (!flags.HasFlags(Flags.HasProduction)) {
+                    yield return "This link has no production (Link ignored)";
+                }
+
+                if (!flags.HasFlags(Flags.HasConsumption)) {
+                    yield return "This link has no consumption (Link ignored)";
+                }
+
+                if (flags.HasFlags(Flags.ChildNotMatched)) {
+                    yield return "Nested table link has unmatched production/consumption. These unmatched products are not captured by this link.";
+                }
+
+                if (!flags.HasFlags(Flags.HasProductionAndConsumption) && owner.owner is RecipeRow recipeRow && recipeRow.FindLink(goods, out _)) {
+                    yield return "Nested tables have their own set of links that DON'T connect to parent links. To connect this product to the outside, remove this link.";
+                }
+
+                if (flags.HasFlags(Flags.LinkRecursiveNotMatched)) {
+                    if (notMatchedFlow <= 0f) {
+                        yield return "YAFC was unable to satisfy this link (Negative feedback loop). This doesn't mean that this link is the problem, but it is part of the loop.";
+                    }
+                    else {
+                        yield return "YAFC was unable to satisfy this link (Overproduction). You can allow overproduction for this link to solve the error.";
+                    }
+                }
+            }
+        }
     }
 
     public record RecipeRowIngredient(Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants) {

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -145,6 +145,8 @@ namespace Yafc {
         private void BuildCommon(FactorioObject target, ImGui gui) {
             BuildHeader(gui);
             using (gui.EnterGroup(contentPadding)) {
+                tooltipOptions.DrawBelowHeader?.Invoke(gui);
+
                 if (InputSystem.Instance.control) {
                     gui.BuildText(target.typeDotName);
                 }
@@ -545,8 +547,18 @@ namespace Yafc {
         /// Gets or sets flags indicating where hints should be displayed in the tooltip.
         /// </summary>
         public HintLocations HintLocations { get; set; }
+        /// <summary>
+        /// Gets or sets a value that, if not null, will be called after drawing the tooltip header.
+        /// </summary>
+        public DrawBelowHeader? DrawBelowHeader { get; set; }
 
         // Reduce boilerplate by permitting unambiguous and relatively obvious implicit conversions.
         public static implicit operator ObjectTooltipOptions(HintLocations hintLocations) => new() { HintLocations = hintLocations };
+        public static implicit operator ObjectTooltipOptions(DrawBelowHeader drawBelowHeader) => new() { DrawBelowHeader = drawBelowHeader };
     }
+
+    /// <summary>
+    /// Called to draw additional information in the tooltip after drawing the tooltip header.
+    /// </summary>
+    public delegate void DrawBelowHeader(ImGui gui);
 }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -36,7 +36,7 @@ namespace Yafc {
         private void BuildHeader(ImGui gui) {
             using (gui.EnterGroup(new Padding(1f, 0.5f), RectAllocator.LeftAlign, spacing: 0f)) {
                 string name = target.text;
-                if (tooltipOptions.ExtendHeader && target is not Goods) {
+                if (tooltipOptions.ShowTypeInHeader && target is not Goods) {
                     name = name + " (" + target.target.type + ")";
                 }
 
@@ -542,7 +542,7 @@ namespace Yafc {
         /// If <see langword="true"/> and the target object is not a <see cref="Goods"/>, this tooltip will specify the type of object.
         /// e.g. "Radar" is the item, "Radar (Recipe)" is the recipe, and "Radar (Entity)" is the building.
         /// </summary>
-        public bool ExtendHeader { get; set; }
+        public bool ShowTypeInHeader { get; set; }
         /// <summary>
         /// Gets or sets flags indicating where hints should be displayed in the tooltip.
         /// </summary>

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -45,7 +45,7 @@ namespace Yafc {
                 string text = fobj.locName + " (" + fobj.type + ")";
                 gui.RemainingRow(0.5f).BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint });
             }
-            if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, fobj, tooltipOptions: new() { ExtendHeader = true }) == Click.Left) {
+            if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, fobj, tooltipOptions: new() { ShowTypeInHeader = true }) == Click.Left) {
                 Change(fobj);
             }
         }

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -30,7 +30,7 @@ namespace Yafc {
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
             SchemeColor bgColor = results.Contains(element) ? SchemeColor.Primary : SchemeColor.None;
-            Click click = gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(bgColor), new() { ExtendHeader = extendHeader });
+            Click click = gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(bgColor), new() { ShowTypeInHeader = showTypeInHeader });
 
             if (checkMark(element)) {
                 gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -17,9 +17,9 @@ namespace Yafc {
         private string? noneTooltip;
         /// <summary>
         /// If <see langword="true"/> and the object being hovered is not a <see cref="Goods"/>, the <see cref="ObjectTooltip"/> should specify the type of object.
-        /// See also <see cref="ObjectTooltipOptions.ExtendHeader"/>.
+        /// See also <see cref="ObjectTooltipOptions.ShowTypeInHeader"/>.
         /// </summary>
-        protected bool extendHeader { get; private set; }
+        protected bool showTypeInHeader { get; private set; }
 
         protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject?>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
 
@@ -39,7 +39,7 @@ namespace Yafc {
         protected void Select<U>(IEnumerable<U> list, string header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone, string? noneTooltip = null) where U : FactorioObject {
             _ = MainScreen.Instance.ShowPseudoScreen(this);
             this.noneTooltip = noneTooltip;
-            extendHeader = typeof(U) == typeof(FactorioObject);
+            showTypeInHeader = typeof(U) == typeof(FactorioObject);
             List<U?> data = new List<U?>(list);
             ordering ??= DataUtils.DefaultOrdering;
             data.Sort(ordering!); // null-forgiving: We don't have any nulls in the list yet.

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -34,7 +34,7 @@ namespace Yafc {
             => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
-            if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ExtendHeader = extendHeader }) == Click.Left) {
+            if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ShowTypeInHeader = showTypeInHeader }) == Click.Left) {
                 CloseWithResult(element);
             }
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,15 +15,13 @@
 //     Internal changes: 
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
-Version: 0.10.1
-Date:
-    Bugfixes:
-        - Fixed recipes now become accessible when their crafter does.
-----------------------------------------------------------------------------------------------------------------------
 Version: 0.10.0
 Date:
-    Feature:
+    Features:
         - Add OSX-arm64 build.
+        - Display link warnings in both the tooltips and the dropdowns.
+    Bugfixes:
+        - Fixed recipes now become accessible when their crafter does.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.9.1
 Date: September 8th 2024


### PR DESCRIPTION
Closes #271. When creating a FactorioObjectButton, the caller can ask to draw extra information below the header. The production table uses this to display the link warnings.