### PR TITLE
UI/Solve performance fix for large tables.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,7 +46,7 @@ dotnet_style_predefined_type_for_member_access = true:suggestion
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:error
 dotnet_style_parentheses_in_other_operators = always_for_clarity:none
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -537,7 +537,8 @@ match:
         /// <param name="goods">The <see cref="Goods"/> that might have its link removed.</param>
         /// <returns><see langword="true"/> if the link should be preserved, or <see langword="false"/> if it is ok to delete the link.</returns>
         private bool HasDisabledRecipeReferencing(Goods goods)
-            => GetAllRecipes().Any(row => !row.hierarchyEnabled && row.recipe.ingredients.Any(i => i.goods == goods) || row.recipe.products.Any(p => p.goods == goods) || row.fuel == goods);
+            => GetAllRecipes().Any(row => !row.hierarchyEnabled
+            && (row.fuel == goods || row.recipe.ingredients.Any(i => i.goods == goods) || row.recipe.products.Any(p => p.goods == goods)));
 
         private bool CheckBuiltCountExceeded() {
             bool builtCountExceeded = false;

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Date:
         - Fixed recipes now become accessible when their crafter does.
     Internal changes:
         - Allow tooltips to be displayed when hovering over radio buttons.
+        - Require parentheses when mixing && and || in the same expression.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.9.1
 Date: September 8th 2024


### PR DESCRIPTION
VS diagnostics reported a lot of CPU time was spent in this `.Any` call, which happened because `!row.hierarchyEnabled` only short-circuited one of the embedded `.Any` calls. 

After fixing the parentheses, the solve-time on a 1400-recipe sheet went from significant (~900 ms) to almost unnoticeable (~200 ms)

I also updated the style to error if && and || are mixed without parentheses again.