### PR TITLE
style: prefer file-scoped namespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -132,6 +132,7 @@ csharp_new_line_between_query_expression_clauses = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
+csharp_style_namespace_declarations = file_scoped:warning;
 # Space preferences
 csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true

--- a/CommandLineToolExample/Program.cs
+++ b/CommandLineToolExample/Program.cs
@@ -3,49 +3,49 @@ using Yafc;
 using Yafc.Model;
 using Yafc.Parser;
 
-namespace CommandLineToolExample {
-    // If you wish to embed YAFC or make a command-line tool using YAFC, here is an example on how to do that
-    // However, I can't make any promises about not changing signatures
-    public static class Program {
-        public static void Main(string[] args) {
-            if (args.Length == 0) {
-                Console.WriteLine("Pass FactorioData path as command-line argument");
-                return;
-            }
-            YafcLib.RegisterDefaultAnalysis(); // Register analysis to get cost, milestones, accessibility, etc information. Skip if you just need data. 
-            string factorioPath = args[0];
-            ErrorCollector errorCollector = new ErrorCollector();
-            Project project;
-            try {
-                // Load YAFC project.
-                // Empty project path loads default project (with one empty page).
-                // Project is irrelevant if you just need data, but you need it to perform sheet calculations
-                // Set to not render any icons
-                project = FactorioDataSource.Parse(factorioPath, "", "", false, false, new ConsoleProgressReport(), errorCollector, "en", false);
-            }
-            catch (Exception ex) {
-                // Critical errors that make project un-loadable will be thrown as exceptions
-                Console.Error.WriteException(ex);
-                return;
-            }
-            if (errorCollector.severity != ErrorSeverity.None) {
-                // Some non-critical errors were found while loading project, for example missing recipe or analysis warnings
-                foreach (var (error, _) in errorCollector.GetArrErrors()) {
-                    Console.Error.WriteLine(error);
-                }
+namespace CommandLineToolExample;
 
+// If you wish to embed YAFC or make a command-line tool using YAFC, here is an example on how to do that
+// However, I can't make any promises about not changing signatures
+public static class Program {
+    public static void Main(string[] args) {
+        if (args.Length == 0) {
+            Console.WriteLine("Pass FactorioData path as command-line argument");
+            return;
+        }
+        YafcLib.RegisterDefaultAnalysis(); // Register analysis to get cost, milestones, accessibility, etc information. Skip if you just need data.
+        string factorioPath = args[0];
+        ErrorCollector errorCollector = new ErrorCollector();
+        Project project;
+        try {
+            // Load YAFC project.
+            // Empty project path loads default project (with one empty page).
+            // Project is irrelevant if you just need data, but you need it to perform sheet calculations
+            // Set to not render any icons
+            project = FactorioDataSource.Parse(factorioPath, "", "", false, false, new ConsoleProgressReport(), errorCollector, "en", false);
+        }
+        catch (Exception ex) {
+            // Critical errors that make project un-loadable will be thrown as exceptions
+            Console.Error.WriteException(ex);
+            return;
+        }
+        if (errorCollector.severity != ErrorSeverity.None) {
+            // Some non-critical errors were found while loading project, for example missing recipe or analysis warnings
+            foreach (var (error, _) in errorCollector.GetArrErrors()) {
+                Console.Error.WriteLine(error);
             }
 
-            // To confirm project loading, enumerate all objects
-            foreach (var obj in Database.objects.all) {
-                Console.WriteLine(obj.locName);
-            }
         }
 
-        private class ConsoleProgressReport : IProgress<(string, string)> {
-            public void Report((string, string) value) {
-                Console.WriteLine(value.Item1 + "  -  " + value.Item2);
-            }
+        // To confirm project loading, enumerate all objects
+        foreach (var obj in Database.objects.all) {
+            Console.WriteLine(obj.locName);
+        }
+    }
+
+    private class ConsoleProgressReport : IProgress<(string, string)> {
+        public void Report((string, string) value) {
+            Console.WriteLine(value.Item1 + "  -  " + value.Item2);
         }
     }
 }

--- a/Yafc.Model.Tests/Analysis/Milestones.cs
+++ b/Yafc.Model.Tests/Analysis/Milestones.cs
@@ -2,118 +2,117 @@
 using Xunit;
 
 #pragma warning disable CA1861 // "CA1861: Avoid constant arrays as arguments." Disabled because it tried to fix constant arrays in InlineData.
-namespace Yafc.Model.Tests {
-    public class MilestonesTests {
-        private static Bits createBits(ulong value) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+namespace Yafc.Model.Tests;
+public class MilestonesTests {
+    private static Bits createBits(ulong value) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Bits bits = new Bits();
-            bitsData.SetValueDirect(__makeref(bits), new ulong[] { value });
-            bitsLength.SetValueDirect(__makeref(bits), sizeof(ulong));
-            bitsLength.SetValueDirect(__makeref(bits), bits.HighestBitSet() + 1);
+        Bits bits = new Bits();
+        bitsData.SetValueDirect(__makeref(bits), new ulong[] { value });
+        bitsLength.SetValueDirect(__makeref(bits), sizeof(ulong));
+        bitsLength.SetValueDirect(__makeref(bits), bits.HighestBitSet() + 1);
 
-            return bits;
+        return bits;
+    }
+    private static Milestones setupMilestones(ulong result, ulong mask, out FactorioObject factorioObj) {
+        factorioObj = new Technology();
+        Mapping<FactorioObject, Bits> milestoneResult = new Mapping<FactorioObject, Bits>(
+            new FactorioIdRange<FactorioObject>(0, 1, [factorioObj])) {
+            [factorioObj] = createBits(result)
+        };
+
+
+        var milestonesType = typeof(Milestones);
+        var milestonesLockedMask = milestonesType.GetProperty("lockedMask");
+        var milestoneResultField = milestonesType.GetField("milestoneResult", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Milestones milestones = new Milestones() {
+            currentMilestones = [factorioObj]
+        };
+
+        milestoneResultField.SetValue(milestones, milestoneResult);
+        milestonesLockedMask.SetValue(milestones, createBits(mask));
+
+        return milestones;
+    }
+
+    [Theory]
+    [InlineData(0, 1, false)]
+    [InlineData(1, 0, false)]
+    [InlineData(1, 1, true)]
+    [InlineData(3, 1, true)]
+    [InlineData(1, 3, true)]
+    public void IsAccessibleWithCurrentMilestones_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool expectedResult) {
+        var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
+
+        Assert.Equal(expectedResult, milestones.IsAccessibleWithCurrentMilestones(0));
+        Assert.Equal(expectedResult, milestones.IsAccessibleWithCurrentMilestones(factorioObj));
+    }
+
+    [Theory]
+    [InlineData(1, 1, true)]
+    [InlineData(3, 3, false)]
+    [InlineData(15, 15, false)] // Triggers last return
+    [InlineData(16, 16, false)] // Triggers last return
+    [InlineData(17, 17, false)] // Caught by 'bit 0 check', otherwise last return would return true
+    public void IsAccessibleAtNextMilestone_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool expectedResult) {
+        var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
+
+        Assert.Equal(expectedResult, milestones.IsAccessibleAtNextMilestone(factorioObj));
+    }
+
+    [Theory]
+    [InlineData(false, new int[] { })] // all bits set (nothing gets masked)
+    [InlineData(true, new int[] { 1 })] // all bits set, except bit 1 (for reasons not bit 0, even if the FIRST milestone has its flag set?!)
+    public void GetLockedMaskFromProject_ShouldCalculateMask(bool unlocked, int[] bitsCleared) {
+        var milestonesType = typeof(Milestones);
+        var getLockedMaskFromProject = milestonesType.GetMethod("GetLockedMaskFromProject", BindingFlags.NonPublic | BindingFlags.Instance);
+        var projectField = milestonesType.GetField("project", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var milestones = setupMilestones(0, 0, out FactorioObject factorioObj);
+
+        Project project = new Project();
+        if (unlocked) {
+            // Can't use SetFlag() as it uses the Undo system, which requires SDL
+            var flags = project.settings.itemFlags;
+            flags[factorioObj] = ProjectPerItemFlags.MilestoneUnlocked;
+            var projectType = typeof(ProjectSettings);
+            var itemFlagsField = projectType.GetField("<itemFlags>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+            itemFlagsField.SetValue(project.settings, flags);
         }
-        private static Milestones setupMilestones(ulong result, ulong mask, out FactorioObject factorioObj) {
-            factorioObj = new Technology();
-            Mapping<FactorioObject, Bits> milestoneResult = new Mapping<FactorioObject, Bits>(
-                new FactorioIdRange<FactorioObject>(0, 1, [factorioObj])) {
-                [factorioObj] = createBits(result)
-            };
 
+        projectField.SetValue(milestones, project);
 
-            var milestonesType = typeof(Milestones);
-            var milestonesLockedMask = milestonesType.GetProperty("lockedMask");
-            var milestoneResultField = milestonesType.GetField("milestoneResult", BindingFlags.NonPublic | BindingFlags.Instance);
+        _ = getLockedMaskFromProject.Invoke(milestones, null);
+        var lockedBits = milestones.lockedMask;
 
-            Milestones milestones = new Milestones() {
-                currentMilestones = [factorioObj]
-            };
-
-            milestoneResultField.SetValue(milestones, milestoneResult);
-            milestonesLockedMask.SetValue(milestones, createBits(mask));
-
-            return milestones;
-        }
-
-        [Theory]
-        [InlineData(0, 1, false)]
-        [InlineData(1, 0, false)]
-        [InlineData(1, 1, true)]
-        [InlineData(3, 1, true)]
-        [InlineData(1, 3, true)]
-        public void IsAccessibleWithCurrentMilestones_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool expectedResult) {
-            var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
-
-            Assert.Equal(expectedResult, milestones.IsAccessibleWithCurrentMilestones(0));
-            Assert.Equal(expectedResult, milestones.IsAccessibleWithCurrentMilestones(factorioObj));
-        }
-
-        [Theory]
-        [InlineData(1, 1, true)]
-        [InlineData(3, 3, false)]
-        [InlineData(15, 15, false)] // Triggers last return
-        [InlineData(16, 16, false)] // Triggers last return
-        [InlineData(17, 17, false)] // Caught by 'bit 0 check', otherwise last return would return true
-        public void IsAccessibleAtNextMilestone_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool expectedResult) {
-            var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
-
-            Assert.Equal(expectedResult, milestones.IsAccessibleAtNextMilestone(factorioObj));
-        }
-
-        [Theory]
-        [InlineData(false, new int[] { })] // all bits set (nothing gets masked)
-        [InlineData(true, new int[] { 1 })] // all bits set, except bit 1 (for reasons not bit 0, even if the FIRST milestone has its flag set?!)
-        public void GetLockedMaskFromProject_ShouldCalculateMask(bool unlocked, int[] bitsCleared) {
-            var milestonesType = typeof(Milestones);
-            var getLockedMaskFromProject = milestonesType.GetMethod("GetLockedMaskFromProject", BindingFlags.NonPublic | BindingFlags.Instance);
-            var projectField = milestonesType.GetField("project", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            var milestones = setupMilestones(0, 0, out FactorioObject factorioObj);
-
-            Project project = new Project();
-            if (unlocked) {
-                // Can't use SetFlag() as it uses the Undo system, which requires SDL
-                var flags = project.settings.itemFlags;
-                flags[factorioObj] = ProjectPerItemFlags.MilestoneUnlocked;
-                var projectType = typeof(ProjectSettings);
-                var itemFlagsField = projectType.GetField("<itemFlags>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
-                itemFlagsField.SetValue(project.settings, flags);
+        int index = 0;
+        for (int i = 0; i < lockedBits.length; i++) {
+            bool expectSet = index == bitsCleared.Length || bitsCleared[index] != i;
+            Assert.True(expectSet == lockedBits[i], "bit " + i + " is expected to be " + (expectSet ? "set" : "cleared"));
+            if (index < bitsCleared.Length && bitsCleared[index] == i) {
+                index++;
             }
-
-            projectField.SetValue(milestones, project);
-
-            _ = getLockedMaskFromProject.Invoke(milestones, null);
-            var lockedBits = milestones.lockedMask;
-
-            int index = 0;
-            for (int i = 0; i < lockedBits.length; i++) {
-                bool expectSet = index == bitsCleared.Length || bitsCleared[index] != i;
-                Assert.True(expectSet == lockedBits[i], "bit " + i + " is expected to be " + (expectSet ? "set" : "cleared"));
-                if (index < bitsCleared.Length && bitsCleared[index] == i) {
-                    index++;
-                }
-            }
         }
+    }
 
-        [Theory]
-        [InlineData(1, 0, true, false)]  // HighestBitSet() - 1, so bit 0 is never in range...
-        [InlineData(2, 0, true, true)] // mask is ignored -> true
-        [InlineData(2, 0, false, false)] // mask is active -> false
-        [InlineData(2, 2, true, true)]
-        [InlineData(2, 2, false, true)] // mask is active and overlaps -> true
-        [InlineData(4, 0, true, false)]  // HighestBitSet() too large...
-        public void GetHighest_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool all, bool expectObject) {
-            var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
+    [Theory]
+    [InlineData(1, 0, true, false)]  // HighestBitSet() - 1, so bit 0 is never in range...
+    [InlineData(2, 0, true, true)] // mask is ignored -> true
+    [InlineData(2, 0, false, false)] // mask is active -> false
+    [InlineData(2, 2, true, true)]
+    [InlineData(2, 2, false, true)] // mask is active and overlaps -> true
+    [InlineData(4, 0, true, false)]  // HighestBitSet() too large...
+    public void GetHighest_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool all, bool expectObject) {
+        var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
 
-            if (expectObject) {
-                Assert.Equal(factorioObj, milestones.GetHighest(factorioObj, all));
-            }
-            else {
-                Assert.Null(milestones.GetHighest(factorioObj, all));
-            }
+        if (expectObject) {
+            Assert.Equal(factorioObj, milestones.GetHighest(factorioObj, all));
+        }
+        else {
+            Assert.Null(milestones.GetHighest(factorioObj, all));
         }
     }
 }

--- a/Yafc.Model.Tests/Math/Bits.cs
+++ b/Yafc.Model.Tests/Math/Bits.cs
@@ -1,433 +1,431 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit;
 
-namespace Yafc.Model.Tests {
-    public class BitsTests {
-        [Fact]
-        public void New_WhenTrueIsProvided_ShouldHaveBit0Set() {
-            Bits bits = new Bits(true);
+namespace Yafc.Model.Tests;
+public class BitsTests {
+    [Fact]
+    public void New_WhenTrueIsProvided_ShouldHaveBit0Set() {
+        Bits bits = new Bits(true);
 
-            Assert.True(bits[0]);
+        Assert.True(bits[0]);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(33)]
+    [InlineData(75)]
+    public void SetBit_WhenGivenABit_ShouldReturnSetBit(int bit) {
+        Bits bits = new Bits();
+
+        bits[bit] = true;
+
+        Assert.True(bits[bit], "Set bit should be set");
+        for (int i = 0; i <= 128; i++) {
+            if (i != bit) {
+                Assert.False(bits[i], "Other bits should be clear");
+            }
         }
+    }
 
-        [Theory]
-        [InlineData(1)]
-        [InlineData(33)]
-        [InlineData(75)]
-        public void SetBit_WhenGivenABit_ShouldReturnSetBit(int bit) {
-            Bits bits = new Bits();
+    [Fact]
+    public void IsClear_WhenNotBitsAreSet_ShouldReturnTrue() {
+        Bits bits = new Bits();
+
+        Assert.True(bits.IsClear(), "IsClear() should return true, as no bits are set");
+    }
+
+    [Fact]
+    public void IsClear_WhenABitSet_ShouldReturnFalse() {
+        Bits bits = new Bits();
+
+        bits[2] = true;
+
+        Assert.False(bits.IsClear(), "IsClear() should return false, as bit 2 is set");
+    }
+
+    [Theory]
+    [InlineData(new int[] { })]
+    [InlineData(new int[] { 0 })]
+    [InlineData(new int[] { 1 })]
+    [InlineData(new int[] { 1, 10 })]
+    [InlineData(new int[] { 1, 76, 42, 3, 11, 68 })]
+    public void HighestBitSet_WithGivenListOfBits_ShouldReturnHighestBit(int[] bitsToSet) {
+        Bits bits = new Bits();
+        int highestBit = -1;
+
+        foreach (int bit in bitsToSet) {
+            if (bit > highestBit) {
+                highestBit = bit;
+            }
 
             bits[bit] = true;
-
-            Assert.True(bits[bit], "Set bit should be set");
-            for (int i = 0; i <= 128; i++) {
-                if (i != bit) {
-                    Assert.False(bits[i], "Other bits should be clear");
-                }
-            }
         }
 
-        [Fact]
-        public void IsClear_WhenNotBitsAreSet_ShouldReturnTrue() {
-            Bits bits = new Bits();
-
-            Assert.True(bits.IsClear(), "IsClear() should return true, as no bits are set");
-        }
-
-        [Fact]
-        public void IsClear_WhenABitSet_ShouldReturnFalse() {
-            Bits bits = new Bits();
-
-            bits[2] = true;
-
-            Assert.False(bits.IsClear(), "IsClear() should return false, as bit 2 is set");
-        }
-
-        [Theory]
-        [InlineData(new int[] { })]
-        [InlineData(new int[] { 0 })]
-        [InlineData(new int[] { 1 })]
-        [InlineData(new int[] { 1, 10 })]
-        [InlineData(new int[] { 1, 76, 42, 3, 11, 68 })]
-        public void HighestBitSet_WithGivenListOfBits_ShouldReturnHighestBit(int[] bitsToSet) {
-            Bits bits = new Bits();
-            int highestBit = -1;
-
-            foreach (int bit in bitsToSet) {
-                if (bit > highestBit) {
-                    highestBit = bit;
-                }
-
-                bits[bit] = true;
-            }
-
-            Assert.Equal(highestBit, bits.HighestBitSet());
-        }
-
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(1, 1)]
-        [InlineData(24, 42)]
-        public void AndOperator_WithGivenInputBits_ShouldReturnANDedBits(ulong aValue, ulong bValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { bValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
-            bitsLength.SetValueDirect(__makeref(b), 8);
-
-            var result = a & b;
-
-            ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
-
-            Assert.Equal(aValue & bValue, resultValue);
-        }
-
-        [Fact]
-        public void AndOperator_WithOneLargeValue_ReturnCorrectBits() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 4 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 128);
-
-            var result = a & b;
-
-            ulong[] resultValue = (ulong[])bitsData.GetValue(result);
-
-            Assert.Equal((ulong)4 & 4, resultValue[0]);
-            Assert.Equal(0ul, resultValue[1]);
-        }
-
-        [Fact]
-        public void AndOperator_WithLargeValues_ReturnCorrectBits() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 1 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 128);
-
-            var result = a & b;
-
-            ulong[] resultValue = (ulong[])bitsData.GetValue(result);
-
-            Assert.Equal((ulong)4 & 4, resultValue[0]);
-            Assert.Equal((ulong)3 & 1, resultValue[1]);
-        }
-
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(1, 1)]
-        [InlineData(24, 42)]
-        public void OrOperator_WithGivenInputBits_ShouldReturnORedBits(ulong aValue, ulong bValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { bValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
-            bitsLength.SetValueDirect(__makeref(b), 8);
-
-            var result = a | b;
-
-            ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
-
-            Assert.Equal(aValue | bValue, resultValue);
-        }
-
-        [Fact]
-        public void OrOperator_WithOneLargeValue_ReturnCorrectBits() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 4 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 128);
-
-            var result = a | b;
+        Assert.Equal(highestBit, bits.HighestBitSet());
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(24, 42)]
+    public void AndOperator_WithGivenInputBits_ShouldReturnANDedBits(ulong aValue, ulong bValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { bValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
+        bitsLength.SetValueDirect(__makeref(b), 8);
+
+        var result = a & b;
+
+        ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
+
+        Assert.Equal(aValue & bValue, resultValue);
+    }
+
+    [Fact]
+    public void AndOperator_WithOneLargeValue_ReturnCorrectBits() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 4 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 128);
+
+        var result = a & b;
+
+        ulong[] resultValue = (ulong[])bitsData.GetValue(result);
+
+        Assert.Equal((ulong)4 & 4, resultValue[0]);
+        Assert.Equal(0ul, resultValue[1]);
+    }
+
+    [Fact]
+    public void AndOperator_WithLargeValues_ReturnCorrectBits() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 1 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 128);
+
+        var result = a & b;
+
+        ulong[] resultValue = (ulong[])bitsData.GetValue(result);
+
+        Assert.Equal((ulong)4 & 4, resultValue[0]);
+        Assert.Equal((ulong)3 & 1, resultValue[1]);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(24, 42)]
+    public void OrOperator_WithGivenInputBits_ShouldReturnORedBits(ulong aValue, ulong bValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { bValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
+        bitsLength.SetValueDirect(__makeref(b), 8);
+
+        var result = a | b;
+
+        ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
+
+        Assert.Equal(aValue | bValue, resultValue);
+    }
+
+    [Fact]
+    public void OrOperator_WithOneLargeValue_ReturnCorrectBits() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 4 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 128);
 
-            ulong[] resultValue = (ulong[])bitsData.GetValue(result);
+        var result = a | b;
 
-            Assert.Equal((ulong)4 | 4, resultValue[0]);
-            Assert.Equal(3ul, resultValue[1]);
-        }
+        ulong[] resultValue = (ulong[])bitsData.GetValue(result);
 
-        [Fact]
-        public void OrOperator_WithLargeValues_ReturnCorrectBits() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.Equal((ulong)4 | 4, resultValue[0]);
+        Assert.Equal(3ul, resultValue[1]);
+    }
 
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 1 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 128);
-
-            var result = a | b;
+    [Fact]
+    public void OrOperator_WithLargeValues_ReturnCorrectBits() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            ulong[] resultValue = (ulong[])bitsData.GetValue(result);
-
-            Assert.Equal((ulong)4 | 4, resultValue[0]);
-            Assert.Equal((ulong)3 | 1, resultValue[1]);
-        }
-
-        [Theory]
-        [InlineData(0, 0 << 1)]
-        [InlineData(1, 1 << 1)]
-        [InlineData(24, 24 << 1)]
-        public void ShiftLeftOperator_WithGivenInputBits_ShouldReturnShiftedBits(ulong aValue, ulong expectedValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
-
-            var result = a << 1;
-
-            ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
-
-            Assert.Equal(expectedValue, resultValue);
-        }
-
-        [Theory]
-        [InlineData(1, 1)] // only subtracting by 1 is supported
-        [InlineData(42, 1)]
-        public void SubtractOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
-
-            var result = a - bValue;
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 1 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 128);
 
-            ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
-
-            Assert.Equal(aValue - bValue, resultValue);
-        }
+        var result = a | b;
 
-        [Theory]
-        [InlineData(1, 1)]
-        [InlineData(2, 1)]
-        public void EqualOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        ulong[] resultValue = (ulong[])bitsData.GetValue(result);
 
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
+        Assert.Equal((ulong)4 | 4, resultValue[0]);
+        Assert.Equal((ulong)3 | 1, resultValue[1]);
+    }
 
-            bool result = a == bValue;
+    [Theory]
+    [InlineData(0, 0 << 1)]
+    [InlineData(1, 1 << 1)]
+    [InlineData(24, 24 << 1)]
+    public void ShiftLeftOperator_WithGivenInputBits_ShouldReturnShiftedBits(ulong aValue, ulong expectedValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Assert.Equal(aValue == bValue, result);
-        }
-
-        [Fact]
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
 
-        public void EqualOperator_WithLargeValues_ShouldReturnCorrectResult() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var result = a << 1;
 
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
+        ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
 
-            bool result = a == 4;
+        Assert.Equal(expectedValue, resultValue);
+    }
 
-            // First data element matches, but next one is not zero
-            Assert.False(result);
-
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 0 });
-
-            bool result2 = a == 4;
-
-            // First data element matches and rest is cleared (zero)
-            Assert.True(result2);
-        }
-
-        [Fact]
-        public void EqualOperator_WithSameValueDifferentLengths_ShouldReturnCorrectResult() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+    [Theory]
+    [InlineData(1, 1)] // only subtracting by 1 is supported
+    [InlineData(42, 1)]
+    public void SubtractOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 3 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 126); // drop some zeros
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
 
-            Assert.True(a == b);
-        }
+        var result = a - bValue;
 
-        [Fact]
-        public void EqualOperator_WithDefault_ShouldReturnTrue() {
-            Bits a = default;
-            bool result = a == 0;
+        ulong resultValue = ((ulong[])bitsData.GetValue(result))[0];
 
-            Assert.True(result);
-        }
+        Assert.Equal(aValue - bValue, resultValue);
+    }
 
-        [Theory]
-        [InlineData(1, 1)]
-        [InlineData(2, 1)]
-        public void UnequalOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 1)]
+    public void EqualOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
 
-            bool result = a != bValue;
+        bool result = a == bValue;
 
-            Assert.Equal(aValue != bValue, result);
-        }
+        Assert.Equal(aValue == bValue, result);
+    }
 
-        [Fact]
-        public void UnequalOperator_WithLargeValues_ShouldReturnCorrectResult() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+    [Fact]
 
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
+    public void EqualOperator_WithLargeValues_ShouldReturnCorrectResult() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            bool result = a != 4;
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
 
-            // First data element matches, but next one is not zero so unequal
-            Assert.True(result);
+        bool result = a == 4;
 
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 0 });
+        // First data element matches, but next one is not zero
+        Assert.False(result);
 
-            bool result2 = a != 4;
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 0 });
 
-            Assert.False(result2);
-        }
+        bool result2 = a == 4;
 
-        [Fact]
-        public void UnequalOperator_WithSameValueDifferentLengths_ShouldReturnCorrectResult() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        // First data element matches and rest is cleared (zero)
+        Assert.True(result2);
+    }
 
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 3 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 126); // drop some zeros
+    [Fact]
+    public void EqualOperator_WithSameValueDifferentLengths_ShouldReturnCorrectResult() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            // Number of bits does not matter, so a == b
-            Assert.False(a != b);
-        }
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 3 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 126); // drop some zeros
 
+        Assert.True(a == b);
+    }
 
-        [Fact]
-        public void UnequalOperator_WithDefault_ShouldReturnFalse() {
-            Bits a = default;
-            bool result = a != 0;
+    [Fact]
+    public void EqualOperator_WithDefault_ShouldReturnTrue() {
+        Bits a = default;
+        bool result = a == 0;
 
-            Assert.False(result);
-        }
-        [Fact]
-        public void SubtractOperator_WithLongInputBits_ShouldReturnCorrectResult() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.True(result);
+    }
 
-            Bits a = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 0, 3 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 1)]
+    public void UnequalOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            var result = a - 1;
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
 
+        bool result = a != bValue;
 
-            ulong[] resultValue = (ulong[])bitsData.GetValue(result);
+        Assert.Equal(aValue != bValue, result);
+    }
 
-            Assert.Equal(~0ul, resultValue[0]);
-            Assert.Equal(2ul, resultValue[1]);
-        }
+    [Fact]
+    public void UnequalOperator_WithLargeValues_ShouldReturnCorrectResult() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
 
-        [Theory]
-        [InlineData(1, 1)]
-        [InlineData(2, 1)]
-        public void LesserThanOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        bool result = a != 4;
 
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { bValue });
-            bitsLength.SetValueDirect(__makeref(a), 8);
-            bitsLength.SetValueDirect(__makeref(b), 8);
+        // First data element matches, but next one is not zero so unequal
+        Assert.True(result);
 
-            bool result = a < b;
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 0 });
 
-            Assert.Equal(aValue < bValue, result);
-        }
+        bool result2 = a != 4;
 
-        [Fact]
+        Assert.False(result2);
+    }
 
-        public void LesserThanOperator_WithLargeValues_ShouldReturnCorrectResult() {
-            var bitsType = typeof(Bits);
-            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+    [Fact]
+    public void UnequalOperator_WithSameValueDifferentLengths_ShouldReturnCorrectResult() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Bits a = new Bits();
-            Bits b = new Bits();
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
-            bitsData.SetValueDirect(__makeref(b), new ulong[] { 3, 3 });
-            bitsLength.SetValueDirect(__makeref(a), 128);
-            bitsLength.SetValueDirect(__makeref(b), 128);
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 4, 3 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 126); // drop some zeros
 
-            bool result = a < b;
+        // Number of bits does not matter, so a == b
+        Assert.False(a != b);
+    }
 
-            // Second data element matches, but first one is not lesser
-            Assert.False(result);
 
-            bitsData.SetValueDirect(__makeref(a), new ulong[] { 2, 3 });
+    [Fact]
+    public void UnequalOperator_WithDefault_ShouldReturnFalse() {
+        Bits a = default;
+        bool result = a != 0;
 
-            bool result2 = a < b;
+        Assert.False(result);
+    }
+    [Fact]
+    public void SubtractOperator_WithLongInputBits_ShouldReturnCorrectResult() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            // Second data element matches, but first one is lesser
-            Assert.True(result2);
-        }
+        Bits a = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 0, 3 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+
+        var result = a - 1;
+
+
+        ulong[] resultValue = (ulong[])bitsData.GetValue(result);
+
+        Assert.Equal(~0ul, resultValue[0]);
+        Assert.Equal(2ul, resultValue[1]);
+    }
+
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 1)]
+    public void LesserThanOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue) {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { aValue });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { bValue });
+        bitsLength.SetValueDirect(__makeref(a), 8);
+        bitsLength.SetValueDirect(__makeref(b), 8);
+
+        bool result = a < b;
+
+        Assert.Equal(aValue < bValue, result);
+    }
+
+    [Fact]
+
+    public void LesserThanOperator_WithLargeValues_ShouldReturnCorrectResult() {
+        var bitsType = typeof(Bits);
+        var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Bits a = new Bits();
+        Bits b = new Bits();
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 4, 3 });
+        bitsData.SetValueDirect(__makeref(b), new ulong[] { 3, 3 });
+        bitsLength.SetValueDirect(__makeref(a), 128);
+        bitsLength.SetValueDirect(__makeref(b), 128);
+
+        bool result = a < b;
+
+        // Second data element matches, but first one is not lesser
+        Assert.False(result);
+
+        bitsData.SetValueDirect(__makeref(a), new ulong[] { 2, 3 });
+
+        bool result2 = a < b;
+
+        // Second data element matches, but first one is lesser
+        Assert.True(result2);
     }
 }

--- a/Yafc.Model.Tests/Model/RecipeParametersTests.cs
+++ b/Yafc.Model.Tests/Model/RecipeParametersTests.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Google.OrTools.ConstraintSolver;
 using Xunit;
 
 namespace Yafc.Model.Tests.Model;

--- a/Yafc.Model/Analysis/Analysis.cs
+++ b/Yafc.Model/Analysis/Analysis.cs
@@ -2,92 +2,91 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Yafc.Model {
-    public abstract class Analysis {
-        internal readonly HashSet<FactorioObject> excludedObjects = [];
+namespace Yafc.Model;
+public abstract class Analysis {
+    internal readonly HashSet<FactorioObject> excludedObjects = [];
 
-        public abstract void Compute(Project project, ErrorCollector warnings);
+    public abstract void Compute(Project project, ErrorCollector warnings);
 
-        private static readonly List<Analysis> analyses = [];
-        public static void RegisterAnalysis(Analysis analysis, params Analysis[] dependencies) // TODO don't ignore dependencies
-        {
-            analyses.Add(analysis);
+    private static readonly List<Analysis> analyses = [];
+    public static void RegisterAnalysis(Analysis analysis, params Analysis[] dependencies) // TODO don't ignore dependencies
+    {
+        analyses.Add(analysis);
+    }
+
+    public static void ProcessAnalyses(IProgress<(string, string)> progress, Project project, ErrorCollector errors) {
+        foreach (var analysis in analyses) {
+            progress.Report(("Running analysis algorithms", analysis.GetType().Name));
+            analysis.Compute(project, errors);
         }
+    }
 
-        public static void ProcessAnalyses(IProgress<(string, string)> progress, Project project, ErrorCollector errors) {
-            foreach (var analysis in analyses) {
-                progress.Report(("Running analysis algorithms", analysis.GetType().Name));
-                analysis.Compute(project, errors);
-            }
-        }
+    public abstract string description { get; }
 
-        public abstract string description { get; }
-
-        public static void Do<T>(Project project) where T : Analysis {
-            foreach (var analysis in analyses) {
-                if (analysis is T t) {
-                    t.Compute(project, new ErrorCollector());
-                }
-            }
-        }
-
-        /// <summary>
-        /// Call to exclude the specified <see cref="FactorioObject"/> from one of the analyses.
-        /// </summary>
-        /// <typeparam name="T">The analysis that should ignore <paramref name="obj"/>.</typeparam>
-        /// <param name="obj">The object to be excluded from analysis.</param>
-        public static void ExcludeFromAnalysis<T>(FactorioObject obj) where T : Analysis {
-            foreach (T analysis in analyses.OfType<T>()) {
-                analysis.excludedObjects.Add(obj);
+    public static void Do<T>(Project project) where T : Analysis {
+        foreach (var analysis in analyses) {
+            if (analysis is T t) {
+                t.Compute(project, new ErrorCollector());
             }
         }
     }
 
-    public static class AnalysisExtensions {
-        public static bool IsAccessible(this FactorioObject obj) {
-            return Milestones.Instance.GetMilestoneResult(obj) != 0;
+    /// <summary>
+    /// Call to exclude the specified <see cref="FactorioObject"/> from one of the analyses.
+    /// </summary>
+    /// <typeparam name="T">The analysis that should ignore <paramref name="obj"/>.</typeparam>
+    /// <param name="obj">The object to be excluded from analysis.</param>
+    public static void ExcludeFromAnalysis<T>(FactorioObject obj) where T : Analysis {
+        foreach (T analysis in analyses.OfType<T>()) {
+            analysis.excludedObjects.Add(obj);
         }
-
-        public static bool IsAccessibleWithCurrentMilestones(this FactorioObject obj) {
-            return Milestones.Instance.IsAccessibleWithCurrentMilestones(obj);
-        }
-
-        public static bool IsAutomatable(this FactorioObject obj) {
-            return AutomationAnalysis.Instance.automatable[obj] != AutomationStatus.NotAutomatable;
-        }
-
-        public static bool IsAutomatableWithCurrentMilestones(this FactorioObject obj) {
-            return AutomationAnalysis.Instance.automatable[obj] == AutomationStatus.AutomatableNow;
-        }
-
-        public static float Cost(this FactorioObject goods, bool atCurrentMilestones = false) {
-            return CostAnalysis.Get(atCurrentMilestones).cost[goods];
-        }
-
-        public static float ApproximateFlow(this FactorioObject recipe, bool atCurrentMilestones = false) {
-            return CostAnalysis.Get(atCurrentMilestones).flow[recipe];
-        }
-
-        public static float ProductCost(this Recipe recipe, bool atCurrentMilestones = false) {
-            return CostAnalysis.Get(atCurrentMilestones).recipeProductCost[recipe];
-        }
-
-        public static float RecipeWaste(this Recipe recipe, bool atCurrentMilestones = false) {
-            return CostAnalysis.Get(atCurrentMilestones).recipeWastePercentage[recipe];
-        }
-
-        public static float RecipeBaseCost(this Recipe recipe, bool atCurrentMilestones = false) {
-            return CostAnalysis.Get(atCurrentMilestones).recipeCost[recipe];
-        }
-
-        /// <summary>
-        /// Filters a list of <see cref="FactorioObject"/>s down to those that were not excluded by the specified <see cref="Analysis"/>
-        /// </summary>
-        /// <typeparam name="T">The type of objects in the list.</typeparam>
-        /// <param name="values">The values that should be filtered.</param>
-        /// <param name="analysis">The <see cref="Analysis"/> that is requesting the filtering. In most circumstances, pass <see langword="this"/>.</param>
-        /// <returns></returns>
-        public static IEnumerable<T> ExceptExcluded<T>(this IEnumerable<T> values, Analysis analysis) where T : FactorioObject =>
-            values.Except(analysis.excludedObjects.OfType<T>());
     }
+}
+
+public static class AnalysisExtensions {
+    public static bool IsAccessible(this FactorioObject obj) {
+        return Milestones.Instance.GetMilestoneResult(obj) != 0;
+    }
+
+    public static bool IsAccessibleWithCurrentMilestones(this FactorioObject obj) {
+        return Milestones.Instance.IsAccessibleWithCurrentMilestones(obj);
+    }
+
+    public static bool IsAutomatable(this FactorioObject obj) {
+        return AutomationAnalysis.Instance.automatable[obj] != AutomationStatus.NotAutomatable;
+    }
+
+    public static bool IsAutomatableWithCurrentMilestones(this FactorioObject obj) {
+        return AutomationAnalysis.Instance.automatable[obj] == AutomationStatus.AutomatableNow;
+    }
+
+    public static float Cost(this FactorioObject goods, bool atCurrentMilestones = false) {
+        return CostAnalysis.Get(atCurrentMilestones).cost[goods];
+    }
+
+    public static float ApproximateFlow(this FactorioObject recipe, bool atCurrentMilestones = false) {
+        return CostAnalysis.Get(atCurrentMilestones).flow[recipe];
+    }
+
+    public static float ProductCost(this Recipe recipe, bool atCurrentMilestones = false) {
+        return CostAnalysis.Get(atCurrentMilestones).recipeProductCost[recipe];
+    }
+
+    public static float RecipeWaste(this Recipe recipe, bool atCurrentMilestones = false) {
+        return CostAnalysis.Get(atCurrentMilestones).recipeWastePercentage[recipe];
+    }
+
+    public static float RecipeBaseCost(this Recipe recipe, bool atCurrentMilestones = false) {
+        return CostAnalysis.Get(atCurrentMilestones).recipeCost[recipe];
+    }
+
+    /// <summary>
+    /// Filters a list of <see cref="FactorioObject"/>s down to those that were not excluded by the specified <see cref="Analysis"/>
+    /// </summary>
+    /// <typeparam name="T">The type of objects in the list.</typeparam>
+    /// <param name="values">The values that should be filtered.</param>
+    /// <param name="analysis">The <see cref="Analysis"/> that is requesting the filtering. In most circumstances, pass <see langword="this"/>.</param>
+    /// <returns></returns>
+    public static IEnumerable<T> ExceptExcluded<T>(this IEnumerable<T> values, Analysis analysis) where T : FactorioObject =>
+        values.Except(analysis.excludedObjects.OfType<T>());
 }

--- a/Yafc.Model/Analysis/AutomationAnalysis.cs
+++ b/Yafc.Model/Analysis/AutomationAnalysis.cs
@@ -3,124 +3,123 @@ using System.Diagnostics;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public enum AutomationStatus : sbyte {
-        NotAutomatable = -1, AutomatableLater = 2, AutomatableNow = 3,
-    }
+namespace Yafc.Model;
+public enum AutomationStatus : sbyte {
+    NotAutomatable = -1, AutomatableLater = 2, AutomatableNow = 3,
+}
 
-    public class AutomationAnalysis : Analysis {
-        private static readonly ILogger logger = Logging.GetLogger<AutomationAnalysis>();
-        public static readonly AutomationAnalysis Instance = new AutomationAnalysis();
-        public Mapping<FactorioObject, AutomationStatus> automatable;
+public class AutomationAnalysis : Analysis {
+    private static readonly ILogger logger = Logging.GetLogger<AutomationAnalysis>();
+    public static readonly AutomationAnalysis Instance = new AutomationAnalysis();
+    public Mapping<FactorioObject, AutomationStatus> automatable;
 
-        private const AutomationStatus Unknown = 0;
-        private const AutomationStatus UnknownInQueue = (AutomationStatus)1;
+    private const AutomationStatus Unknown = 0;
+    private const AutomationStatus UnknownInQueue = (AutomationStatus)1;
 
-        public override void Compute(Project project, ErrorCollector warnings) {
-            Stopwatch time = Stopwatch.StartNew();
-            var state = Database.objects.CreateMapping<AutomationStatus>();
-            state[Database.voidEnergy] = AutomationStatus.AutomatableNow;
-            Queue<FactorioId> processingQueue = new Queue<FactorioId>(Database.objects.count);
-            int unknowns = 0;
-            foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
-                bool hasAutomatableCrafter = false;
-                foreach (var crafter in recipe.crafters) {
-                    if (crafter != Database.character && crafter.IsAccessible()) {
-                        hasAutomatableCrafter = true;
-                    }
-                }
-                if (!hasAutomatableCrafter) {
-                    state[recipe] = AutomationStatus.NotAutomatable;
+    public override void Compute(Project project, ErrorCollector warnings) {
+        Stopwatch time = Stopwatch.StartNew();
+        var state = Database.objects.CreateMapping<AutomationStatus>();
+        state[Database.voidEnergy] = AutomationStatus.AutomatableNow;
+        Queue<FactorioId> processingQueue = new Queue<FactorioId>(Database.objects.count);
+        int unknowns = 0;
+        foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
+            bool hasAutomatableCrafter = false;
+            foreach (var crafter in recipe.crafters) {
+                if (crafter != Database.character && crafter.IsAccessible()) {
+                    hasAutomatableCrafter = true;
                 }
             }
-
-            foreach (FactorioObject obj in Database.objects.all.ExceptExcluded(this)) {
-                if (!obj.IsAccessible()) {
-                    state[obj] = AutomationStatus.NotAutomatable;
-                }
-                else if (state[obj] == Unknown) {
-                    unknowns++;
-                    state[obj] = UnknownInQueue;
-                    processingQueue.Enqueue(obj.id);
-                }
+            if (!hasAutomatableCrafter) {
+                state[recipe] = AutomationStatus.NotAutomatable;
             }
-
-            while (processingQueue.Count > 0) {
-                var index = processingQueue.Dequeue();
-                var dependencies = Dependencies.dependencyList[index];
-                var automationState = Milestones.Instance.IsAccessibleWithCurrentMilestones(index) ? AutomationStatus.AutomatableNow : AutomationStatus.AutomatableLater;
-                foreach (var depGroup in dependencies) {
-                    if (!depGroup.flags.HasFlags(DependencyList.Flags.OneTimeInvestment)) {
-                        if (depGroup.flags.HasFlags(DependencyList.Flags.RequireEverything)) {
-                            foreach (var element in depGroup.elements) {
-                                if (state[element] < automationState) {
-                                    automationState = state[element];
-                                }
-                            }
-                        }
-                        else {
-                            var localHighest = AutomationStatus.NotAutomatable;
-                            foreach (var element in depGroup.elements) {
-                                if (state[element] > localHighest) {
-                                    localHighest = state[element];
-                                }
-                            }
-
-                            if (localHighest < automationState) {
-                                automationState = localHighest;
-                            }
-                        }
-                    }
-                    else if (automationState == AutomationStatus.AutomatableNow && depGroup.flags == DependencyList.Flags.CraftingEntity) {
-                        // If only character is accessible at current milestones as a crafting entity, don't count the object as currently automatable
-                        bool hasMachine = false;
-                        foreach (var element in depGroup.elements) {
-                            if (element != Database.character?.id && Milestones.Instance.IsAccessibleWithCurrentMilestones(element)) {
-                                hasMachine = true;
-                                break;
-                            }
-                        }
-
-                        if (!hasMachine) {
-                            automationState = AutomationStatus.AutomatableLater;
-                        }
-                    }
-                }
-
-                if (automationState == UnknownInQueue) {
-                    automationState = Unknown;
-                }
-
-                state[index] = automationState;
-                if (automationState != Unknown) {
-                    unknowns--;
-                    foreach (var revDep in Dependencies.reverseDependencies[index]) {
-                        var oldState = state[revDep];
-                        if (oldState == Unknown || (oldState == AutomationStatus.AutomatableLater && automationState == AutomationStatus.AutomatableNow)) {
-                            if (oldState == AutomationStatus.AutomatableLater) {
-                                unknowns++;
-                            }
-
-                            processingQueue.Enqueue(revDep);
-                            state[revDep] = UnknownInQueue;
-                        }
-                    }
-                }
-            }
-            state[Database.voidEnergy] = AutomationStatus.NotAutomatable;
-
-            logger.Information("Automation analysis (first pass) finished in {ElapsedTime}ms. Unknowns left: {unknownsRemaining}", time.ElapsedMilliseconds, unknowns);
-            if (unknowns > 0) {
-                // TODO run graph analysis if there are any unknowns left... Right now assume they are not automatable
-                foreach (var (k, v) in state) {
-                    if (v == Unknown) {
-                        state[k] = AutomationStatus.NotAutomatable;
-                    }
-                }
-            }
-            automatable = state;
         }
 
-        public override string description => "Automation analysis tries to find what objects can be automated. Object cannot be automated if it requires looting an entity or manual crafting.";
+        foreach (FactorioObject obj in Database.objects.all.ExceptExcluded(this)) {
+            if (!obj.IsAccessible()) {
+                state[obj] = AutomationStatus.NotAutomatable;
+            }
+            else if (state[obj] == Unknown) {
+                unknowns++;
+                state[obj] = UnknownInQueue;
+                processingQueue.Enqueue(obj.id);
+            }
+        }
+
+        while (processingQueue.Count > 0) {
+            var index = processingQueue.Dequeue();
+            var dependencies = Dependencies.dependencyList[index];
+            var automationState = Milestones.Instance.IsAccessibleWithCurrentMilestones(index) ? AutomationStatus.AutomatableNow : AutomationStatus.AutomatableLater;
+            foreach (var depGroup in dependencies) {
+                if (!depGroup.flags.HasFlags(DependencyList.Flags.OneTimeInvestment)) {
+                    if (depGroup.flags.HasFlags(DependencyList.Flags.RequireEverything)) {
+                        foreach (var element in depGroup.elements) {
+                            if (state[element] < automationState) {
+                                automationState = state[element];
+                            }
+                        }
+                    }
+                    else {
+                        var localHighest = AutomationStatus.NotAutomatable;
+                        foreach (var element in depGroup.elements) {
+                            if (state[element] > localHighest) {
+                                localHighest = state[element];
+                            }
+                        }
+
+                        if (localHighest < automationState) {
+                            automationState = localHighest;
+                        }
+                    }
+                }
+                else if (automationState == AutomationStatus.AutomatableNow && depGroup.flags == DependencyList.Flags.CraftingEntity) {
+                    // If only character is accessible at current milestones as a crafting entity, don't count the object as currently automatable
+                    bool hasMachine = false;
+                    foreach (var element in depGroup.elements) {
+                        if (element != Database.character?.id && Milestones.Instance.IsAccessibleWithCurrentMilestones(element)) {
+                            hasMachine = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasMachine) {
+                        automationState = AutomationStatus.AutomatableLater;
+                    }
+                }
+            }
+
+            if (automationState == UnknownInQueue) {
+                automationState = Unknown;
+            }
+
+            state[index] = automationState;
+            if (automationState != Unknown) {
+                unknowns--;
+                foreach (var revDep in Dependencies.reverseDependencies[index]) {
+                    var oldState = state[revDep];
+                    if (oldState == Unknown || (oldState == AutomationStatus.AutomatableLater && automationState == AutomationStatus.AutomatableNow)) {
+                        if (oldState == AutomationStatus.AutomatableLater) {
+                            unknowns++;
+                        }
+
+                        processingQueue.Enqueue(revDep);
+                        state[revDep] = UnknownInQueue;
+                    }
+                }
+            }
+        }
+        state[Database.voidEnergy] = AutomationStatus.NotAutomatable;
+
+        logger.Information("Automation analysis (first pass) finished in {ElapsedTime}ms. Unknowns left: {unknownsRemaining}", time.ElapsedMilliseconds, unknowns);
+        if (unknowns > 0) {
+            // TODO run graph analysis if there are any unknowns left... Right now assume they are not automatable
+            foreach (var (k, v) in state) {
+                if (v == Unknown) {
+                    state[k] = AutomationStatus.NotAutomatable;
+                }
+            }
+        }
+        automatable = state;
     }
+
+    public override string description => "Automation analysis tries to find what objects can be automated. Object cannot be automated if it requires looting an entity or manual crafting.";
 }

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -7,396 +7,395 @@ using Google.OrTools.LinearSolver;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
-        private readonly ILogger logger = Logging.GetLogger<CostAnalysis>();
+namespace Yafc.Model;
+public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
+    private readonly ILogger logger = Logging.GetLogger<CostAnalysis>();
 
-        public static readonly CostAnalysis Instance = new CostAnalysis(false);
-        public static readonly CostAnalysis InstanceAtMilestones = new CostAnalysis(true);
-        public static CostAnalysis Get(bool atCurrentMilestones) {
-            return atCurrentMilestones ? InstanceAtMilestones : Instance;
-        }
+    public static readonly CostAnalysis Instance = new CostAnalysis(false);
+    public static readonly CostAnalysis InstanceAtMilestones = new CostAnalysis(true);
+    public static CostAnalysis Get(bool atCurrentMilestones) {
+        return atCurrentMilestones ? InstanceAtMilestones : Instance;
+    }
 
-        private const float CostPerSecond = 0.1f;
-        private const float CostPerMj = 0.1f;
-        private const float CostPerIngredientPerSize = 0.1f;
-        private const float CostPerProductPerSize = 0.2f;
-        private const float CostPerItem = 0.02f;
-        private const float CostPerFluid = 0.0005f;
-        private const float CostPerPollution = 0.01f;
-        private const float CostLowerLimit = -10f;
-        private const float CostLimitWhenGeneratesOnMap = 1e4f;
-        private const float MiningPenalty = 1f; // Penalty for any mining
-        private const float MiningMaxDensityForPenalty = 2000; // Mining things with less density than this gets extra penalty
-        private const float MiningMaxExtraPenaltyForRarity = 10f;
+    private const float CostPerSecond = 0.1f;
+    private const float CostPerMj = 0.1f;
+    private const float CostPerIngredientPerSize = 0.1f;
+    private const float CostPerProductPerSize = 0.2f;
+    private const float CostPerItem = 0.02f;
+    private const float CostPerFluid = 0.0005f;
+    private const float CostPerPollution = 0.01f;
+    private const float CostLowerLimit = -10f;
+    private const float CostLimitWhenGeneratesOnMap = 1e4f;
+    private const float MiningPenalty = 1f; // Penalty for any mining
+    private const float MiningMaxDensityForPenalty = 2000; // Mining things with less density than this gets extra penalty
+    private const float MiningMaxExtraPenaltyForRarity = 10f;
 
-        public Mapping<FactorioObject, float> cost;
-        public Mapping<Recipe, float> recipeCost;
-        public Mapping<RecipeOrTechnology, float> recipeProductCost;
-        public Mapping<FactorioObject, float> flow;
-        public Mapping<Recipe, float> recipeWastePercentage;
-        public Goods[]? importantItems;
-        private readonly bool onlyCurrentMilestones = onlyCurrentMilestones;
-        private string? itemAmountPrefix;
+    public Mapping<FactorioObject, float> cost;
+    public Mapping<Recipe, float> recipeCost;
+    public Mapping<RecipeOrTechnology, float> recipeProductCost;
+    public Mapping<FactorioObject, float> flow;
+    public Mapping<Recipe, float> recipeWastePercentage;
+    public Goods[]? importantItems;
+    private readonly bool onlyCurrentMilestones = onlyCurrentMilestones;
+    private string? itemAmountPrefix;
 
-        private bool ShouldInclude(FactorioObject obj) {
-            return onlyCurrentMilestones ? obj.IsAutomatableWithCurrentMilestones() : obj.IsAutomatable();
-        }
+    private bool ShouldInclude(FactorioObject obj) {
+        return onlyCurrentMilestones ? obj.IsAutomatableWithCurrentMilestones() : obj.IsAutomatable();
+    }
 
-        public override void Compute(Project project, ErrorCollector warnings) {
-            var workspaceSolver = DataUtils.CreateSolver();
-            var objective = workspaceSolver.Objective();
-            objective.SetMaximization();
-            Stopwatch time = Stopwatch.StartNew();
+    public override void Compute(Project project, ErrorCollector warnings) {
+        var workspaceSolver = DataUtils.CreateSolver();
+        var objective = workspaceSolver.Objective();
+        objective.SetMaximization();
+        Stopwatch time = Stopwatch.StartNew();
 
-            var variables = Database.goods.CreateMapping<Variable>();
-            var constraints = Database.recipes.CreateMapping<Constraint>();
+        var variables = Database.goods.CreateMapping<Variable>();
+        var constraints = Database.recipes.CreateMapping<Constraint>();
 
-            Dictionary<Goods, float> sciencePackUsage = [];
-            if (!onlyCurrentMilestones && project.preferences.targetTechnology != null) {
-                itemAmountPrefix = "Estimated amount for " + project.preferences.targetTechnology.locName + ": ";
-                foreach (var spUsage in TechnologyScienceAnalysis.Instance.allSciencePacks[project.preferences.targetTechnology]) {
-                    sciencePackUsage[spUsage.goods] = spUsage.amount;
-                }
+        Dictionary<Goods, float> sciencePackUsage = [];
+        if (!onlyCurrentMilestones && project.preferences.targetTechnology != null) {
+            itemAmountPrefix = "Estimated amount for " + project.preferences.targetTechnology.locName + ": ";
+            foreach (var spUsage in TechnologyScienceAnalysis.Instance.allSciencePacks[project.preferences.targetTechnology]) {
+                sciencePackUsage[spUsage.goods] = spUsage.amount;
             }
-            else {
-                itemAmountPrefix = "Estimated amount for all researches: ";
-                foreach (Technology technology in Database.technologies.all.ExceptExcluded(this)) {
-                    if (technology.IsAccessible() && technology.ingredients is not null) {
-                        foreach (var ingredient in technology.ingredients) {
-                            if (ingredient.goods.IsAutomatable()) {
-                                if (onlyCurrentMilestones && !Milestones.Instance.IsAccessibleAtNextMilestone(ingredient.goods)) {
-                                    continue;
-                                }
-
-                                _ = sciencePackUsage.TryGetValue(ingredient.goods, out float prev);
-                                sciencePackUsage[ingredient.goods] = prev + (ingredient.amount * technology.count);
+        }
+        else {
+            itemAmountPrefix = "Estimated amount for all researches: ";
+            foreach (Technology technology in Database.technologies.all.ExceptExcluded(this)) {
+                if (technology.IsAccessible() && technology.ingredients is not null) {
+                    foreach (var ingredient in technology.ingredients) {
+                        if (ingredient.goods.IsAutomatable()) {
+                            if (onlyCurrentMilestones && !Milestones.Instance.IsAccessibleAtNextMilestone(ingredient.goods)) {
+                                continue;
                             }
+
+                            _ = sciencePackUsage.TryGetValue(ingredient.goods, out float prev);
+                            sciencePackUsage[ingredient.goods] = prev + (ingredient.amount * technology.count);
                         }
                     }
                 }
             }
+        }
 
 
-            foreach (Goods goods in Database.goods.all.ExceptExcluded(this)) {
-                if (!ShouldInclude(goods)) {
-                    continue;
-                }
+        foreach (Goods goods in Database.goods.all.ExceptExcluded(this)) {
+            if (!ShouldInclude(goods)) {
+                continue;
+            }
 
-                float mapGeneratedAmount = 0f;
-                foreach (var src in goods.miscSources) {
-                    if (src is Entity ent && ent.mapGenerated) {
-                        foreach (var product in ent.loot) {
-                            if (product.goods == goods) {
-                                mapGeneratedAmount += product.amount;
-                            }
+            float mapGeneratedAmount = 0f;
+            foreach (var src in goods.miscSources) {
+                if (src is Entity ent && ent.mapGenerated) {
+                    foreach (var product in ent.loot) {
+                        if (product.goods == goods) {
+                            mapGeneratedAmount += product.amount;
                         }
                     }
                 }
-                var variable = workspaceSolver.MakeVar(CostLowerLimit, CostLimitWhenGeneratesOnMap / mapGeneratedAmount, false, goods.name);
-                objective.SetCoefficient(variable, 1e-3); // adding small amount to each object cost, so even objects that aren't required for science will get cost calculated
-                variables[goods] = variable;
+            }
+            var variable = workspaceSolver.MakeVar(CostLowerLimit, CostLimitWhenGeneratesOnMap / mapGeneratedAmount, false, goods.name);
+            objective.SetCoefficient(variable, 1e-3); // adding small amount to each object cost, so even objects that aren't required for science will get cost calculated
+            variables[goods] = variable;
+        }
+
+        foreach (var (item, count) in sciencePackUsage) {
+            objective.SetCoefficient(variables[item], count / 1000f);
+        }
+
+        var export = Database.objects.CreateMapping<float>();
+        var recipeProductionCost = Database.recipesAndTechnologies.CreateMapping<float>();
+        recipeCost = Database.recipes.CreateMapping<float>();
+        flow = Database.objects.CreateMapping<float>();
+        var lastVariable = Database.goods.CreateMapping<Variable>();
+        foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
+            if (!ShouldInclude(recipe)) {
+                continue;
             }
 
-            foreach (var (item, count) in sciencePackUsage) {
-                objective.SetCoefficient(variables[item], count / 1000f);
+            if (onlyCurrentMilestones && !recipe.IsAccessibleWithCurrentMilestones()) {
+                continue;
             }
 
-            var export = Database.objects.CreateMapping<float>();
-            var recipeProductionCost = Database.recipesAndTechnologies.CreateMapping<float>();
-            recipeCost = Database.recipes.CreateMapping<float>();
-            flow = Database.objects.CreateMapping<float>();
-            var lastVariable = Database.goods.CreateMapping<Variable>();
-            foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
-                if (!ShouldInclude(recipe)) {
-                    continue;
+            // TODO incorporate fuel selection. Now just select fuel if it only uses 1 fuel
+            Goods? singleUsedFuel = null;
+            float singleUsedFuelAmount = 0f;
+            float minEmissions = 100f;
+            int minSize = 15;
+            float minPower = 1000f;
+            foreach (var crafter in recipe.crafters) {
+                minEmissions = MathF.Min(crafter.energy.emissions, minEmissions);
+                if (crafter.energy.type == EntityEnergyType.Heat) {
+                    break;
                 }
 
-                if (onlyCurrentMilestones && !recipe.IsAccessibleWithCurrentMilestones()) {
-                    continue;
+                if (crafter.size < minSize) {
+                    minSize = crafter.size;
                 }
 
-                // TODO incorporate fuel selection. Now just select fuel if it only uses 1 fuel
-                Goods? singleUsedFuel = null;
-                float singleUsedFuelAmount = 0f;
-                float minEmissions = 100f;
-                int minSize = 15;
-                float minPower = 1000f;
-                foreach (var crafter in recipe.crafters) {
-                    minEmissions = MathF.Min(crafter.energy.emissions, minEmissions);
-                    if (crafter.energy.type == EntityEnergyType.Heat) {
+                float power = crafter.energy.type == EntityEnergyType.Void ? 0f : recipe.time * crafter.power / (crafter.craftingSpeed * crafter.energy.effectivity);
+                if (power < minPower) {
+                    minPower = power;
+                }
+
+                foreach (var fuel in crafter.energy.fuels) {
+                    if (!ShouldInclude(fuel)) {
+                        continue;
+                    }
+
+                    if (fuel.fuelValue <= 0f) {
+                        singleUsedFuel = null;
                         break;
                     }
-
-                    if (crafter.size < minSize) {
-                        minSize = crafter.size;
-                    }
-
-                    float power = crafter.energy.type == EntityEnergyType.Void ? 0f : recipe.time * crafter.power / (crafter.craftingSpeed * crafter.energy.effectivity);
-                    if (power < minPower) {
-                        minPower = power;
-                    }
-
-                    foreach (var fuel in crafter.energy.fuels) {
-                        if (!ShouldInclude(fuel)) {
-                            continue;
-                        }
-
-                        if (fuel.fuelValue <= 0f) {
-                            singleUsedFuel = null;
-                            break;
-                        }
-                        float amount = power / fuel.fuelValue;
-                        if (singleUsedFuel == null) {
-                            singleUsedFuel = fuel;
-                            singleUsedFuelAmount = amount;
-                        }
-                        else if (singleUsedFuel == fuel) {
-                            singleUsedFuelAmount = MathF.Min(singleUsedFuelAmount, amount);
-                        }
-                        else {
-                            singleUsedFuel = null;
-                            break;
-                        }
-                    }
+                    float amount = power / fuel.fuelValue;
                     if (singleUsedFuel == null) {
+                        singleUsedFuel = fuel;
+                        singleUsedFuelAmount = amount;
+                    }
+                    else if (singleUsedFuel == fuel) {
+                        singleUsedFuelAmount = MathF.Min(singleUsedFuelAmount, amount);
+                    }
+                    else {
+                        singleUsedFuel = null;
                         break;
                     }
                 }
+                if (singleUsedFuel == null) {
+                    break;
+                }
+            }
 
-                if (minPower < 0f) {
-                    minPower = 0f;
+            if (minPower < 0f) {
+                minPower = 0f;
+            }
+
+            int size = Math.Max(minSize, (recipe.ingredients.Length + recipe.products.Length) / 2);
+            float sizeUsage = CostPerSecond * recipe.time * size;
+            float logisticsCost = (sizeUsage * (1f + (CostPerIngredientPerSize * recipe.ingredients.Length) + (CostPerProductPerSize * recipe.products.Length))) + (CostPerMj * minPower);
+
+            if (singleUsedFuel == Database.electricity || singleUsedFuel == Database.voidEnergy || singleUsedFuel == Database.heat) {
+                singleUsedFuel = null;
+            }
+
+            var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, recipe.name);
+            constraints[recipe] = constraint;
+
+            foreach (var product in recipe.products) {
+                var var = variables[product.goods];
+                float amount = product.amount;
+                constraint.SetCoefficientCheck(var, amount, ref lastVariable[product.goods]);
+                if (product.goods is Item) {
+                    logisticsCost += amount * CostPerItem;
+                }
+                else if (product.goods is Fluid) {
+                    logisticsCost += amount * CostPerFluid;
+                }
+            }
+
+            if (singleUsedFuel != null) {
+                var var = variables[singleUsedFuel];
+                constraint.SetCoefficientCheck(var, -singleUsedFuelAmount, ref lastVariable[singleUsedFuel]);
+            }
+
+            foreach (var ingredient in recipe.ingredients) {
+                var var = variables[ingredient.goods]; // TODO split cost analysis
+                constraint.SetCoefficientCheck(var, -ingredient.amount, ref lastVariable[ingredient.goods]);
+                if (ingredient.goods is Item) {
+                    logisticsCost += ingredient.amount * CostPerItem;
+                }
+                else if (ingredient.goods is Fluid) {
+                    logisticsCost += ingredient.amount * CostPerFluid;
+                }
+            }
+
+            if (recipe.sourceEntity != null && recipe.sourceEntity.mapGenerated) {
+                float totalMining = 0f;
+                foreach (var product in recipe.products) {
+                    totalMining += product.amount;
                 }
 
-                int size = Math.Max(minSize, (recipe.ingredients.Length + recipe.products.Length) / 2);
-                float sizeUsage = CostPerSecond * recipe.time * size;
-                float logisticsCost = (sizeUsage * (1f + (CostPerIngredientPerSize * recipe.ingredients.Length) + (CostPerProductPerSize * recipe.products.Length))) + (CostPerMj * minPower);
-
-                if (singleUsedFuel == Database.electricity || singleUsedFuel == Database.voidEnergy || singleUsedFuel == Database.heat) {
-                    singleUsedFuel = null;
+                float miningPenalty = MiningPenalty;
+                float totalDensity = recipe.sourceEntity.mapGenDensity / totalMining;
+                if (totalDensity < MiningMaxDensityForPenalty) {
+                    float extraPenalty = MathF.Log(MiningMaxDensityForPenalty / totalDensity);
+                    miningPenalty += Math.Min(extraPenalty, MiningMaxExtraPenaltyForRarity);
                 }
 
-                var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, recipe.name);
-                constraints[recipe] = constraint;
+                logisticsCost *= miningPenalty;
+            }
+
+            if (minEmissions >= 0f) {
+                logisticsCost += minEmissions * CostPerPollution * recipe.time * project.settings.PollutionCostModifier;
+            }
+
+            constraint.SetUb(logisticsCost);
+            export[recipe] = logisticsCost;
+            recipeCost[recipe] = logisticsCost;
+        }
+
+        // TODO this is temporary fix for strange item sources (make the cost of item not higher than the cost of its source)
+        foreach (Item item in Database.items.all.ExceptExcluded(this)) {
+            if (ShouldInclude(item)) {
+                foreach (var source in item.miscSources) {
+                    if (source is Goods g && ShouldInclude(g)) {
+                        var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, "source-" + item.locName);
+                        constraint.SetCoefficient(variables[g], -1);
+                        constraint.SetCoefficient(variables[item], 1);
+                    }
+                }
+            }
+        }
+
+        // TODO this is temporary fix for fluid temperatures (make the cost of fluid with lower temp not higher than the cost of fluid with higher temp)
+        foreach (var (name, fluids) in Database.fluidVariants) {
+            var prev = fluids[0];
+            for (int i = 1; i < fluids.Count; i++) {
+                var cur = fluids[i];
+                var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, "fluid-" + name + "-" + prev.temperature);
+                constraint.SetCoefficient(variables[prev], 1);
+                constraint.SetCoefficient(variables[cur], -1);
+                prev = cur;
+            }
+        }
+
+        var result = workspaceSolver.TrySolveWithDifferentSeeds();
+        logger.Information("Cost analysis completed in {ElapsedTime}ms with result {result}", time.ElapsedMilliseconds, result);
+        float sumImportance = 1f;
+        int totalRecipes = 0;
+        if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
+            float objectiveValue = (float)objective.Value();
+            logger.Information("Estimated modpack cost: {EstimatedCost}", DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
+            foreach (Goods g in Database.goods.all.ExceptExcluded(this)) {
+                if (variables[g] == null) {
+                    continue;
+                }
+
+                float value = (float)variables[g].SolutionValue();
+                export[g] = value;
+            }
+
+            foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
+                if (constraints[recipe] == null) {
+                    continue;
+                }
+
+                float recipeFlow = (float)constraints[recipe].DualValue();
+                if (recipeFlow > 0f) {
+                    totalRecipes++;
+                    sumImportance += recipeFlow;
+                    flow[recipe] = recipeFlow;
+                    foreach (var product in recipe.products) {
+                        flow[product.goods] += recipeFlow * product.amount;
+                    }
+                }
+            }
+        }
+        foreach (FactorioObject o in Database.objects.all.ExceptExcluded(this)) {
+            if (!ShouldInclude(o)) {
+                export[o] = float.PositiveInfinity;
+                continue;
+            }
+
+            if (o is RecipeOrTechnology recipe) {
+                foreach (var ingredient in recipe.ingredients) // TODO split
+{
+                    export[o] += export[ingredient.goods] * ingredient.amount;
+                }
 
                 foreach (var product in recipe.products) {
-                    var var = variables[product.goods];
-                    float amount = product.amount;
-                    constraint.SetCoefficientCheck(var, amount, ref lastVariable[product.goods]);
-                    if (product.goods is Item) {
-                        logisticsCost += amount * CostPerItem;
-                    }
-                    else if (product.goods is Fluid) {
-                        logisticsCost += amount * CostPerFluid;
-                    }
-                }
-
-                if (singleUsedFuel != null) {
-                    var var = variables[singleUsedFuel];
-                    constraint.SetCoefficientCheck(var, -singleUsedFuelAmount, ref lastVariable[singleUsedFuel]);
-                }
-
-                foreach (var ingredient in recipe.ingredients) {
-                    var var = variables[ingredient.goods]; // TODO split cost analysis
-                    constraint.SetCoefficientCheck(var, -ingredient.amount, ref lastVariable[ingredient.goods]);
-                    if (ingredient.goods is Item) {
-                        logisticsCost += ingredient.amount * CostPerItem;
-                    }
-                    else if (ingredient.goods is Fluid) {
-                        logisticsCost += ingredient.amount * CostPerFluid;
-                    }
-                }
-
-                if (recipe.sourceEntity != null && recipe.sourceEntity.mapGenerated) {
-                    float totalMining = 0f;
-                    foreach (var product in recipe.products) {
-                        totalMining += product.amount;
-                    }
-
-                    float miningPenalty = MiningPenalty;
-                    float totalDensity = recipe.sourceEntity.mapGenDensity / totalMining;
-                    if (totalDensity < MiningMaxDensityForPenalty) {
-                        float extraPenalty = MathF.Log(MiningMaxDensityForPenalty / totalDensity);
-                        miningPenalty += Math.Min(extraPenalty, MiningMaxExtraPenaltyForRarity);
-                    }
-
-                    logisticsCost *= miningPenalty;
-                }
-
-                if (minEmissions >= 0f) {
-                    logisticsCost += minEmissions * CostPerPollution * recipe.time * project.settings.PollutionCostModifier;
-                }
-
-                constraint.SetUb(logisticsCost);
-                export[recipe] = logisticsCost;
-                recipeCost[recipe] = logisticsCost;
-            }
-
-            // TODO this is temporary fix for strange item sources (make the cost of item not higher than the cost of its source)
-            foreach (Item item in Database.items.all.ExceptExcluded(this)) {
-                if (ShouldInclude(item)) {
-                    foreach (var source in item.miscSources) {
-                        if (source is Goods g && ShouldInclude(g)) {
-                            var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, "source-" + item.locName);
-                            constraint.SetCoefficient(variables[g], -1);
-                            constraint.SetCoefficient(variables[item], 1);
-                        }
-                    }
+                    recipeProductionCost[recipe] += product.amount * export[product.goods];
                 }
             }
-
-            // TODO this is temporary fix for fluid temperatures (make the cost of fluid with lower temp not higher than the cost of fluid with higher temp)
-            foreach (var (name, fluids) in Database.fluidVariants) {
-                var prev = fluids[0];
-                for (int i = 1; i < fluids.Count; i++) {
-                    var cur = fluids[i];
-                    var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, "fluid-" + name + "-" + prev.temperature);
-                    constraint.SetCoefficient(variables[prev], 1);
-                    constraint.SetCoefficient(variables[cur], -1);
-                    prev = cur;
+            else if (o is Entity entity) {
+                float minimal = float.PositiveInfinity;
+                foreach (var item in entity.itemsToPlace) {
+                    if (export[item] < minimal) {
+                        minimal = export[item];
+                    }
                 }
+                export[o] = minimal;
             }
+        }
+        cost = export;
+        recipeProductCost = recipeProductionCost;
 
-            var result = workspaceSolver.TrySolveWithDifferentSeeds();
-            logger.Information("Cost analysis completed in {ElapsedTime}ms with result {result}", time.ElapsedMilliseconds, result);
-            float sumImportance = 1f;
-            int totalRecipes = 0;
-            if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
-                float objectiveValue = (float)objective.Value();
-                logger.Information("Estimated modpack cost: {EstimatedCost}", DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
-                foreach (Goods g in Database.goods.all.ExceptExcluded(this)) {
-                    if (variables[g] == null) {
-                        continue;
-                    }
-
-                    float value = (float)variables[g].SolutionValue();
-                    export[g] = value;
-                }
-
-                foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
-                    if (constraints[recipe] == null) {
-                        continue;
-                    }
-
-                    float recipeFlow = (float)constraints[recipe].DualValue();
-                    if (recipeFlow > 0f) {
-                        totalRecipes++;
-                        sumImportance += recipeFlow;
-                        flow[recipe] = recipeFlow;
-                        foreach (var product in recipe.products) {
-                            flow[product.goods] += recipeFlow * product.amount;
-                        }
-                    }
-                }
-            }
-            foreach (FactorioObject o in Database.objects.all.ExceptExcluded(this)) {
-                if (!ShouldInclude(o)) {
-                    export[o] = float.PositiveInfinity;
+        recipeWastePercentage = Database.recipes.CreateMapping<float>();
+        if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
+            foreach (var (recipe, constraint) in constraints) {
+                if (constraint == null) {
                     continue;
                 }
 
-                if (o is RecipeOrTechnology recipe) {
-                    foreach (var ingredient in recipe.ingredients) // TODO split
-{
-                        export[o] += export[ingredient.goods] * ingredient.amount;
-                    }
+                float productCost = 0f;
+                foreach (var product in recipe.products) {
+                    productCost += product.amount * export[product.goods];
+                }
 
-                    foreach (var product in recipe.products) {
-                        recipeProductionCost[recipe] += product.amount * export[product.goods];
-                    }
-                }
-                else if (o is Entity entity) {
-                    float minimal = float.PositiveInfinity;
-                    foreach (var item in entity.itemsToPlace) {
-                        if (export[item] < minimal) {
-                            minimal = export[item];
-                        }
-                    }
-                    export[o] = minimal;
-                }
+                recipeWastePercentage[recipe] = 1f - (productCost / export[recipe]);
             }
-            cost = export;
-            recipeProductCost = recipeProductionCost;
-
-            recipeWastePercentage = Database.recipes.CreateMapping<float>();
-            if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
-                foreach (var (recipe, constraint) in constraints) {
-                    if (constraint == null) {
-                        continue;
-                    }
-
-                    float productCost = 0f;
-                    foreach (var product in recipe.products) {
-                        productCost += product.amount * export[product.goods];
-                    }
-
-                    recipeWastePercentage[recipe] = 1f - (productCost / export[recipe]);
-                }
+        }
+        else {
+            if (!onlyCurrentMilestones) {
+                warnings.Error("Cost analysis was unable to process this modpack. This may mean YAFC bug.", ErrorSeverity.AnalysisWarning);
             }
-            else {
-                if (!onlyCurrentMilestones) {
-                    warnings.Error("Cost analysis was unable to process this modpack. This may mean YAFC bug.", ErrorSeverity.AnalysisWarning);
-                }
-            }
-
-            importantItems = [.. Database.goods.all.ExceptExcluded(this).Where(x => x.usages.Length > 1).OrderByDescending(x => flow[x] * cost[x] * x.usages.Count(y => ShouldInclude(y) && recipeWastePercentage[y] == 0f))];
-
-            workspaceSolver.Dispose();
         }
 
-        public override string description => "Cost analysis computes a hypothetical late-game base. This simulation has two very important results: How much does stuff (items, recipes, etc) cost and how much of stuff do you need. " +
-                                              "It also collects a bunch of auxiliary results, for example how efficient are different recipes. These results are used as heuristics and weights for calculations, and are also useful by themselves.";
+        importantItems = [.. Database.goods.all.ExceptExcluded(this).Where(x => x.usages.Length > 1).OrderByDescending(x => flow[x] * cost[x] * x.usages.Count(y => ShouldInclude(y) && recipeWastePercentage[y] == 0f))];
 
-        private static readonly StringBuilder sb = new StringBuilder();
-        public static string GetDisplayCost(FactorioObject goods) {
-            float cost = goods.Cost();
-            float costNow = goods.Cost(true);
-            if (float.IsPositiveInfinity(cost)) {
-                return "YAFC analysis: Unable to find a way to fully automate this";
-            }
+        workspaceSolver.Dispose();
+    }
 
-            _ = sb.Clear();
+    public override string description => "Cost analysis computes a hypothetical late-game base. This simulation has two very important results: How much does stuff (items, recipes, etc) cost and how much of stuff do you need. " +
+                                          "It also collects a bunch of auxiliary results, for example how efficient are different recipes. These results are used as heuristics and weights for calculations, and are also useful by themselves.";
 
-            float compareCost = cost;
-            float compareCostNow = costNow;
-            string costPrefix;
-            if (goods is Fluid) {
-                compareCost = cost * 50;
-                compareCostNow = costNow * 50;
-                costPrefix = "YAFC cost per 50 units of fluid:";
-            }
-            else if (goods is Item) {
-                costPrefix = "YAFC cost per item:";
-            }
-            else if (goods is Special special && special.isPower) {
-                costPrefix = "YAFC cost per 1 MW:";
-            }
-            else if (goods is Recipe) {
-                costPrefix = "YAFC cost per recipe:";
-            }
-            else {
-                costPrefix = "YAFC cost:";
-            }
-
-            _ = sb.Append(costPrefix).Append(" ¥").Append(DataUtils.FormatAmount(compareCost, UnitOfMeasure.None));
-            if (compareCostNow > compareCost && !float.IsPositiveInfinity(compareCostNow)) {
-                _ = sb.Append(" (Currently ¥").Append(DataUtils.FormatAmount(compareCostNow, UnitOfMeasure.None)).Append(')');
-            }
-
-            return sb.ToString();
+    private static readonly StringBuilder sb = new StringBuilder();
+    public static string GetDisplayCost(FactorioObject goods) {
+        float cost = goods.Cost();
+        float costNow = goods.Cost(true);
+        if (float.IsPositiveInfinity(cost)) {
+            return "YAFC analysis: Unable to find a way to fully automate this";
         }
 
-        public static float GetBuildingHours(Recipe recipe, float flow) {
-            return recipe.time * flow * (1000f / 3600f);
+        _ = sb.Clear();
+
+        float compareCost = cost;
+        float compareCostNow = costNow;
+        string costPrefix;
+        if (goods is Fluid) {
+            compareCost = cost * 50;
+            compareCostNow = costNow * 50;
+            costPrefix = "YAFC cost per 50 units of fluid:";
+        }
+        else if (goods is Item) {
+            costPrefix = "YAFC cost per item:";
+        }
+        else if (goods is Special special && special.isPower) {
+            costPrefix = "YAFC cost per 1 MW:";
+        }
+        else if (goods is Recipe) {
+            costPrefix = "YAFC cost per recipe:";
+        }
+        else {
+            costPrefix = "YAFC cost:";
         }
 
-        public string? GetItemAmount(Goods goods) {
-            float itemFlow = flow[goods];
-            if (itemFlow <= 1f) {
-                return null;
-            }
-
-            return DataUtils.FormatAmount(itemFlow * 1000f, UnitOfMeasure.None, itemAmountPrefix);
+        _ = sb.Append(costPrefix).Append(" ¥").Append(DataUtils.FormatAmount(compareCost, UnitOfMeasure.None));
+        if (compareCostNow > compareCost && !float.IsPositiveInfinity(compareCostNow)) {
+            _ = sb.Append(" (Currently ¥").Append(DataUtils.FormatAmount(compareCostNow, UnitOfMeasure.None)).Append(')');
         }
+
+        return sb.ToString();
+    }
+
+    public static float GetBuildingHours(Recipe recipe, float flow) {
+        return recipe.time * flow * (1000f / 3600f);
+    }
+
+    public string? GetItemAmount(Goods goods) {
+        float itemFlow = flow[goods];
+        if (itemFlow <= 1f) {
+            return null;
+        }
+
+        return DataUtils.FormatAmount(itemFlow * 1000f, UnitOfMeasure.None, itemAmountPrefix);
     }
 }

--- a/Yafc.Model/Analysis/Dependencies.cs
+++ b/Yafc.Model/Analysis/Dependencies.cs
@@ -1,84 +1,83 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Yafc.Model {
-    public interface IDependencyCollector {
-        void Add(FactorioId[] raw, DependencyList.Flags flags);
-        void Add(IReadOnlyList<FactorioObject> raw, DependencyList.Flags flags);
+namespace Yafc.Model;
+public interface IDependencyCollector {
+    void Add(FactorioId[] raw, DependencyList.Flags flags);
+    void Add(IReadOnlyList<FactorioObject> raw, DependencyList.Flags flags);
+}
+
+public struct DependencyList {
+    [Flags]
+    public enum Flags {
+        RequireEverything = 0x100,
+        OneTimeInvestment = 0x200,
+
+        Ingredient = 1 | RequireEverything,
+        CraftingEntity = 2 | OneTimeInvestment,
+        SourceEntity = 3 | OneTimeInvestment,
+        TechnologyUnlock = 4 | OneTimeInvestment,
+        Source = 5,
+        Fuel = 6,
+        ItemToPlace = 7,
+        TechnologyPrerequisites = 8 | RequireEverything | OneTimeInvestment,
+        IngredientVariant = 9,
+        Hidden = 10,
     }
 
-    public struct DependencyList {
-        [Flags]
-        public enum Flags {
-            RequireEverything = 0x100,
-            OneTimeInvestment = 0x200,
+    public Flags flags;
+    public FactorioId[] elements;
+}
 
-            Ingredient = 1 | RequireEverything,
-            CraftingEntity = 2 | OneTimeInvestment,
-            SourceEntity = 3 | OneTimeInvestment,
-            TechnologyUnlock = 4 | OneTimeInvestment,
-            Source = 5,
-            Fuel = 6,
-            ItemToPlace = 7,
-            TechnologyPrerequisites = 8 | RequireEverything | OneTimeInvestment,
-            IngredientVariant = 9,
-            Hidden = 10,
+public static class Dependencies {
+    public static Mapping<FactorioObject, DependencyList[]> dependencyList;
+    public static Mapping<FactorioObject, List<FactorioId>> reverseDependencies;
+
+    public static void Calculate() {
+        dependencyList = Database.objects.CreateMapping<DependencyList[]>();
+        reverseDependencies = Database.objects.CreateMapping<List<FactorioId>>();
+        foreach (var obj in Database.objects.all) {
+            reverseDependencies[obj] = [];
         }
 
-        public Flags flags;
-        public FactorioId[] elements;
-    }
+        DependencyCollector collector = new DependencyCollector();
+        List<FactorioObject> temp = [];
+        foreach (var obj in Database.objects.all) {
+            obj.GetDependencies(collector, temp);
+            var packed = collector.Pack();
+            dependencyList[obj] = packed;
 
-    public static class Dependencies {
-        public static Mapping<FactorioObject, DependencyList[]> dependencyList;
-        public static Mapping<FactorioObject, List<FactorioId>> reverseDependencies;
-
-        public static void Calculate() {
-            dependencyList = Database.objects.CreateMapping<DependencyList[]>();
-            reverseDependencies = Database.objects.CreateMapping<List<FactorioId>>();
-            foreach (var obj in Database.objects.all) {
-                reverseDependencies[obj] = [];
-            }
-
-            DependencyCollector collector = new DependencyCollector();
-            List<FactorioObject> temp = [];
-            foreach (var obj in Database.objects.all) {
-                obj.GetDependencies(collector, temp);
-                var packed = collector.Pack();
-                dependencyList[obj] = packed;
-
-                foreach (var group in packed) {
-                    foreach (var req in group.elements) {
-                        if (!reverseDependencies[req].Contains(obj.id)) {
-                            reverseDependencies[req].Add(obj.id);
-                        }
+            foreach (var group in packed) {
+                foreach (var req in group.elements) {
+                    if (!reverseDependencies[req].Contains(obj.id)) {
+                        reverseDependencies[req].Add(obj.id);
                     }
                 }
             }
         }
+    }
 
-        private class DependencyCollector : IDependencyCollector {
-            private readonly List<DependencyList> list = [];
+    private class DependencyCollector : IDependencyCollector {
+        private readonly List<DependencyList> list = [];
 
-            public void Add(FactorioId[] raw, DependencyList.Flags flags) {
-                list.Add(new DependencyList { elements = raw, flags = flags });
-            }
-
-            public void Add(IReadOnlyList<FactorioObject> raw, DependencyList.Flags flags) {
-                FactorioId[] elems = new FactorioId[raw.Count];
-                for (int i = 0; i < raw.Count; i++) {
-                    elems[i] = raw[i].id;
-                }
-
-                list.Add(new DependencyList { elements = elems, flags = flags });
-            }
-
-            public DependencyList[] Pack() {
-                var packed = list.ToArray();
-                list.Clear();
-                return packed;
-            }
+        public void Add(FactorioId[] raw, DependencyList.Flags flags) {
+            list.Add(new DependencyList { elements = raw, flags = flags });
         }
 
+        public void Add(IReadOnlyList<FactorioObject> raw, DependencyList.Flags flags) {
+            FactorioId[] elems = new FactorioId[raw.Count];
+            for (int i = 0; i < raw.Count; i++) {
+                elems[i] = raw[i].id;
+            }
+
+            list.Add(new DependencyList { elements = elems, flags = flags });
+        }
+
+        public DependencyList[] Pack() {
+            var packed = list.ToArray();
+            list.Clear();
+            return packed;
+        }
     }
+
 }

--- a/Yafc.Model/Analysis/Milestones.cs
+++ b/Yafc.Model/Analysis/Milestones.cs
@@ -5,283 +5,282 @@ using System.Linq;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public class Milestones : Analysis {
-        public static readonly Milestones Instance = new Milestones();
+namespace Yafc.Model;
+public class Milestones : Analysis {
+    public static readonly Milestones Instance = new Milestones();
 
-        private static readonly ILogger logger = Logging.GetLogger<Milestones>();
+    private static readonly ILogger logger = Logging.GetLogger<Milestones>();
 
-        public FactorioObject[] currentMilestones = [];
-        private Mapping<FactorioObject, Bits> milestoneResult;
-        public Bits lockedMask { get; private set; } = new();
-        private Project? project;
+    public FactorioObject[] currentMilestones = [];
+    private Mapping<FactorioObject, Bits> milestoneResult;
+    public Bits lockedMask { get; private set; } = new();
+    private Project? project;
 
-        public bool IsAccessibleWithCurrentMilestones(FactorioId obj) {
-            return (milestoneResult[obj] & lockedMask) == 1;
+    public bool IsAccessibleWithCurrentMilestones(FactorioId obj) {
+        return (milestoneResult[obj] & lockedMask) == 1;
+    }
+
+    public bool IsAccessibleWithCurrentMilestones(FactorioObject obj) {
+        return (milestoneResult[obj] & lockedMask) == 1;
+    }
+
+    public bool IsAccessibleAtNextMilestone(FactorioObject obj) {
+        var milestoneMask = milestoneResult[obj] & lockedMask;
+        if (milestoneMask == 1) {
+            return true;
         }
 
-        public bool IsAccessibleWithCurrentMilestones(FactorioObject obj) {
-            return (milestoneResult[obj] & lockedMask) == 1;
-        }
-
-        public bool IsAccessibleAtNextMilestone(FactorioObject obj) {
-            var milestoneMask = milestoneResult[obj] & lockedMask;
-            if (milestoneMask == 1) {
-                return true;
-            }
-
-            if (milestoneMask[0]) {
-                return false;
-            }
-            // TODO Always returns false -> milestoneMask is a power of 2 + 1 always has bit 0 set, as x pow 2 sets one (high) bit, so the + 1 adds bit 0, which is detected by (milestoneMask & 1) != 0
-            // return ((milestoneMask - 1) & (milestoneMask - 2)) == 0; // milestoneMask is a power of 2 + 1
+        if (milestoneMask[0]) {
             return false;
         }
+        // TODO Always returns false -> milestoneMask is a power of 2 + 1 always has bit 0 set, as x pow 2 sets one (high) bit, so the + 1 adds bit 0, which is detected by (milestoneMask & 1) != 0
+        // return ((milestoneMask - 1) & (milestoneMask - 2)) == 0; // milestoneMask is a power of 2 + 1
+        return false;
+    }
 
-        public Bits GetMilestoneResult(FactorioId obj) {
-            // Return a copy of Bits
-            return new Bits(milestoneResult[obj]);
+    public Bits GetMilestoneResult(FactorioId obj) {
+        // Return a copy of Bits
+        return new Bits(milestoneResult[obj]);
+    }
+
+    public Bits GetMilestoneResult(FactorioObject obj) {
+        // Return a copy of Bits
+        return new Bits(milestoneResult[obj]);
+    }
+
+    private void GetLockedMaskFromProject() {
+        if (project is null) {
+            throw new InvalidOperationException($"{nameof(project)} must be set before calling {nameof(GetLockedMaskFromProject)}");
         }
 
-        public Bits GetMilestoneResult(FactorioObject obj) {
-            // Return a copy of Bits
-            return new Bits(milestoneResult[obj]);
+        Bits bits = new(true); // The first bit is skipped (index is increased before the first bit is written) and always set
+        int index = 0;
+        foreach (var milestone in currentMilestones) {
+            index++;
+            bits[index] = !project.settings.Flags(milestone).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
+        }
+        lockedMask = bits;
+    }
+
+    private void ProjectSettingsChanged(bool visualOnly) {
+        if (!visualOnly) {
+            GetLockedMaskFromProject();
+        }
+    }
+
+    public FactorioObject? GetHighest(FactorioObject target, bool all) {
+        if (target == null) {
+            return null;
         }
 
-        private void GetLockedMaskFromProject() {
-            if (project is null) {
-                throw new InvalidOperationException($"{nameof(project)} must be set before calling {nameof(GetLockedMaskFromProject)}");
-            }
-
-            Bits bits = new(true); // The first bit is skipped (index is increased before the first bit is written) and always set
-            int index = 0;
-            foreach (var milestone in currentMilestones) {
-                index++;
-                bits[index] = !project.settings.Flags(milestone).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
-            }
-            lockedMask = bits;
+        var ms = milestoneResult[target];
+        if (!all) {
+            ms &= lockedMask;
         }
 
-        private void ProjectSettingsChanged(bool visualOnly) {
-            if (!visualOnly) {
-                GetLockedMaskFromProject();
+        if (ms == 0) {
+            return null;
+        }
+
+        int msb = ms.HighestBitSet() - 1;
+        return msb < 0 || msb >= currentMilestones.Length ? null : currentMilestones[msb];
+    }
+
+    [Flags]
+    private enum ProcessingFlags : byte {
+        InQueue = 1,
+        Initial = 2,
+        MilestoneNeedOrdering = 4,
+        ForceInaccessible = 8
+    }
+
+    public override void Compute(Project project, ErrorCollector warnings) {
+        if (project.settings.milestones.Count == 0) {
+            ComputeWithParameters(project, warnings, Database.allSciencePacks, true);
+        }
+        else {
+            ComputeWithParameters(project, warnings, project.settings.milestones.ToArray(), false);
+        }
+    }
+
+    public void ComputeWithParameters(Project project, ErrorCollector warnings, FactorioObject[] milestones, bool autoSort) {
+        if (this.project == null) {
+            this.project = project;
+            project.settings.changed += ProjectSettingsChanged;
+        }
+
+        Stopwatch time = Stopwatch.StartNew();
+        var result = Database.objects.CreateMapping<Bits>();
+        var processing = Database.objects.CreateMapping<ProcessingFlags>();
+        Queue<FactorioId> processingQueue = new Queue<FactorioId>();
+
+        foreach (var rootAccessible in Database.rootAccessible) {
+            result[rootAccessible] = new Bits(true);
+            processingQueue.Enqueue(rootAccessible.id);
+            processing[rootAccessible] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
+        }
+
+        foreach (var (obj, flag) in project.settings.itemFlags) {
+            if (flag.HasFlags(ProjectPerItemFlags.MarkedAccessible)) {
+                result[obj] = new Bits(true);
+                processingQueue.Enqueue(obj.id);
+                processing[obj] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
+            }
+            else if (flag.HasFlag(ProjectPerItemFlags.MarkedInaccessible)) {
+                processing[obj] = ProcessingFlags.ForceInaccessible;
             }
         }
 
-        public FactorioObject? GetHighest(FactorioObject target, bool all) {
-            if (target == null) {
-                return null;
+        if (autoSort) {
+            // Adding default milestones AND special flag to auto-order them
+            foreach (var milestone in milestones) {
+                processing[milestone] |= ProcessingFlags.MilestoneNeedOrdering;
             }
 
-            var ms = milestoneResult[target];
-            if (!all) {
-                ms &= lockedMask;
-            }
-
-            if (ms == 0) {
-                return null;
-            }
-
-            int msb = ms.HighestBitSet() - 1;
-            return msb < 0 || msb >= currentMilestones.Length ? null : currentMilestones[msb];
+            currentMilestones = new FactorioObject[milestones.Length];
         }
-
-        [Flags]
-        private enum ProcessingFlags : byte {
-            InQueue = 1,
-            Initial = 2,
-            MilestoneNeedOrdering = 4,
-            ForceInaccessible = 8
-        }
-
-        public override void Compute(Project project, ErrorCollector warnings) {
-            if (project.settings.milestones.Count == 0) {
-                ComputeWithParameters(project, warnings, Database.allSciencePacks, true);
-            }
-            else {
-                ComputeWithParameters(project, warnings, project.settings.milestones.ToArray(), false);
+        else {
+            currentMilestones = milestones;
+            for (int i = 0; i < milestones.Length; i++) {
+                //  result[milestones[i]] = (1ul << (i + 1)) | 1;
+                Bits b = new Bits(true);
+                b[i + 1] = true;
+                result[milestones[i]] = b;
             }
         }
 
-        public void ComputeWithParameters(Project project, ErrorCollector warnings, FactorioObject[] milestones, bool autoSort) {
-            if (this.project == null) {
-                this.project = project;
-                project.settings.changed += ProjectSettingsChanged;
-            }
+        var dependencyList = Dependencies.dependencyList;
+        var reverseDependencies = Dependencies.reverseDependencies;
+        List<FactorioObject>? milestonesNotReachable = null;
 
-            Stopwatch time = Stopwatch.StartNew();
-            var result = Database.objects.CreateMapping<Bits>();
-            var processing = Database.objects.CreateMapping<ProcessingFlags>();
-            Queue<FactorioId> processingQueue = new Queue<FactorioId>();
+        Bits nextMilestoneMask = new Bits();
+        nextMilestoneMask[1] = true;
+        int nextMilestoneIndex = 0;
+        int accessibleObjects = 0;
 
-            foreach (var rootAccessible in Database.rootAccessible) {
-                result[rootAccessible] = new Bits(true);
-                processingQueue.Enqueue(rootAccessible.id);
-                processing[rootAccessible] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
-            }
-
-            foreach (var (obj, flag) in project.settings.itemFlags) {
-                if (flag.HasFlags(ProjectPerItemFlags.MarkedAccessible)) {
-                    result[obj] = new Bits(true);
-                    processingQueue.Enqueue(obj.id);
-                    processing[obj] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
-                }
-                else if (flag.HasFlag(ProjectPerItemFlags.MarkedInaccessible)) {
-                    processing[obj] = ProcessingFlags.ForceInaccessible;
-                }
-            }
-
-            if (autoSort) {
-                // Adding default milestones AND special flag to auto-order them
-                foreach (var milestone in milestones) {
-                    processing[milestone] |= ProcessingFlags.MilestoneNeedOrdering;
-                }
-
-                currentMilestones = new FactorioObject[milestones.Length];
-            }
-            else {
-                currentMilestones = milestones;
-                for (int i = 0; i < milestones.Length; i++) {
-                    //  result[milestones[i]] = (1ul << (i + 1)) | 1;
-                    Bits b = new Bits(true);
-                    b[i + 1] = true;
-                    result[milestones[i]] = b;
-                }
-            }
-
-            var dependencyList = Dependencies.dependencyList;
-            var reverseDependencies = Dependencies.reverseDependencies;
-            List<FactorioObject>? milestonesNotReachable = null;
-
-            Bits nextMilestoneMask = new Bits();
-            nextMilestoneMask[1] = true;
-            int nextMilestoneIndex = 0;
-            int accessibleObjects = 0;
-
-            Bits flagMask = new Bits();
-            for (int i = 0; i <= currentMilestones.Length; i++) {
-                flagMask[i] = true;
-                if (i > 0) {
-                    var milestone = currentMilestones[i - 1];
-                    if (milestone == null) {
-                        milestonesNotReachable = [];
-                        foreach (var pack in Database.allSciencePacks) {
-                            if (Array.IndexOf(currentMilestones, pack) == -1) {
-                                currentMilestones[nextMilestoneIndex++] = pack;
-                                milestonesNotReachable.Add(pack);
-                            }
+        Bits flagMask = new Bits();
+        for (int i = 0; i <= currentMilestones.Length; i++) {
+            flagMask[i] = true;
+            if (i > 0) {
+                var milestone = currentMilestones[i - 1];
+                if (milestone == null) {
+                    milestonesNotReachable = [];
+                    foreach (var pack in Database.allSciencePacks) {
+                        if (Array.IndexOf(currentMilestones, pack) == -1) {
+                            currentMilestones[nextMilestoneIndex++] = pack;
+                            milestonesNotReachable.Add(pack);
                         }
-                        Array.Resize(ref currentMilestones, nextMilestoneIndex);
-                        break;
                     }
-                    logger.Information("Processing milestone {Milestone}", milestone.locName);
-                    processingQueue.Enqueue(milestone.id);
-                    processing[milestone] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
+                    Array.Resize(ref currentMilestones, nextMilestoneIndex);
+                    break;
                 }
+                logger.Information("Processing milestone {Milestone}", milestone.locName);
+                processingQueue.Enqueue(milestone.id);
+                processing[milestone] = ProcessingFlags.Initial | ProcessingFlags.InQueue;
+            }
 
-                while (processingQueue.Count > 0) {
-                    var elem = processingQueue.Dequeue();
-                    var entry = dependencyList[elem];
+            while (processingQueue.Count > 0) {
+                var elem = processingQueue.Dequeue();
+                var entry = dependencyList[elem];
 
 
-                    var cur = result[elem];
-                    var elementFlags = cur;
-                    bool isInitial = (processing[elem] & ProcessingFlags.Initial) != 0;
-                    processing[elem] &= ProcessingFlags.MilestoneNeedOrdering;
+                var cur = result[elem];
+                var elementFlags = cur;
+                bool isInitial = (processing[elem] & ProcessingFlags.Initial) != 0;
+                processing[elem] &= ProcessingFlags.MilestoneNeedOrdering;
 
-                    foreach (var list in entry) {
-                        if ((list.flags & DependencyList.Flags.RequireEverything) != 0) {
-                            foreach (var req in list.elements) {
-                                var reqFlags = result[req];
-                                if (reqFlags.IsClear() && !isInitial) {
-                                    goto skip;
-                                }
-
-                                elementFlags |= reqFlags;
-                            }
-                        }
-                        else {
-                            Bits groupFlags = new Bits();
-                            foreach (var req in list.elements) {
-                                var acc = result[req];
-                                if (acc.IsClear()) {
-                                    continue;
-                                }
-
-                                if (acc < groupFlags || groupFlags.IsClear()) {
-                                    groupFlags = acc;
-                                }
-                            }
-
-                            if (groupFlags.IsClear() && !isInitial) {
+                foreach (var list in entry) {
+                    if ((list.flags & DependencyList.Flags.RequireEverything) != 0) {
+                        foreach (var req in list.elements) {
+                            var reqFlags = result[req];
+                            if (reqFlags.IsClear() && !isInitial) {
                                 goto skip;
                             }
 
-                            elementFlags |= groupFlags;
-                        }
-                    }
-
-                    if (!isInitial) {
-                        if (elementFlags == cur || (elementFlags | flagMask) != flagMask) {
-                            continue;
+                            elementFlags |= reqFlags;
                         }
                     }
                     else {
-                        elementFlags &= flagMask;
-                    }
+                        Bits groupFlags = new Bits();
+                        foreach (var req in list.elements) {
+                            var acc = result[req];
+                            if (acc.IsClear()) {
+                                continue;
+                            }
 
-                    accessibleObjects++;
-                    //var obj = Database.objects[elem];
-                    //logger.Information("Added object {LocalizedName} [{Type}] with mask {MilestoneMask} (was {PreviousMask})", obj.locName, obj.GetType().Name, elementFlags, cur);
-                    if (processing[elem] == ProcessingFlags.MilestoneNeedOrdering) {
-                        processing[elem] = 0;
-                        elementFlags |= nextMilestoneMask;
-                        nextMilestoneMask <<= 1;
-                        currentMilestones[nextMilestoneIndex++] = Database.objects[elem];
-                    }
-
-                    result[elem] = elementFlags;
-                    foreach (var reverseDependency in reverseDependencies[elem]) {
-                        if ((processing[reverseDependency] & ~ProcessingFlags.MilestoneNeedOrdering) != 0 || !result[reverseDependency].IsClear()) {
-                            continue;
+                            if (acc < groupFlags || groupFlags.IsClear()) {
+                                groupFlags = acc;
+                            }
                         }
 
-                        processing[reverseDependency] |= ProcessingFlags.InQueue;
-                        processingQueue.Enqueue(reverseDependency);
+                        if (groupFlags.IsClear() && !isInitial) {
+                            goto skip;
+                        }
+
+                        elementFlags |= groupFlags;
+                    }
+                }
+
+                if (!isInitial) {
+                    if (elementFlags == cur || (elementFlags | flagMask) != flagMask) {
+                        continue;
+                    }
+                }
+                else {
+                    elementFlags &= flagMask;
+                }
+
+                accessibleObjects++;
+                //var obj = Database.objects[elem];
+                //logger.Information("Added object {LocalizedName} [{Type}] with mask {MilestoneMask} (was {PreviousMask})", obj.locName, obj.GetType().Name, elementFlags, cur);
+                if (processing[elem] == ProcessingFlags.MilestoneNeedOrdering) {
+                    processing[elem] = 0;
+                    elementFlags |= nextMilestoneMask;
+                    nextMilestoneMask <<= 1;
+                    currentMilestones[nextMilestoneIndex++] = Database.objects[elem];
+                }
+
+                result[elem] = elementFlags;
+                foreach (var reverseDependency in reverseDependencies[elem]) {
+                    if ((processing[reverseDependency] & ~ProcessingFlags.MilestoneNeedOrdering) != 0 || !result[reverseDependency].IsClear()) {
+                        continue;
                     }
 
-skip:;
+                    processing[reverseDependency] |= ProcessingFlags.InQueue;
+                    processingQueue.Enqueue(reverseDependency);
                 }
-            }
 
-            if (!project.settings.milestones.SequenceEqual(currentMilestones)) {
-                _ = project.settings.RecordUndo();
-                project.settings.milestones.Clear();
-                project.settings.milestones.AddRange(currentMilestones);
+skip:;
             }
-            GetLockedMaskFromProject();
-
-            bool hasAutomatableRocketLaunch = result[Database.objectsByTypeName["Special.launch"]] != 0;
-            if (accessibleObjects < Database.objects.count / 2) {
-                warnings.Error("More than 50% of all in-game objects appear to be inaccessible in this project with your current mod list. This can have a variety of reasons like objects being accessible via scripts," +
-                               MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
-            }
-            else if (!hasAutomatableRocketLaunch) {
-                warnings.Error("Rocket launch appear to be inaccessible. This means that rocket may not be launched in this mod pack, or it requires mod script to spawn or unlock some items," +
-                               MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
-            }
-            else if (milestonesNotReachable != null) {
-                warnings.Error("There are some milestones that are not accessible: " + string.Join(", ", milestonesNotReachable.Select(x => x.locName)) + ". You may remove these from milestone list," +
-                               MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
-            }
-            logger.Information("Milestones calculation finished in {ElapsedTime}ms.", time.ElapsedMilliseconds);
-            milestoneResult = result;
         }
 
-        private const string MaybeBug = " or it might be due to a bug inside a mod or YAFC.";
-        private const string MilestoneAnalysisIsImportant = "\nA lot of YAFC's systems rely on objects being accessible, so some features may not work as intended.";
-        private const string UseDependencyExplorer = "\n\nFor this reason YAFC has a Dependency Explorer that allows you to manually enable some of the core recipes. YAFC will iteratively try to unlock all the dependencies after each recipe you manually enabled. For most modpacks it's enough to unlock a few early recipes like any special recipes for plates that everything in the mod is based on.";
+        if (!project.settings.milestones.SequenceEqual(currentMilestones)) {
+            _ = project.settings.RecordUndo();
+            project.settings.milestones.Clear();
+            project.settings.milestones.AddRange(currentMilestones);
+        }
+        GetLockedMaskFromProject();
 
-        public override string description => "Milestone analysis starts from objects that are placed on map by the map generator and tries to find all objects that are accessible from that, taking notes about which objects are locked behind which milestones.";
+        bool hasAutomatableRocketLaunch = result[Database.objectsByTypeName["Special.launch"]] != 0;
+        if (accessibleObjects < Database.objects.count / 2) {
+            warnings.Error("More than 50% of all in-game objects appear to be inaccessible in this project with your current mod list. This can have a variety of reasons like objects being accessible via scripts," +
+                           MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
+        }
+        else if (!hasAutomatableRocketLaunch) {
+            warnings.Error("Rocket launch appear to be inaccessible. This means that rocket may not be launched in this mod pack, or it requires mod script to spawn or unlock some items," +
+                           MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
+        }
+        else if (milestonesNotReachable != null) {
+            warnings.Error("There are some milestones that are not accessible: " + string.Join(", ", milestonesNotReachable.Select(x => x.locName)) + ". You may remove these from milestone list," +
+                           MaybeBug + MilestoneAnalysisIsImportant + UseDependencyExplorer, ErrorSeverity.AnalysisWarning);
+        }
+        logger.Information("Milestones calculation finished in {ElapsedTime}ms.", time.ElapsedMilliseconds);
+        milestoneResult = result;
     }
+
+    private const string MaybeBug = " or it might be due to a bug inside a mod or YAFC.";
+    private const string MilestoneAnalysisIsImportant = "\nA lot of YAFC's systems rely on objects being accessible, so some features may not work as intended.";
+    private const string UseDependencyExplorer = "\n\nFor this reason YAFC has a Dependency Explorer that allows you to manually enable some of the core recipes. YAFC will iteratively try to unlock all the dependencies after each recipe you manually enabled. For most modpacks it's enough to unlock a few early recipes like any special recipes for plates that everything in the mod is based on.";
+
+    public override string description => "Milestone analysis starts from objects that are placed on map by the map generator and tries to find all objects that are accessible from that, taking notes about which objects are locked behind which milestones.";
 }

--- a/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
+++ b/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
@@ -2,29 +2,28 @@
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public static class TechnologyLoopsFinder {
-        private static readonly ILogger logger = Logging.GetLogger(typeof(TechnologyLoopsFinder));
+namespace Yafc.Model;
+public static class TechnologyLoopsFinder {
+    private static readonly ILogger logger = Logging.GetLogger(typeof(TechnologyLoopsFinder));
 
-        public static void FindTechnologyLoops() {
-            Graph<Technology> graph = new Graph<Technology>();
-            foreach (var technology in Database.technologies.all) {
-                foreach (var prerequisite in technology.prerequisites) {
-                    graph.Connect(prerequisite, technology);
-                }
+    public static void FindTechnologyLoops() {
+        Graph<Technology> graph = new Graph<Technology>();
+        foreach (var technology in Database.technologies.all) {
+            foreach (var prerequisite in technology.prerequisites) {
+                graph.Connect(prerequisite, technology);
             }
+        }
 
-            var merged = graph.MergeStrongConnectedComponents();
-            bool loops = false;
-            foreach (var m in merged) {
-                if (m.userData.list != null) {
-                    logger.Error("Technology loop: {LoopMembers}", string.Join(", ", m.userData.list.Select(x => x.locName)));
-                    loops = true;
-                }
+        var merged = graph.MergeStrongConnectedComponents();
+        bool loops = false;
+        foreach (var m in merged) {
+            if (m.userData.list != null) {
+                logger.Error("Technology loop: {LoopMembers}", string.Join(", ", m.userData.list.Select(x => x.locName)));
+                loops = true;
             }
-            if (!loops) {
-                logger.Information("No technology loops found.");
-            }
+        }
+        if (!loops) {
+            logger.Information("No technology loops found.");
         }
     }
 }

--- a/Yafc.Model/Analysis/TechnologyScienceAnalysis.cs
+++ b/Yafc.Model/Analysis/TechnologyScienceAnalysis.cs
@@ -1,105 +1,104 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Yafc.Model {
-    public class TechnologyScienceAnalysis : Analysis {
-        public static readonly TechnologyScienceAnalysis Instance = new TechnologyScienceAnalysis();
-        public Mapping<Technology, Ingredient[]> allSciencePacks { get; private set; }
+namespace Yafc.Model;
+public class TechnologyScienceAnalysis : Analysis {
+    public static readonly TechnologyScienceAnalysis Instance = new TechnologyScienceAnalysis();
+    public Mapping<Technology, Ingredient[]> allSciencePacks { get; private set; }
 
-        public Ingredient? GetMaxTechnologyIngredient(Technology tech) {
-            Ingredient[] list = allSciencePacks[tech];
-            Ingredient? ingredient = null;
-            Bits order = new Bits();
-            foreach (Ingredient entry in list) {
-                Bits entryOrder = Milestones.Instance.GetMilestoneResult(entry.goods.id);
-                if (entryOrder != 0) {
-                    entryOrder -= 1;
-                }// else: The science pack is not accessible *and* not a milestone. We may still display it, but any actual milestone will win.
+    public Ingredient? GetMaxTechnologyIngredient(Technology tech) {
+        Ingredient[] list = allSciencePacks[tech];
+        Ingredient? ingredient = null;
+        Bits order = new Bits();
+        foreach (Ingredient entry in list) {
+            Bits entryOrder = Milestones.Instance.GetMilestoneResult(entry.goods.id);
+            if (entryOrder != 0) {
+                entryOrder -= 1;
+            }// else: The science pack is not accessible *and* not a milestone. We may still display it, but any actual milestone will win.
 
-                if (ingredient == null || entryOrder > order) {
-                    order = entryOrder;
-                    ingredient = entry;
+            if (ingredient == null || entryOrder > order) {
+                order = entryOrder;
+                ingredient = entry;
+            }
+        }
+
+        return ingredient;
+    }
+
+    public override void Compute(Project project, ErrorCollector warnings) {
+        var sciencePacks = Database.allSciencePacks;
+        var sciencePackIndex = Database.goods.CreateMapping<int>();
+        for (int i = 0; i < sciencePacks.Length; i++) {
+            sciencePackIndex[sciencePacks[i]] = i;
+        }
+
+        Mapping<Technology, float>[] sciencePackCount = new Mapping<Technology, float>[sciencePacks.Length];
+        for (int i = 0; i < sciencePacks.Length; i++) {
+            sciencePackCount[i] = Database.technologies.CreateMapping<float>();
+        }
+
+        var processing = Database.technologies.CreateMapping<bool>();
+        var requirementMap = Database.technologies.CreateMapping<Technology, bool>(Database.technologies);
+
+        Queue<Technology> queue = new Queue<Technology>();
+        foreach (Technology tech in Database.technologies.all.ExceptExcluded(this)) {
+            if (tech.prerequisites.Length == 0) {
+                processing[tech] = true;
+                queue.Enqueue(tech);
+            }
+        }
+        Queue<Technology> prerequisiteQueue = new Queue<Technology>();
+
+        while (queue.Count > 0) {
+            var current = queue.Dequeue();
+
+            // Fast processing for the first prerequisite (just copy everything)
+            if (current.prerequisites.Length > 0) {
+                var firstRequirement = current.prerequisites[0];
+                foreach (var pack in sciencePackCount) {
+                    pack[current] += pack[firstRequirement];
+                }
+
+                requirementMap.CopyRow(firstRequirement, current);
+            }
+
+            requirementMap[current, current] = true;
+            prerequisiteQueue.Enqueue(current);
+
+            while (prerequisiteQueue.Count > 0) {
+                var prerequisite = prerequisiteQueue.Dequeue();
+                foreach (var ingredient in prerequisite.ingredients) {
+                    int science = sciencePackIndex[ingredient.goods];
+                    sciencePackCount[science][current] += ingredient.amount * prerequisite.count;
+                }
+
+                foreach (var prerequisitePrerequisite in prerequisite.prerequisites) {
+                    if (!requirementMap[current, prerequisitePrerequisite]) {
+                        prerequisiteQueue.Enqueue(prerequisitePrerequisite);
+                        requirementMap[current, prerequisitePrerequisite] = true;
+                    }
                 }
             }
 
-            return ingredient;
-        }
+            foreach (var unlocks in Dependencies.reverseDependencies[current]) {
+                if (Database.objects[unlocks] is Technology tech && !processing[tech]) {
+                    foreach (var techPrerequisite in tech.prerequisites) {
+                        if (!processing[techPrerequisite]) {
+                            goto locked;
+                        }
+                    }
 
-        public override void Compute(Project project, ErrorCollector warnings) {
-            var sciencePacks = Database.allSciencePacks;
-            var sciencePackIndex = Database.goods.CreateMapping<int>();
-            for (int i = 0; i < sciencePacks.Length; i++) {
-                sciencePackIndex[sciencePacks[i]] = i;
-            }
-
-            Mapping<Technology, float>[] sciencePackCount = new Mapping<Technology, float>[sciencePacks.Length];
-            for (int i = 0; i < sciencePacks.Length; i++) {
-                sciencePackCount[i] = Database.technologies.CreateMapping<float>();
-            }
-
-            var processing = Database.technologies.CreateMapping<bool>();
-            var requirementMap = Database.technologies.CreateMapping<Technology, bool>(Database.technologies);
-
-            Queue<Technology> queue = new Queue<Technology>();
-            foreach (Technology tech in Database.technologies.all.ExceptExcluded(this)) {
-                if (tech.prerequisites.Length == 0) {
                     processing[tech] = true;
                     queue.Enqueue(tech);
-                }
-            }
-            Queue<Technology> prerequisiteQueue = new Queue<Technology>();
-
-            while (queue.Count > 0) {
-                var current = queue.Dequeue();
-
-                // Fast processing for the first prerequisite (just copy everything)
-                if (current.prerequisites.Length > 0) {
-                    var firstRequirement = current.prerequisites[0];
-                    foreach (var pack in sciencePackCount) {
-                        pack[current] += pack[firstRequirement];
-                    }
-
-                    requirementMap.CopyRow(firstRequirement, current);
-                }
-
-                requirementMap[current, current] = true;
-                prerequisiteQueue.Enqueue(current);
-
-                while (prerequisiteQueue.Count > 0) {
-                    var prerequisite = prerequisiteQueue.Dequeue();
-                    foreach (var ingredient in prerequisite.ingredients) {
-                        int science = sciencePackIndex[ingredient.goods];
-                        sciencePackCount[science][current] += ingredient.amount * prerequisite.count;
-                    }
-
-                    foreach (var prerequisitePrerequisite in prerequisite.prerequisites) {
-                        if (!requirementMap[current, prerequisitePrerequisite]) {
-                            prerequisiteQueue.Enqueue(prerequisitePrerequisite);
-                            requirementMap[current, prerequisitePrerequisite] = true;
-                        }
-                    }
-                }
-
-                foreach (var unlocks in Dependencies.reverseDependencies[current]) {
-                    if (Database.objects[unlocks] is Technology tech && !processing[tech]) {
-                        foreach (var techPrerequisite in tech.prerequisites) {
-                            if (!processing[techPrerequisite]) {
-                                goto locked;
-                            }
-                        }
-
-                        processing[tech] = true;
-                        queue.Enqueue(tech);
 
 locked:;
-                    }
                 }
             }
-
-            allSciencePacks = Database.technologies.CreateMapping(tech => sciencePackCount.Select((x, id) => x[tech] == 0 ? null : new Ingredient(sciencePacks[id], x[tech])).WhereNotNull().ToArray());
         }
 
-        public override string description =>
-            "Technology analysis calculates the total amount of science packs required for each technology";
+        allSciencePacks = Database.technologies.CreateMapping(tech => sciencePackCount.Select((x, id) => x[tech] == 0 ? null : new Ingredient(sciencePacks[id], x[tech])).WhereNotNull().ToArray());
     }
+
+    public override string description =>
+        "Technology analysis calculates the total amount of science packs required for each technology";
 }

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -7,158 +7,157 @@ using System.Text.Json.Serialization;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc.Blueprints {
-    [Serializable]
-    public class BlueprintString(string blueprintName) {
-        public Blueprint blueprint { get; } = new Blueprint(blueprintName);
-        private static readonly byte[] header = { 0x78, 0xDA };
+namespace Yafc.Blueprints;
+[Serializable]
+public class BlueprintString(string blueprintName) {
+    public Blueprint blueprint { get; } = new Blueprint(blueprintName);
+    private static readonly byte[] header = { 0x78, 0xDA };
 
-        public string ToBpString() {
-            if (InputSystem.Instance.control) {
-                return ToJson();
-            }
-
-            byte[] sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
-            using MemoryStream memory = new MemoryStream();
-            memory.Write(header);
-            using (DeflateStream compress = new DeflateStream(memory, CompressionLevel.Optimal, true)) {
-                compress.Write(sourceBytes);
-            }
-
-            memory.Write(GetChecksum(sourceBytes, sourceBytes.Length));
-            return "0" + Convert.ToBase64String(memory.ToArray());
+    public string ToBpString() {
+        if (InputSystem.Instance.control) {
+            return ToJson();
         }
 
-        private byte[] GetChecksum(byte[] buffer, int length) {
-            int a = 1, b = 0;
-            for (int counter = 0; counter < length; ++counter) {
-                a = (a + buffer[counter]) % 65521;
-                b = (b + a) % 65521;
-            }
-            int checksum = (b * 65536) + a;
-            byte[] intBytes = BitConverter.GetBytes(checksum);
-            Array.Reverse(intBytes);
-            return intBytes;
+        byte[] sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        using MemoryStream memory = new MemoryStream();
+        memory.Write(header);
+        using (DeflateStream compress = new DeflateStream(memory, CompressionLevel.Optimal, true)) {
+            compress.Write(sourceBytes);
         }
 
-        public string ToJson() {
-            byte[] sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
-            using MemoryStream memory = new MemoryStream(sourceBytes);
-            using StreamReader reader = new StreamReader(memory);
-            return reader.ReadToEnd();
+        memory.Write(GetChecksum(sourceBytes, sourceBytes.Length));
+        return "0" + Convert.ToBase64String(memory.ToArray());
+    }
+
+    private byte[] GetChecksum(byte[] buffer, int length) {
+        int a = 1, b = 0;
+        for (int counter = 0; counter < length; ++counter) {
+            a = (a + buffer[counter]) % 65521;
+            b = (b + a) % 65521;
+        }
+        int checksum = (b * 65536) + a;
+        byte[] intBytes = BitConverter.GetBytes(checksum);
+        Array.Reverse(intBytes);
+        return intBytes;
+    }
+
+    public string ToJson() {
+        byte[] sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        using MemoryStream memory = new MemoryStream(sourceBytes);
+        using StreamReader reader = new StreamReader(memory);
+        return reader.ReadToEnd();
+    }
+}
+
+[Serializable]
+public class Blueprint(string label) {
+    public const int VERSION = 0x01000000;
+
+    public string item { get; set; } = "blueprint";
+    public string label { get; set; } = label;
+    public List<BlueprintEntity> entities { get; } = [];
+    public List<BlueprintIcon> icons { get; } = [];
+    public int version { get; set; } = VERSION;
+}
+
+[Serializable]
+public class BlueprintIcon {
+    public int index { get; set; }
+    public BlueprintSignal signal { get; set; } = new BlueprintSignal();
+}
+
+[Serializable]
+public class BlueprintSignal {
+    public string? name { get; set; }
+    public string? type { get; set; }
+
+    public void Set(Goods goods) {
+        if (goods is Special sp) {
+            type = "virtual";
+            name = sp.virtualSignal;
+        }
+        else if (goods is Fluid fluid) {
+            type = "fluid";
+            name = fluid.originalName;
+        }
+        else {
+            type = "item";
+            name = goods.name;
         }
     }
+}
 
-    [Serializable]
-    public class Blueprint(string label) {
-        public const int VERSION = 0x01000000;
+[Serializable]
+public class BlueprintEntity {
+    [JsonPropertyName("entity_number")] public int index { get; set; }
+    public string? name { get; set; }
+    public BlueprintPosition position { get; set; } = new BlueprintPosition();
+    public int direction { get; set; }
+    public string? recipe { get; set; }
+    [JsonPropertyName("control_behavior")] public BlueprintControlBehavior? controlBehavior { get; set; }
+    public BlueprintConnection? connections { get; set; }
+    [JsonPropertyName("request_filters")] public List<BlueprintRequestFilter> requestFilters { get; } = [];
+    public Dictionary<string, int>? items { get; set; }
 
-        public string item { get; set; } = "blueprint";
-        public string label { get; set; } = label;
-        public List<BlueprintEntity> entities { get; } = [];
-        public List<BlueprintIcon> icons { get; } = [];
-        public int version { get; set; } = VERSION;
+    public void Connect(BlueprintEntity other, bool red = true, bool secondPort = false, bool targetSecond = false) {
+        ConnectSingle(other, red, secondPort, targetSecond);
+        other.ConnectSingle(this, red, targetSecond, secondPort);
     }
 
-    [Serializable]
-    public class BlueprintIcon {
-        public int index { get; set; }
-        public BlueprintSignal signal { get; set; } = new BlueprintSignal();
-    }
-
-    [Serializable]
-    public class BlueprintSignal {
-        public string? name { get; set; }
-        public string? type { get; set; }
-
-        public void Set(Goods goods) {
-            if (goods is Special sp) {
-                type = "virtual";
-                name = sp.virtualSignal;
-            }
-            else if (goods is Fluid fluid) {
-                type = "fluid";
-                name = fluid.originalName;
-            }
-            else {
-                type = "item";
-                name = goods.name;
-            }
+    private void ConnectSingle(BlueprintEntity other, bool red = true, bool secondPort = false, bool targetSecond = false) {
+        connections ??= new BlueprintConnection();
+        BlueprintConnectionPoint port;
+        if (secondPort) {
+            port = connections.p2 ?? (connections.p2 = new BlueprintConnectionPoint());
         }
-    }
-
-    [Serializable]
-    public class BlueprintEntity {
-        [JsonPropertyName("entity_number")] public int index { get; set; }
-        public string? name { get; set; }
-        public BlueprintPosition position { get; set; } = new BlueprintPosition();
-        public int direction { get; set; }
-        public string? recipe { get; set; }
-        [JsonPropertyName("control_behavior")] public BlueprintControlBehavior? controlBehavior { get; set; }
-        public BlueprintConnection? connections { get; set; }
-        [JsonPropertyName("request_filters")] public List<BlueprintRequestFilter> requestFilters { get; } = [];
-        public Dictionary<string, int>? items { get; set; }
-
-        public void Connect(BlueprintEntity other, bool red = true, bool secondPort = false, bool targetSecond = false) {
-            ConnectSingle(other, red, secondPort, targetSecond);
-            other.ConnectSingle(this, red, targetSecond, secondPort);
+        else {
+            port = connections.p1 ?? (connections.p1 = new BlueprintConnectionPoint());
         }
 
-        private void ConnectSingle(BlueprintEntity other, bool red = true, bool secondPort = false, bool targetSecond = false) {
-            connections ??= new BlueprintConnection();
-            BlueprintConnectionPoint port;
-            if (secondPort) {
-                port = connections.p2 ?? (connections.p2 = new BlueprintConnectionPoint());
-            }
-            else {
-                port = connections.p1 ?? (connections.p1 = new BlueprintConnectionPoint());
-            }
-
-            var list = red ? port.red : port.green;
-            list.Add(new BlueprintConnectionData { entityId = other.index, circuitId = targetSecond ? 2 : 1 });
-        }
+        var list = red ? port.red : port.green;
+        list.Add(new BlueprintConnectionData { entityId = other.index, circuitId = targetSecond ? 2 : 1 });
     }
+}
 
-    [Serializable]
-    public class BlueprintRequestFilter {
-        public string? name { get; set; }
-        public int index { get; set; }
-        public int count { get; set; }
-    }
+[Serializable]
+public class BlueprintRequestFilter {
+    public string? name { get; set; }
+    public int index { get; set; }
+    public int count { get; set; }
+}
 
-    [Serializable]
-    public class BlueprintConnection {
-        [JsonPropertyName("1")] public BlueprintConnectionPoint? p1 { get; set; }
-        [JsonPropertyName("2")] public BlueprintConnectionPoint? p2 { get; set; }
-    }
+[Serializable]
+public class BlueprintConnection {
+    [JsonPropertyName("1")] public BlueprintConnectionPoint? p1 { get; set; }
+    [JsonPropertyName("2")] public BlueprintConnectionPoint? p2 { get; set; }
+}
 
-    [Serializable]
-    public class BlueprintConnectionPoint {
-        public List<BlueprintConnectionData> red { get; } = [];
-        public List<BlueprintConnectionData> green { get; } = [];
-    }
+[Serializable]
+public class BlueprintConnectionPoint {
+    public List<BlueprintConnectionData> red { get; } = [];
+    public List<BlueprintConnectionData> green { get; } = [];
+}
 
-    [Serializable]
-    public class BlueprintConnectionData {
-        [JsonPropertyName("entity_id")] public int entityId { get; set; }
-        [JsonPropertyName("circuit_id")] public int circuitId { get; set; } = 1;
-    }
+[Serializable]
+public class BlueprintConnectionData {
+    [JsonPropertyName("entity_id")] public int entityId { get; set; }
+    [JsonPropertyName("circuit_id")] public int circuitId { get; set; } = 1;
+}
 
-    [Serializable]
-    public class BlueprintPosition {
-        public float x { get; set; }
-        public float y { get; set; }
-    }
+[Serializable]
+public class BlueprintPosition {
+    public float x { get; set; }
+    public float y { get; set; }
+}
 
-    [Serializable]
-    public class BlueprintControlBehavior {
-        public List<BlueprintControlFilter> filters { get; } = [];
-    }
+[Serializable]
+public class BlueprintControlBehavior {
+    public List<BlueprintControlFilter> filters { get; } = [];
+}
 
-    [Serializable]
-    public class BlueprintControlFilter {
-        public BlueprintSignal signal { get; set; } = new BlueprintSignal();
-        public int index { get; set; }
-        public int count { get; set; }
-    }
+[Serializable]
+public class BlueprintControlFilter {
+    public BlueprintSignal signal { get; set; } = new BlueprintSignal();
+    public int index { get; set; }
+    public int count { get; set; }
 }

--- a/Yafc.Model/Blueprints/BlueprintUtilities.cs
+++ b/Yafc.Model/Blueprints/BlueprintUtilities.cs
@@ -3,70 +3,69 @@ using System.Collections.Generic;
 using SDL2;
 using Yafc.Model;
 
-namespace Yafc.Blueprints {
-    public static class BlueprintUtilities {
-        private static string ExportBlueprint(BlueprintString blueprint, bool copyToClipboard) {
-            string result = blueprint.ToBpString();
-            if (copyToClipboard) {
-                _ = SDL.SDL_SetClipboardText(result);
-            }
-
-            return result;
+namespace Yafc.Blueprints;
+public static class BlueprintUtilities {
+    private static string ExportBlueprint(BlueprintString blueprint, bool copyToClipboard) {
+        string result = blueprint.ToBpString();
+        if (copyToClipboard) {
+            _ = SDL.SDL_SetClipboardText(result);
         }
 
-        public static string ExportConstantCombinators(string name, IReadOnlyList<(Goods item, int amount)> goods, bool copyToClipboard = true) {
-            int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
-            int offset = -combinatorCount / 2;
-            BlueprintString blueprint = new BlueprintString(name);
-            int index = 0;
-            BlueprintEntity? last = null;
-            for (int i = 0; i < combinatorCount; i++) {
-                BlueprintControlBehavior controlBehavior = new BlueprintControlBehavior();
-                BlueprintEntity entity = new BlueprintEntity { index = i + 1, position = { x = i + offset, y = 0 }, name = "constant-combinator", controlBehavior = controlBehavior };
-                blueprint.blueprint.entities.Add(entity);
-                for (int j = 0; j < Database.constantCombinatorCapacity; j++) {
-                    var (item, amount) = goods[index++];
-                    BlueprintControlFilter filter = new BlueprintControlFilter { index = j + 1, count = amount };
-                    filter.signal.Set(item);
-                    controlBehavior.filters.Add(filter);
-                    if (index >= goods.Count) {
-                        break;
-                    }
-                }
+        return result;
+    }
 
-                if (last != null) {
-                    entity.Connect(last);
-                }
-
-                last = entity;
-            }
-
-            return ExportBlueprint(blueprint, copyToClipboard);
-        }
-
-        public static string ExportRequesterChests(string name, IReadOnlyList<(Item item, int amount)> goods, EntityContainer chest, bool copyToClipboard = true) {
-            if (chest.logisticSlotsCount <= 0) {
-                throw new NotSupportedException("Chest does not have logistic slots");
-            }
-
-            int combinatorCount = ((goods.Count - 1) / chest.logisticSlotsCount) + 1;
-            int offset = -chest.size * combinatorCount / 2;
-            BlueprintString blueprint = new BlueprintString(name);
-            int index = 0;
-            for (int i = 0; i < combinatorCount; i++) {
-                BlueprintEntity entity = new BlueprintEntity { index = i + 1, position = { x = (i * chest.size) + offset, y = 0 }, name = chest.name };
-                blueprint.blueprint.entities.Add(entity);
-                for (int j = 0; j < chest.logisticSlotsCount; j++) {
-                    var (item, amount) = goods[index++];
-                    BlueprintRequestFilter filter = new BlueprintRequestFilter { index = j + 1, count = amount, name = item.name };
-                    entity.requestFilters.Add(filter);
-                    if (index >= goods.Count) {
-                        break;
-                    }
+    public static string ExportConstantCombinators(string name, IReadOnlyList<(Goods item, int amount)> goods, bool copyToClipboard = true) {
+        int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
+        int offset = -combinatorCount / 2;
+        BlueprintString blueprint = new BlueprintString(name);
+        int index = 0;
+        BlueprintEntity? last = null;
+        for (int i = 0; i < combinatorCount; i++) {
+            BlueprintControlBehavior controlBehavior = new BlueprintControlBehavior();
+            BlueprintEntity entity = new BlueprintEntity { index = i + 1, position = { x = i + offset, y = 0 }, name = "constant-combinator", controlBehavior = controlBehavior };
+            blueprint.blueprint.entities.Add(entity);
+            for (int j = 0; j < Database.constantCombinatorCapacity; j++) {
+                var (item, amount) = goods[index++];
+                BlueprintControlFilter filter = new BlueprintControlFilter { index = j + 1, count = amount };
+                filter.signal.Set(item);
+                controlBehavior.filters.Add(filter);
+                if (index >= goods.Count) {
+                    break;
                 }
             }
 
-            return ExportBlueprint(blueprint, copyToClipboard);
+            if (last != null) {
+                entity.Connect(last);
+            }
+
+            last = entity;
         }
+
+        return ExportBlueprint(blueprint, copyToClipboard);
+    }
+
+    public static string ExportRequesterChests(string name, IReadOnlyList<(Item item, int amount)> goods, EntityContainer chest, bool copyToClipboard = true) {
+        if (chest.logisticSlotsCount <= 0) {
+            throw new NotSupportedException("Chest does not have logistic slots");
+        }
+
+        int combinatorCount = ((goods.Count - 1) / chest.logisticSlotsCount) + 1;
+        int offset = -chest.size * combinatorCount / 2;
+        BlueprintString blueprint = new BlueprintString(name);
+        int index = 0;
+        for (int i = 0; i < combinatorCount; i++) {
+            BlueprintEntity entity = new BlueprintEntity { index = i + 1, position = { x = (i * chest.size) + offset, y = 0 }, name = chest.name };
+            blueprint.blueprint.entities.Add(entity);
+            for (int j = 0; j < chest.logisticSlotsCount; j++) {
+                var (item, amount) = goods[index++];
+                BlueprintRequestFilter filter = new BlueprintRequestFilter { index = j + 1, count = amount, name = item.name };
+                entity.requestFilters.Add(filter);
+                if (index >= goods.Count) {
+                    break;
+                }
+            }
+        }
+
+        return ExportBlueprint(blueprint, copyToClipboard);
     }
 }

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -6,574 +6,573 @@ using System.Runtime.CompilerServices;
 using Yafc.UI;
 [assembly: InternalsVisibleTo("Yafc.Parser")]
 
-namespace Yafc.Model {
-    public interface IFactorioObjectWrapper {
-        string text { get; }
-        FactorioObject target { get; }
-        float amount { get; }
-    }
+namespace Yafc.Model;
+public interface IFactorioObjectWrapper {
+    string text { get; }
+    FactorioObject target { get; }
+    float amount { get; }
+}
 
-    internal enum FactorioObjectSortOrder {
-        SpecialGoods,
-        Items,
-        Fluids,
-        Recipes,
-        Mechanics,
-        Technologies,
-        Entities
-    }
+internal enum FactorioObjectSortOrder {
+    SpecialGoods,
+    Items,
+    Fluids,
+    Recipes,
+    Mechanics,
+    Technologies,
+    Entities
+}
 
-    public enum FactorioId { }
+public enum FactorioId { }
 
-    public abstract class FactorioObject : IFactorioObjectWrapper, IComparable<FactorioObject> {
-        public string? factorioType { get; internal set; }
-        public string name { get; internal set; } = null!; // null-forgiving: Initialized to non-null by GetObject.
-        public string typeDotName => type + '.' + name;
-        public string locName { get; internal set; } = null!; // null-forgiving: Copied from name if still null at the end of CalculateMaps
-        public string? locDescr { get; internal set; }
-        public FactorioIconPart[]? iconSpec { get; internal set; }
-        public Icon icon { get; internal set; }
-        public FactorioId id { get; internal set; }
-        internal abstract FactorioObjectSortOrder sortingOrder { get; }
-        public FactorioObjectSpecialType specialType { get; internal set; }
-        public abstract string type { get; }
-        FactorioObject IFactorioObjectWrapper.target => this;
-        float IFactorioObjectWrapper.amount => 1f;
+public abstract class FactorioObject : IFactorioObjectWrapper, IComparable<FactorioObject> {
+    public string? factorioType { get; internal set; }
+    public string name { get; internal set; } = null!; // null-forgiving: Initialized to non-null by GetObject.
+    public string typeDotName => type + '.' + name;
+    public string locName { get; internal set; } = null!; // null-forgiving: Copied from name if still null at the end of CalculateMaps
+    public string? locDescr { get; internal set; }
+    public FactorioIconPart[]? iconSpec { get; internal set; }
+    public Icon icon { get; internal set; }
+    public FactorioId id { get; internal set; }
+    internal abstract FactorioObjectSortOrder sortingOrder { get; }
+    public FactorioObjectSpecialType specialType { get; internal set; }
+    public abstract string type { get; }
+    FactorioObject IFactorioObjectWrapper.target => this;
+    float IFactorioObjectWrapper.amount => 1f;
 
-        string IFactorioObjectWrapper.text => locName;
+    string IFactorioObjectWrapper.text => locName;
 
-        public void FallbackLocalization(FactorioObject? other, string description) {
-            if (locName == null) {
-                if (other == null) {
-                    locName = name;
-                }
-                else {
-                    locName = other.locName;
-                    locDescr = description + " " + locName;
-                }
+    public void FallbackLocalization(FactorioObject? other, string description) {
+        if (locName == null) {
+            if (other == null) {
+                locName = name;
             }
-
-            if (iconSpec == null && other?.iconSpec != null) {
-                iconSpec = other.iconSpec;
+            else {
+                locName = other.locName;
+                locDescr = description + " " + locName;
             }
         }
 
-        public abstract void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp);
-
-        public override string ToString() {
-            return name;
-        }
-
-        public int CompareTo(FactorioObject? other) {
-            return DataUtils.DefaultOrdering.Compare(this, other);
-        }
-
-        public virtual bool showInExplorers => true;
-    }
-
-    public class FactorioIconPart(string path) {
-        public string path = path;
-        public float size = 32;
-        public float x, y, r = 1, g = 1, b = 1, a = 1;
-        public float scale = 1;
-
-        public bool IsSimple() {
-            return x == 0 && y == 0 && r == 1 && g == 1 && b == 1 && a == 1 && scale == 1;
+        if (iconSpec == null && other?.iconSpec != null) {
+            iconSpec = other.iconSpec;
         }
     }
 
-    [Flags]
-    public enum RecipeFlags {
-        UsesMiningProductivity = 1 << 0,
-        UsesFluidTemperature = 1 << 2,
-        ScaleProductionWithPower = 1 << 3,
-        LimitedByTickRate = 1 << 4,
+    public abstract void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp);
+
+    public override string ToString() {
+        return name;
     }
 
-    public abstract class RecipeOrTechnology : FactorioObject {
-        public EntityCrafter[] crafters { get; internal set; } = null!; // null-forgiving: Initialized by CalculateMaps
-        public Ingredient[] ingredients { get; internal set; } = null!; // null-forgiving: Initialized by LoadRecipeData, LoadTechnologyData, and after all calls to CreateSpecialRecipe
-        public Product[] products { get; internal set; } = null!; // null-forgiving: Initialized by LoadRecipeData, LoadTechnologyData, and after all calls to CreateSpecialRecipe
-        public Module[] modules { get; internal set; } = [];
-        public Entity? sourceEntity { get; internal set; }
-        public Goods? mainProduct { get; internal set; }
-        public float time { get; internal set; }
-        public bool enabled { get; internal set; }
-        public bool hidden { get; internal set; }
-        public RecipeFlags flags { get; internal set; }
-        public override string type => "Recipe";
-
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Recipes;
-
-        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
-            if (ingredients.Length > 0) {
-                temp.Clear();
-                foreach (var ingredient in ingredients) {
-                    if (ingredient.variants != null) {
-                        collector.Add(ingredient.variants, DependencyList.Flags.IngredientVariant);
-                    }
-                    else {
-                        temp.Add(ingredient.goods);
-                    }
-                }
-                if (temp.Count > 0) {
-                    collector.Add(temp, DependencyList.Flags.Ingredient);
-                }
-            }
-            collector.Add(crafters, DependencyList.Flags.CraftingEntity);
-            if (sourceEntity != null) {
-                collector.Add(new[] { sourceEntity.id }, DependencyList.Flags.SourceEntity);
-            }
-        }
-
-        public bool CanFit(int itemInputs, int fluidInputs, Goods[]? slots) {
-            foreach (var ingredient in ingredients) {
-                if (ingredient.goods is Item && --itemInputs < 0) {
-                    return false;
-                }
-
-                if (ingredient.goods is Fluid && --fluidInputs < 0) {
-                    return false;
-                }
-
-                if (slots != null && !slots.Contains(ingredient.goods)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        public virtual bool CanAcceptModule(Item _) => true;
+    public int CompareTo(FactorioObject? other) {
+        return DataUtils.DefaultOrdering.Compare(this, other);
     }
 
-    public enum FactorioObjectSpecialType {
-        Normal,
-        Voiding,
-        Barreling,
-        Stacking,
-        Pressurization,
-        Crating,
-    }
+    public virtual bool showInExplorers => true;
+}
 
-    public class Recipe : RecipeOrTechnology {
-        public Technology[] technologyUnlock { get; internal set; } = [];
-        public bool HasIngredientVariants() {
+public class FactorioIconPart(string path) {
+    public string path = path;
+    public float size = 32;
+    public float x, y, r = 1, g = 1, b = 1, a = 1;
+    public float scale = 1;
+
+    public bool IsSimple() {
+        return x == 0 && y == 0 && r == 1 && g == 1 && b == 1 && a == 1 && scale == 1;
+    }
+}
+
+[Flags]
+public enum RecipeFlags {
+    UsesMiningProductivity = 1 << 0,
+    UsesFluidTemperature = 1 << 2,
+    ScaleProductionWithPower = 1 << 3,
+    LimitedByTickRate = 1 << 4,
+}
+
+public abstract class RecipeOrTechnology : FactorioObject {
+    public EntityCrafter[] crafters { get; internal set; } = null!; // null-forgiving: Initialized by CalculateMaps
+    public Ingredient[] ingredients { get; internal set; } = null!; // null-forgiving: Initialized by LoadRecipeData, LoadTechnologyData, and after all calls to CreateSpecialRecipe
+    public Product[] products { get; internal set; } = null!; // null-forgiving: Initialized by LoadRecipeData, LoadTechnologyData, and after all calls to CreateSpecialRecipe
+    public Module[] modules { get; internal set; } = [];
+    public Entity? sourceEntity { get; internal set; }
+    public Goods? mainProduct { get; internal set; }
+    public float time { get; internal set; }
+    public bool enabled { get; internal set; }
+    public bool hidden { get; internal set; }
+    public RecipeFlags flags { get; internal set; }
+    public override string type => "Recipe";
+
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Recipes;
+
+    public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+        if (ingredients.Length > 0) {
+            temp.Clear();
             foreach (var ingredient in ingredients) {
                 if (ingredient.variants != null) {
-                    return true;
+                    collector.Add(ingredient.variants, DependencyList.Flags.IngredientVariant);
+                }
+                else {
+                    temp.Add(ingredient.goods);
                 }
             }
-
-            return false;
-        }
-
-        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
-            base.GetDependencies(collector, temp);
-            if (!enabled) {
-                collector.Add(technologyUnlock, DependencyList.Flags.TechnologyUnlock);
+            if (temp.Count > 0) {
+                collector.Add(temp, DependencyList.Flags.Ingredient);
             }
         }
-
-        public bool IsProductivityAllowed() {
-            foreach (var module in modules) {
-                if (module.moduleSpecification.productivity != 0f) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        public override bool CanAcceptModule(Item module) {
-            return modules.Contains(module);
+        collector.Add(crafters, DependencyList.Flags.CraftingEntity);
+        if (sourceEntity != null) {
+            collector.Add(new[] { sourceEntity.id }, DependencyList.Flags.SourceEntity);
         }
     }
 
-    public class Mechanics : Recipe {
-        internal FactorioObject source { get; set; } = null!; // null-forgiving: Set by CreateSpecialRecipe
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Mechanics;
-        public override string type => "Mechanics";
+    public bool CanFit(int itemInputs, int fluidInputs, Goods[]? slots) {
+        foreach (var ingredient in ingredients) {
+            if (ingredient.goods is Item && --itemInputs < 0) {
+                return false;
+            }
+
+            if (ingredient.goods is Fluid && --fluidInputs < 0) {
+                return false;
+            }
+
+            if (slots != null && !slots.Contains(ingredient.goods)) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    public class Ingredient : IFactorioObjectWrapper {
-        public readonly float amount;
-        public Goods goods { get; internal set; }
-        public Goods[]? variants { get; internal set; }
-        public TemperatureRange temperature { get; internal set; } = TemperatureRange.Any;
-        public Ingredient(Goods goods, float amount) {
-            this.goods = goods;
-            this.amount = amount;
-            if (goods is Fluid fluid) {
-                temperature = fluid.temperatureRange;
-            }
-        }
+    public virtual bool CanAcceptModule(Item _) => true;
+}
 
-        string IFactorioObjectWrapper.text {
-            get {
-                string text = goods.locName;
-                if (amount != 1f) {
-                    text = amount + "x " + text;
-                }
+public enum FactorioObjectSpecialType {
+    Normal,
+    Voiding,
+    Barreling,
+    Stacking,
+    Pressurization,
+    Crating,
+}
 
-                if (!temperature.IsAny()) {
-                    text += " (" + temperature + ")";
-                }
-
-                return text;
-            }
-        }
-
-        FactorioObject IFactorioObjectWrapper.target => goods;
-
-        float IFactorioObjectWrapper.amount => amount;
-
-        public bool ContainsVariant(Goods product) {
-            if (goods == product) {
+public class Recipe : RecipeOrTechnology {
+    public Technology[] technologyUnlock { get; internal set; } = [];
+    public bool HasIngredientVariants() {
+        foreach (var ingredient in ingredients) {
+            if (ingredient.variants != null) {
                 return true;
             }
+        }
 
-            if (variants != null) {
-                return Array.IndexOf(variants, product) >= 0;
-            }
+        return false;
+    }
 
-            return false;
+    public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+        base.GetDependencies(collector, temp);
+        if (!enabled) {
+            collector.Add(technologyUnlock, DependencyList.Flags.TechnologyUnlock);
         }
     }
 
-    public class Product : IFactorioObjectWrapper {
-        public readonly Goods goods;
-        internal readonly float amountMin;
-        internal readonly float amountMax;
-        internal readonly float probability;
-        public readonly float amount; // This is average amount including probability and range
-        internal float productivityAmount { get; private set; }
-
-        public void SetCatalyst(float catalyst) {
-            float catalyticMin = amountMin - catalyst;
-            float catalyticMax = amountMax - catalyst;
-            if (catalyticMax <= 0) {
-                productivityAmount = 0f;
-            }
-            else if (catalyticMin >= 0f) {
-                productivityAmount = (catalyticMin + catalyticMax) * 0.5f * probability;
-            }
-            else {
-                // TODO super duper rare case, might not be precise
-                productivityAmount = probability * catalyticMax * catalyticMax * 0.5f / (catalyticMax - catalyticMin);
-            }
-        }
-
-        internal float GetAmountForRow(RecipeRow row) => GetAmountPerRecipe(row.parameters.productivity) * (float)row.recipesPerSecond;
-        internal float GetAmountPerRecipe(float productivityBonus) => amount + (productivityBonus * productivityAmount);
-
-        public Product(Goods goods, float amount) {
-            this.goods = goods;
-            amountMin = amountMax = this.amount = productivityAmount = amount;
-            probability = 1f;
-        }
-
-        public Product(Goods goods, float min, float max, float probability) {
-            this.goods = goods;
-            amountMin = min;
-            amountMax = max;
-            this.probability = probability;
-            amount = productivityAmount = probability * (min + max) / 2;
-        }
-
-        public bool IsSimple => amountMin == amountMax && probability == 1f;
-
-        FactorioObject IFactorioObjectWrapper.target => goods;
-
-        string IFactorioObjectWrapper.text {
-            get {
-                string text = goods.locName;
-                if (amountMin != 1f || amountMax != 1f) {
-                    text = DataUtils.FormatAmount(amountMax, UnitOfMeasure.None) + "x " + text;
-                    if (amountMin != amountMax) {
-                        text = DataUtils.FormatAmount(amountMin, UnitOfMeasure.None) + "-" + text;
-                    }
-                }
-                if (probability != 1f) {
-                    text = DataUtils.FormatAmount(probability, UnitOfMeasure.Percent) + " " + text;
-                }
-
-                return text;
-            }
-        }
-        float IFactorioObjectWrapper.amount => amount;
-    }
-
-    // Abstract base for anything that can be produced or consumed by recipes (etc)
-    public abstract class Goods : FactorioObject {
-        public float fuelValue { get; internal set; }
-        public abstract bool isPower { get; }
-        public Fluid? fluid => this as Fluid;
-        public Recipe[] production { get; internal set; } = [];
-        public Recipe[] usages { get; internal set; } = [];
-        public FactorioObject[] miscSources { get; internal set; } = [];
-        public Entity[] fuelFor { get; internal set; } = [];
-        public abstract UnitOfMeasure flowUnitOfMeasure { get; }
-
-        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
-            collector.Add(production.Concat(miscSources).ToArray(), DependencyList.Flags.Source);
-        }
-
-        public virtual bool HasSpentFuel([MaybeNullWhen(false)] out Item spent) {
-            spent = null;
-            return false;
-        }
-    }
-
-    public class Item : Goods {
-        public Item? fuelResult { get; internal set; }
-        public int stackSize { get; internal set; }
-        public Entity? placeResult { get; internal set; }
-        public override bool isPower => false;
-        public override string type => "Item";
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Items;
-        public override UnitOfMeasure flowUnitOfMeasure => UnitOfMeasure.ItemPerSecond;
-
-        public override bool HasSpentFuel([NotNullWhen(true)] out Item? spent) {
-            spent = fuelResult;
-            return spent != null;
-        }
-    }
-
-    public class Module : Item {
-        public ModuleSpecification moduleSpecification { get; internal set; } = null!; // null-forgiving: Initialized by DeserializeItem.
-    }
-
-    public class Fluid : Goods {
-        public override string type => "Fluid";
-        public string originalName { get; internal set; } = null!; // name without temperature, null-forgiving: Initialized by DeserializeFluid.
-        public float heatCapacity { get; internal set; } = 1e-3f;
-        public TemperatureRange temperatureRange { get; internal set; }
-        public int temperature { get; internal set; }
-        public float heatValue { get; internal set; }
-        public List<Fluid>? variants { get; internal set; }
-        public override bool isPower => false;
-        public override UnitOfMeasure flowUnitOfMeasure => UnitOfMeasure.FluidPerSecond;
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Fluids;
-        internal Fluid Clone() => (Fluid)MemberwiseClone();
-
-        internal void SetTemperature(int temp) {
-            temperature = temp;
-            heatValue = (temp - temperatureRange.min) * heatCapacity;
-        }
-    }
-
-    public class Special : Goods {
-        internal string? virtualSignal { get; set; }
-        internal bool power;
-        internal bool isResearch;
-        public override bool isPower => power;
-        public override string type => isPower ? "Power" : "Special";
-        public override UnitOfMeasure flowUnitOfMeasure => isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.SpecialGoods;
-        public override bool showInExplorers => !isResearch;
-
-        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
-            if (isResearch) {
-                collector.Add(Database.technologies.all.ToArray(), DependencyList.Flags.Source);
-            }
-            else {
-                base.GetDependencies(collector, temp);
-            }
-        }
-    }
-
-    [Flags]
-    public enum AllowedEffects {
-        Speed = 1 << 0,
-        Productivity = 1 << 1,
-        Consumption = 1 << 2,
-        Pollution = 1 << 3,
-
-        All = Speed | Productivity | Consumption | Pollution,
-        None = 0
-    }
-
-    public class Entity : FactorioObject {
-        public Product[] loot { get; internal set; } = [];
-        public bool mapGenerated { get; internal set; }
-        public float mapGenDensity { get; internal set; }
-        public float power { get; internal set; }
-        public EntityEnergy energy { get; internal set; } = null!; // TODO: Prove that this is always properly initialized. (Do we need an EntityWithEnergy type?)
-        public Item[] itemsToPlace { get; internal set; } = null!; // null-forgiving: This is initialized in CalculateMaps.
-        public int size { get; internal set; }
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Entities;
-        public override string type => "Entity";
-
-        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
-            if (energy != null) {
-                collector.Add(energy.fuels, DependencyList.Flags.Fuel);
-            }
-
-            if (mapGenerated) {
-                return;
-            }
-
-            collector.Add(itemsToPlace, DependencyList.Flags.ItemToPlace);
-        }
-    }
-
-    public abstract class EntityWithModules : Entity {
-        public AllowedEffects allowedEffects { get; internal set; } = AllowedEffects.None;
-        public int moduleSlots { get; internal set; }
-
-        public static bool CanAcceptModule(ModuleSpecification module, AllowedEffects effects) {
-            // Check most common cases first
-            if (effects == AllowedEffects.All) {
+    public bool IsProductivityAllowed() {
+        foreach (var module in modules) {
+            if (module.moduleSpecification.productivity != 0f) {
                 return true;
             }
+        }
 
-            if (effects == (AllowedEffects.Consumption | AllowedEffects.Pollution | AllowedEffects.Speed)) {
-                return module.productivity == 0f;
+        return false;
+    }
+
+    public override bool CanAcceptModule(Item module) {
+        return modules.Contains(module);
+    }
+}
+
+public class Mechanics : Recipe {
+    internal FactorioObject source { get; set; } = null!; // null-forgiving: Set by CreateSpecialRecipe
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Mechanics;
+    public override string type => "Mechanics";
+}
+
+public class Ingredient : IFactorioObjectWrapper {
+    public readonly float amount;
+    public Goods goods { get; internal set; }
+    public Goods[]? variants { get; internal set; }
+    public TemperatureRange temperature { get; internal set; } = TemperatureRange.Any;
+    public Ingredient(Goods goods, float amount) {
+        this.goods = goods;
+        this.amount = amount;
+        if (goods is Fluid fluid) {
+            temperature = fluid.temperatureRange;
+        }
+    }
+
+    string IFactorioObjectWrapper.text {
+        get {
+            string text = goods.locName;
+            if (amount != 1f) {
+                text = amount + "x " + text;
             }
 
-            if (effects == AllowedEffects.None) {
-                return false;
-            }
-            // Check the rest
-            if (module.productivity != 0f && (effects & AllowedEffects.Productivity) == 0) {
-                return false;
+            if (!temperature.IsAny()) {
+                text += " (" + temperature + ")";
             }
 
-            if (module.consumption != 0f && (effects & AllowedEffects.Consumption) == 0) {
-                return false;
-            }
+            return text;
+        }
+    }
 
-            if (module.pollution != 0f && (effects & AllowedEffects.Pollution) == 0) {
-                return false;
-            }
+    FactorioObject IFactorioObjectWrapper.target => goods;
 
-            if (module.speed != 0f && (effects & AllowedEffects.Speed) == 0) {
-                return false;
-            }
+    float IFactorioObjectWrapper.amount => amount;
 
+    public bool ContainsVariant(Goods product) {
+        if (goods == product) {
             return true;
         }
 
-        public bool CanAcceptModule(ModuleSpecification module) {
-            return CanAcceptModule(module, allowedEffects);
+        if (variants != null) {
+            return Array.IndexOf(variants, product) >= 0;
+        }
+
+        return false;
+    }
+}
+
+public class Product : IFactorioObjectWrapper {
+    public readonly Goods goods;
+    internal readonly float amountMin;
+    internal readonly float amountMax;
+    internal readonly float probability;
+    public readonly float amount; // This is average amount including probability and range
+    internal float productivityAmount { get; private set; }
+
+    public void SetCatalyst(float catalyst) {
+        float catalyticMin = amountMin - catalyst;
+        float catalyticMax = amountMax - catalyst;
+        if (catalyticMax <= 0) {
+            productivityAmount = 0f;
+        }
+        else if (catalyticMin >= 0f) {
+            productivityAmount = (catalyticMin + catalyticMax) * 0.5f * probability;
+        }
+        else {
+            // TODO super duper rare case, might not be precise
+            productivityAmount = probability * catalyticMax * catalyticMax * 0.5f / (catalyticMax - catalyticMin);
         }
     }
 
-    public class EntityCrafter : EntityWithModules {
-        public int itemInputs { get; internal set; }
-        public int fluidInputs { get; internal set; } // fluid inputs for recipe, not including power
-        public Goods[]? inputs { get; internal set; }
-        public RecipeOrTechnology[] recipes { get; internal set; } = null!; // null-forgiving: Set in the first step of CalculateMaps
-        private float _craftingSpeed = 1;
-        public float craftingSpeed {
-            // The speed of a lab is baseSpeed * (1 + researchSpeedBonus) * Math.Min(0.2, 1 + moduleAndBeaconSpeedBonus)
-            get => _craftingSpeed * (1 + (factorioType == "lab" ? Project.current.settings.researchSpeedBonus : 0));
-            internal set => _craftingSpeed = value;
+    internal float GetAmountForRow(RecipeRow row) => GetAmountPerRecipe(row.parameters.productivity) * (float)row.recipesPerSecond;
+    internal float GetAmountPerRecipe(float productivityBonus) => amount + (productivityBonus * productivityAmount);
+
+    public Product(Goods goods, float amount) {
+        this.goods = goods;
+        amountMin = amountMax = this.amount = productivityAmount = amount;
+        probability = 1f;
+    }
+
+    public Product(Goods goods, float min, float max, float probability) {
+        this.goods = goods;
+        amountMin = min;
+        amountMax = max;
+        this.probability = probability;
+        amount = productivityAmount = probability * (min + max) / 2;
+    }
+
+    public bool IsSimple => amountMin == amountMax && probability == 1f;
+
+    FactorioObject IFactorioObjectWrapper.target => goods;
+
+    string IFactorioObjectWrapper.text {
+        get {
+            string text = goods.locName;
+            if (amountMin != 1f || amountMax != 1f) {
+                text = DataUtils.FormatAmount(amountMax, UnitOfMeasure.None) + "x " + text;
+                if (amountMin != amountMax) {
+                    text = DataUtils.FormatAmount(amountMin, UnitOfMeasure.None) + "-" + text;
+                }
+            }
+            if (probability != 1f) {
+                text = DataUtils.FormatAmount(probability, UnitOfMeasure.Percent) + " " + text;
+            }
+
+            return text;
         }
-        public float productivity { get; internal set; }
+    }
+    float IFactorioObjectWrapper.amount => amount;
+}
+
+// Abstract base for anything that can be produced or consumed by recipes (etc)
+public abstract class Goods : FactorioObject {
+    public float fuelValue { get; internal set; }
+    public abstract bool isPower { get; }
+    public Fluid? fluid => this as Fluid;
+    public Recipe[] production { get; internal set; } = [];
+    public Recipe[] usages { get; internal set; } = [];
+    public FactorioObject[] miscSources { get; internal set; } = [];
+    public Entity[] fuelFor { get; internal set; } = [];
+    public abstract UnitOfMeasure flowUnitOfMeasure { get; }
+
+    public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+        collector.Add(production.Concat(miscSources).ToArray(), DependencyList.Flags.Source);
     }
 
-    public class EntityInserter : Entity {
-        public bool isStackInserter { get; internal set; }
-        public float inserterSwingTime { get; internal set; }
+    public virtual bool HasSpentFuel([MaybeNullWhen(false)] out Item spent) {
+        spent = null;
+        return false;
     }
+}
 
-    public class EntityAccumulator : Entity {
-        public float accumulatorCapacity { get; internal set; }
+public class Item : Goods {
+    public Item? fuelResult { get; internal set; }
+    public int stackSize { get; internal set; }
+    public Entity? placeResult { get; internal set; }
+    public override bool isPower => false;
+    public override string type => "Item";
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Items;
+    public override UnitOfMeasure flowUnitOfMeasure => UnitOfMeasure.ItemPerSecond;
+
+    public override bool HasSpentFuel([NotNullWhen(true)] out Item? spent) {
+        spent = fuelResult;
+        return spent != null;
     }
+}
 
-    public class EntityBelt : Entity {
-        public float beltItemsPerSecond { get; internal set; }
+public class Module : Item {
+    public ModuleSpecification moduleSpecification { get; internal set; } = null!; // null-forgiving: Initialized by DeserializeItem.
+}
+
+public class Fluid : Goods {
+    public override string type => "Fluid";
+    public string originalName { get; internal set; } = null!; // name without temperature, null-forgiving: Initialized by DeserializeFluid.
+    public float heatCapacity { get; internal set; } = 1e-3f;
+    public TemperatureRange temperatureRange { get; internal set; }
+    public int temperature { get; internal set; }
+    public float heatValue { get; internal set; }
+    public List<Fluid>? variants { get; internal set; }
+    public override bool isPower => false;
+    public override UnitOfMeasure flowUnitOfMeasure => UnitOfMeasure.FluidPerSecond;
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Fluids;
+    internal Fluid Clone() => (Fluid)MemberwiseClone();
+
+    internal void SetTemperature(int temp) {
+        temperature = temp;
+        heatValue = (temp - temperatureRange.min) * heatCapacity;
     }
+}
 
-    public class EntityReactor : EntityCrafter {
-        public float reactorNeighborBonus { get; internal set; }
-    }
+public class Special : Goods {
+    internal string? virtualSignal { get; set; }
+    internal bool power;
+    internal bool isResearch;
+    public override bool isPower => power;
+    public override string type => isPower ? "Power" : "Special";
+    public override UnitOfMeasure flowUnitOfMeasure => isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.SpecialGoods;
+    public override bool showInExplorers => !isResearch;
 
-    public class EntityBeacon : EntityWithModules {
-        public float beaconEfficiency { get; internal set; }
-    }
-
-    public class EntityContainer : Entity {
-        public int inventorySize { get; internal set; }
-        public string? logisticMode { get; set; }
-        public int logisticSlotsCount { get; internal set; }
-    }
-
-    public class Technology : RecipeOrTechnology { // Technology is very similar to recipe
-        public float count { get; internal set; } // TODO support formula count
-        public Technology[] prerequisites { get; internal set; } = [];
-        public Recipe[] unlockRecipes { get; internal set; } = [];
-        internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Technologies;
-        public override string type => "Technology";
-
-        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+    public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+        if (isResearch) {
+            collector.Add(Database.technologies.all.ToArray(), DependencyList.Flags.Source);
+        }
+        else {
             base.GetDependencies(collector, temp);
-            if (prerequisites.Length > 0) {
-                collector.Add(prerequisites, DependencyList.Flags.TechnologyPrerequisites);
-            }
-
-            if (hidden && !enabled) {
-                collector.Add(Array.Empty<FactorioId>(), DependencyList.Flags.Hidden);
-            }
         }
     }
+}
 
-    public enum EntityEnergyType {
-        Void,
-        Electric,
-        Heat,
-        SolidFuel,
-        FluidFuel,
-        FluidHeat,
-        Labor, // Special energy type for character
+[Flags]
+public enum AllowedEffects {
+    Speed = 1 << 0,
+    Productivity = 1 << 1,
+    Consumption = 1 << 2,
+    Pollution = 1 << 3,
+
+    All = Speed | Productivity | Consumption | Pollution,
+    None = 0
+}
+
+public class Entity : FactorioObject {
+    public Product[] loot { get; internal set; } = [];
+    public bool mapGenerated { get; internal set; }
+    public float mapGenDensity { get; internal set; }
+    public float power { get; internal set; }
+    public EntityEnergy energy { get; internal set; } = null!; // TODO: Prove that this is always properly initialized. (Do we need an EntityWithEnergy type?)
+    public Item[] itemsToPlace { get; internal set; } = null!; // null-forgiving: This is initialized in CalculateMaps.
+    public int size { get; internal set; }
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Entities;
+    public override string type => "Entity";
+
+    public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+        if (energy != null) {
+            collector.Add(energy.fuels, DependencyList.Flags.Fuel);
+        }
+
+        if (mapGenerated) {
+            return;
+        }
+
+        collector.Add(itemsToPlace, DependencyList.Flags.ItemToPlace);
+    }
+}
+
+public abstract class EntityWithModules : Entity {
+    public AllowedEffects allowedEffects { get; internal set; } = AllowedEffects.None;
+    public int moduleSlots { get; internal set; }
+
+    public static bool CanAcceptModule(ModuleSpecification module, AllowedEffects effects) {
+        // Check most common cases first
+        if (effects == AllowedEffects.All) {
+            return true;
+        }
+
+        if (effects == (AllowedEffects.Consumption | AllowedEffects.Pollution | AllowedEffects.Speed)) {
+            return module.productivity == 0f;
+        }
+
+        if (effects == AllowedEffects.None) {
+            return false;
+        }
+        // Check the rest
+        if (module.productivity != 0f && (effects & AllowedEffects.Productivity) == 0) {
+            return false;
+        }
+
+        if (module.consumption != 0f && (effects & AllowedEffects.Consumption) == 0) {
+            return false;
+        }
+
+        if (module.pollution != 0f && (effects & AllowedEffects.Pollution) == 0) {
+            return false;
+        }
+
+        if (module.speed != 0f && (effects & AllowedEffects.Speed) == 0) {
+            return false;
+        }
+
+        return true;
     }
 
-    public class EntityEnergy {
-        public EntityEnergyType type { get; internal set; }
-        public TemperatureRange workingTemperature { get; internal set; }
-        public TemperatureRange acceptedTemperature { get; internal set; } = TemperatureRange.Any;
-        public float emissions { get; internal set; }
-        public float drain { get; internal set; }
-        public float fuelConsumptionLimit { get; internal set; } = float.PositiveInfinity;
-        public Goods[] fuels { get; internal set; } = [];
-        public float effectivity { get; internal set; } = 1f;
+    public bool CanAcceptModule(ModuleSpecification module) {
+        return CanAcceptModule(module, allowedEffects);
+    }
+}
+
+public class EntityCrafter : EntityWithModules {
+    public int itemInputs { get; internal set; }
+    public int fluidInputs { get; internal set; } // fluid inputs for recipe, not including power
+    public Goods[]? inputs { get; internal set; }
+    public RecipeOrTechnology[] recipes { get; internal set; } = null!; // null-forgiving: Set in the first step of CalculateMaps
+    private float _craftingSpeed = 1;
+    public float craftingSpeed {
+        // The speed of a lab is baseSpeed * (1 + researchSpeedBonus) * Math.Min(0.2, 1 + moduleAndBeaconSpeedBonus)
+        get => _craftingSpeed * (1 + (factorioType == "lab" ? Project.current.settings.researchSpeedBonus : 0));
+        internal set => _craftingSpeed = value;
+    }
+    public float productivity { get; internal set; }
+}
+
+public class EntityInserter : Entity {
+    public bool isStackInserter { get; internal set; }
+    public float inserterSwingTime { get; internal set; }
+}
+
+public class EntityAccumulator : Entity {
+    public float accumulatorCapacity { get; internal set; }
+}
+
+public class EntityBelt : Entity {
+    public float beltItemsPerSecond { get; internal set; }
+}
+
+public class EntityReactor : EntityCrafter {
+    public float reactorNeighborBonus { get; internal set; }
+}
+
+public class EntityBeacon : EntityWithModules {
+    public float beaconEfficiency { get; internal set; }
+}
+
+public class EntityContainer : Entity {
+    public int inventorySize { get; internal set; }
+    public string? logisticMode { get; set; }
+    public int logisticSlotsCount { get; internal set; }
+}
+
+public class Technology : RecipeOrTechnology { // Technology is very similar to recipe
+    public float count { get; internal set; } // TODO support formula count
+    public Technology[] prerequisites { get; internal set; } = [];
+    public Recipe[] unlockRecipes { get; internal set; } = [];
+    internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Technologies;
+    public override string type => "Technology";
+
+    public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+        base.GetDependencies(collector, temp);
+        if (prerequisites.Length > 0) {
+            collector.Add(prerequisites, DependencyList.Flags.TechnologyPrerequisites);
+        }
+
+        if (hidden && !enabled) {
+            collector.Add(Array.Empty<FactorioId>(), DependencyList.Flags.Hidden);
+        }
+    }
+}
+
+public enum EntityEnergyType {
+    Void,
+    Electric,
+    Heat,
+    SolidFuel,
+    FluidFuel,
+    FluidHeat,
+    Labor, // Special energy type for character
+}
+
+public class EntityEnergy {
+    public EntityEnergyType type { get; internal set; }
+    public TemperatureRange workingTemperature { get; internal set; }
+    public TemperatureRange acceptedTemperature { get; internal set; } = TemperatureRange.Any;
+    public float emissions { get; internal set; }
+    public float drain { get; internal set; }
+    public float fuelConsumptionLimit { get; internal set; } = float.PositiveInfinity;
+    public Goods[] fuels { get; internal set; } = [];
+    public float effectivity { get; internal set; } = 1f;
+}
+
+public class ModuleSpecification {
+    public float consumption { get; internal set; }
+    public float speed { get; internal set; }
+    public float productivity { get; internal set; }
+    public float pollution { get; internal set; }
+    public Recipe[]? limitation { get; internal set; }
+    public Recipe[]? limitation_blacklist { get; internal set; }
+}
+
+public struct TemperatureRange(int min, int max) {
+    public int min = min;
+    public int max = max;
+
+    public static readonly TemperatureRange Any = new TemperatureRange(int.MinValue, int.MaxValue);
+    public readonly bool IsAny() {
+        return min == int.MinValue && max == int.MaxValue;
     }
 
-    public class ModuleSpecification {
-        public float consumption { get; internal set; }
-        public float speed { get; internal set; }
-        public float productivity { get; internal set; }
-        public float pollution { get; internal set; }
-        public Recipe[]? limitation { get; internal set; }
-        public Recipe[]? limitation_blacklist { get; internal set; }
+    public readonly bool IsSingle() {
+        return min == max;
     }
 
-    public struct TemperatureRange(int min, int max) {
-        public int min = min;
-        public int max = max;
+    public TemperatureRange(int single) : this(single, single) { }
 
-        public static readonly TemperatureRange Any = new TemperatureRange(int.MinValue, int.MaxValue);
-        public readonly bool IsAny() {
-            return min == int.MinValue && max == int.MaxValue;
+    public override readonly string ToString() {
+        if (min == max) {
+            return min + "°";
         }
 
-        public readonly bool IsSingle() {
-            return min == max;
-        }
+        return min + "°-" + max + "°";
+    }
 
-        public TemperatureRange(int single) : this(single, single) { }
-
-        public override readonly string ToString() {
-            if (min == max) {
-                return min + "°";
-            }
-
-            return min + "°-" + max + "°";
-        }
-
-        public readonly bool Contains(int value) {
-            return min <= value && max >= value;
-        }
+    public readonly bool Contains(int value) {
+        return min <= value && max >= value;
     }
 }

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -10,693 +10,692 @@ using Google.OrTools.LinearSolver;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public static partial class DataUtils {
-        private static readonly ILogger logger = Logging.GetLogger(typeof(DataUtils));
+namespace Yafc.Model;
+public static partial class DataUtils {
+    private static readonly ILogger logger = Logging.GetLogger(typeof(DataUtils));
 
-        public static readonly FactorioObjectComparer<FactorioObject> DefaultOrdering = new FactorioObjectComparer<FactorioObject>((x, y) => {
-            float yFlow = y.ApproximateFlow();
-            float xFlow = x.ApproximateFlow();
-            if (xFlow != yFlow) {
-                return xFlow.CompareTo(yFlow);
-            }
-
-            Recipe? rx = x as Recipe;
-            Recipe? ry = y as Recipe;
-            if (rx != null || ry != null) {
-                float xWaste = rx?.RecipeWaste() ?? 0;
-                float yWaste = ry?.RecipeWaste() ?? 0;
-                return xWaste.CompareTo(yWaste);
-            }
-
-            return y.Cost().CompareTo(x.Cost());
-        });
-        public static readonly FactorioObjectComparer<Goods> FuelOrdering = new FactorioObjectComparer<Goods>((x, y) => {
-            if (x.fuelValue <= 0f && y.fuelValue <= 0f) {
-                if (x is Fluid fx && y is Fluid fy) {
-                    return (x.Cost() / fx.heatValue).CompareTo(y.Cost() / fy.heatValue);
-                }
-
-                return DefaultOrdering.Compare(x, y);
-            }
-            return (x.Cost() / x.fuelValue).CompareTo(y.Cost() / y.fuelValue);
-        });
-        public static readonly FactorioObjectComparer<Recipe> DefaultRecipeOrdering = new FactorioObjectComparer<Recipe>((x, y) => {
-            float yFlow = y.ApproximateFlow();
-            float xFlow = x.ApproximateFlow();
-            if (yFlow != xFlow) {
-                return yFlow > xFlow ? 1 : -1;
-            }
-
-            return x.RecipeWaste().CompareTo(y.RecipeWaste());
-        });
-        public static readonly FactorioObjectComparer<Recipe> AlreadySortedRecipe = new FactorioObjectComparer<Recipe>(DefaultRecipeOrdering.Compare);
-        public static readonly FactorioObjectComparer<EntityCrafter> CrafterOrdering = new FactorioObjectComparer<EntityCrafter>((x, y) => {
-            if (x.energy?.type != y.energy?.type) {
-                return Comparer<EntityEnergyType?>.Default.Compare(x.energy?.type, y.energy?.type);
-            }
-
-            if (x.craftingSpeed != y.craftingSpeed) {
-                return y.craftingSpeed.CompareTo(x.craftingSpeed);
-            }
-
-            return x.Cost().CompareTo(y.Cost());
-        });
-
-        public static FavoritesComparer<Goods> FavoriteFuel { get; private set; } = null!; // null-forgiving: Set by SetupForProject when loading a project.
-        public static FavoritesComparer<EntityCrafter> FavoriteCrafter { get; private set; } = null!; // null-forgiving: Set by SetupForProject when loading a project.
-        public static FavoritesComparer<Module> FavoriteModule { get; private set; } = null!; // null-forgiving: Set by SetupForProject when loading a project.
-
-        public static readonly IComparer<FactorioObject> DeterministicComparer = new FactorioObjectDeterministicComparer();
-        public static readonly IComparer<Fluid> FluidTemperatureComparer = new FluidTemperatureComparerImp();
-
-        public static Bits GetMilestoneOrder(FactorioId id) {
-            var ms = Milestones.Instance;
-            if (ms.GetMilestoneResult(id).IsClear()) {
-                // subtracting 1 of all zeros would set all bits ANDing this with lockedMask is equal to lockedMask
-                return ms.lockedMask;
-            }
-            return (ms.GetMilestoneResult(id) - 1) & ms.lockedMask;
+    public static readonly FactorioObjectComparer<FactorioObject> DefaultOrdering = new FactorioObjectComparer<FactorioObject>((x, y) => {
+        float yFlow = y.ApproximateFlow();
+        float xFlow = x.ApproximateFlow();
+        if (xFlow != yFlow) {
+            return xFlow.CompareTo(yFlow);
         }
 
-        public static string dataPath { get; internal set; } = "";
-        public static string modsPath { get; internal set; } = "";
-        public static bool expensiveRecipes { get; internal set; }
-        /// <summary>
-        /// If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
-        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
-        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
-        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.
-        /// </summary>
-        public static bool netProduction { get; internal set; }
-        public static Icon NoFuelIcon { get; internal set; }
-        public static Icon WarningIcon { get; internal set; }
-        public static Icon HandIcon { get; internal set; }
+        Recipe? rx = x as Recipe;
+        Recipe? ry = y as Recipe;
+        if (rx != null || ry != null) {
+            float xWaste = rx?.RecipeWaste() ?? 0;
+            float yWaste = ry?.RecipeWaste() ?? 0;
+            return xWaste.CompareTo(yWaste);
+        }
 
-        public static readonly Random random = new Random();
-
-        /// <summary>
-        /// Call to get the favorite or only useful item in the list, considering milestones, accessibility, and <see cref="FactorioObject.specialType"/>, provided there is exactly one such item.
-        /// If no best item exists, returns <see langword="null"/>. Always returns a tooltip applicable to using ctrl+click to add a recipe.
-        /// </summary>
-        /// <typeparam name="T">The element type of <paramref name="list"/>. This type must be derived from <see cref="FactorioObject"/>.</typeparam>
-        /// <param name="list">The array of items to search.</param>
-        /// <param name="recipeHint">Upon return, contains a hint that is applicable to using ctrl+click to add a recipe.
-        /// This will either suggest using ctrl+click, or explain why ctrl+click cannot be used.
-        /// It is not useful when <typeparamref name="T"/> is not <see cref="Recipe"/>.</param>
-        /// <returns>Items that are not accessible at the current milestones are always ignored. After those have been discarded, the return value is the first applicable entry in the following list:
-        /// <list type="bullet">
-        /// <item>The only normal item in <paramref name="list"/>.</item>
-        /// <item>The only normal user favorite in <paramref name="list"/>.</item>
-        /// <item>The only item in <paramref name="list"/>, considering both normal and special items.</item>
-        /// <item>The only user favorite in <paramref name="list"/>, considering both normal and special items.</item>
-        /// <item>If no previous options are applicable, <see langword="null"/>.</item>
-        /// </list></returns>
-        public static T? SelectSingle<T>(this T[] list, out string recipeHint) where T : FactorioObject {
-            return @internal(list, true, out recipeHint) ?? @internal(list, false, out recipeHint);
-
-            static T? @internal(T[] list, bool excludeSpecial, out string recipeHint) {
-                HashSet<FactorioObject> userFavorites = Project.current.preferences.favorites;
-                bool acceptOnlyFavorites = false;
-                T? element = null;
-                if (list.Any(t => t.IsAccessible())) {
-                    recipeHint = "Hint: Complete milestones to enable ctrl+click";
-                }
-                else {
-                    recipeHint = "Hint: Mark a recipe as accessible to enable ctrl+click";
-                }
-                foreach (T elem in list) {
-                    // Always consider normal entries. A list with two normals and one special should select nothing, rather than selecting the only special item.
-                    if (!elem.IsAccessibleWithCurrentMilestones() || (elem.specialType != FactorioObjectSpecialType.Normal && excludeSpecial)) {
-                        continue;
-                    }
-
-                    if (userFavorites.Contains(elem)) {
-                        if (!acceptOnlyFavorites || element == null) {
-                            element = elem;
-                            recipeHint = "Hint: ctrl+click to add your favorited recipe";
-                            acceptOnlyFavorites = true;
-                        }
-                        else {
-                            recipeHint = "Hint: Cannot ctrl+click with multiple favorited recipes";
-                            return null;
-                        }
-                    }
-                    else if (!acceptOnlyFavorites) {
-                        if (element == null) {
-                            element = elem;
-                            recipeHint = excludeSpecial ? "Hint: ctrl+click to add the accessible normal recipe" : "Hint: ctrl+click to add the accessible recipe";
-                        }
-                        else {
-                            element = null;
-                            recipeHint = "Hint: Set a favorite recipe to add it with ctrl+click";
-                            acceptOnlyFavorites = true;
-                        }
-                    }
-                }
-
-                return element;
+        return y.Cost().CompareTo(x.Cost());
+    });
+    public static readonly FactorioObjectComparer<Goods> FuelOrdering = new FactorioObjectComparer<Goods>((x, y) => {
+        if (x.fuelValue <= 0f && y.fuelValue <= 0f) {
+            if (x is Fluid fx && y is Fluid fy) {
+                return (x.Cost() / fx.heatValue).CompareTo(y.Cost() / fy.heatValue);
             }
+
+            return DefaultOrdering.Compare(x, y);
+        }
+        return (x.Cost() / x.fuelValue).CompareTo(y.Cost() / y.fuelValue);
+    });
+    public static readonly FactorioObjectComparer<Recipe> DefaultRecipeOrdering = new FactorioObjectComparer<Recipe>((x, y) => {
+        float yFlow = y.ApproximateFlow();
+        float xFlow = x.ApproximateFlow();
+        if (yFlow != xFlow) {
+            return yFlow > xFlow ? 1 : -1;
         }
 
-        public static void SetupForProject(Project project) {
-            FavoriteFuel = new FavoritesComparer<Goods>(project, FuelOrdering);
-            FavoriteCrafter = new FavoritesComparer<EntityCrafter>(project, CrafterOrdering);
-            FavoriteModule = new FavoritesComparer<Module>(project, DefaultOrdering);
+        return x.RecipeWaste().CompareTo(y.RecipeWaste());
+    });
+    public static readonly FactorioObjectComparer<Recipe> AlreadySortedRecipe = new FactorioObjectComparer<Recipe>(DefaultRecipeOrdering.Compare);
+    public static readonly FactorioObjectComparer<EntityCrafter> CrafterOrdering = new FactorioObjectComparer<EntityCrafter>((x, y) => {
+        if (x.energy?.type != y.energy?.type) {
+            return Comparer<EntityEnergyType?>.Default.Compare(x.energy?.type, y.energy?.type);
         }
 
-        private class FactorioObjectDeterministicComparer : IComparer<FactorioObject> {
-            public int Compare(FactorioObject? x, FactorioObject? y) => Comparer<int?>.Default.Compare((int?)x?.id, (int?)y?.id); // id comparison is deterministic because objects are sorted deterministically
+        if (x.craftingSpeed != y.craftingSpeed) {
+            return y.craftingSpeed.CompareTo(x.craftingSpeed);
         }
 
-        private class FluidTemperatureComparerImp : IComparer<Fluid> {
-            public int Compare(Fluid? x, Fluid? y) => Comparer<int?>.Default.Compare(x?.temperature, y?.temperature);
+        return x.Cost().CompareTo(y.Cost());
+    });
+
+    public static FavoritesComparer<Goods> FavoriteFuel { get; private set; } = null!; // null-forgiving: Set by SetupForProject when loading a project.
+    public static FavoritesComparer<EntityCrafter> FavoriteCrafter { get; private set; } = null!; // null-forgiving: Set by SetupForProject when loading a project.
+    public static FavoritesComparer<Module> FavoriteModule { get; private set; } = null!; // null-forgiving: Set by SetupForProject when loading a project.
+
+    public static readonly IComparer<FactorioObject> DeterministicComparer = new FactorioObjectDeterministicComparer();
+    public static readonly IComparer<Fluid> FluidTemperatureComparer = new FluidTemperatureComparerImp();
+
+    public static Bits GetMilestoneOrder(FactorioId id) {
+        var ms = Milestones.Instance;
+        if (ms.GetMilestoneResult(id).IsClear()) {
+            // subtracting 1 of all zeros would set all bits ANDing this with lockedMask is equal to lockedMask
+            return ms.lockedMask;
         }
+        return (ms.GetMilestoneResult(id) - 1) & ms.lockedMask;
+    }
 
-        public class FactorioObjectComparer<T>(Comparison<T> similarComparison) : IComparer<T> where T : FactorioObject {
-            private readonly Comparison<T> similarComparison = similarComparison;
+    public static string dataPath { get; internal set; } = "";
+    public static string modsPath { get; internal set; } = "";
+    public static bool expensiveRecipes { get; internal set; }
+    /// <summary>
+    /// If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+    /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+    /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+    /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.
+    /// </summary>
+    public static bool netProduction { get; internal set; }
+    public static Icon NoFuelIcon { get; internal set; }
+    public static Icon WarningIcon { get; internal set; }
+    public static Icon HandIcon { get; internal set; }
 
-            public int Compare(T? x, T? y) {
-                if (x == null) {
-                    return y == null ? 0 : 1;
-                }
+    public static readonly Random random = new Random();
 
-                if (y == null) {
-                    return -1;
-                }
+    /// <summary>
+    /// Call to get the favorite or only useful item in the list, considering milestones, accessibility, and <see cref="FactorioObject.specialType"/>, provided there is exactly one such item.
+    /// If no best item exists, returns <see langword="null"/>. Always returns a tooltip applicable to using ctrl+click to add a recipe.
+    /// </summary>
+    /// <typeparam name="T">The element type of <paramref name="list"/>. This type must be derived from <see cref="FactorioObject"/>.</typeparam>
+    /// <param name="list">The array of items to search.</param>
+    /// <param name="recipeHint">Upon return, contains a hint that is applicable to using ctrl+click to add a recipe.
+    /// This will either suggest using ctrl+click, or explain why ctrl+click cannot be used.
+    /// It is not useful when <typeparamref name="T"/> is not <see cref="Recipe"/>.</param>
+    /// <returns>Items that are not accessible at the current milestones are always ignored. After those have been discarded, the return value is the first applicable entry in the following list:
+    /// <list type="bullet">
+    /// <item>The only normal item in <paramref name="list"/>.</item>
+    /// <item>The only normal user favorite in <paramref name="list"/>.</item>
+    /// <item>The only item in <paramref name="list"/>, considering both normal and special items.</item>
+    /// <item>The only user favorite in <paramref name="list"/>, considering both normal and special items.</item>
+    /// <item>If no previous options are applicable, <see langword="null"/>.</item>
+    /// </list></returns>
+    public static T? SelectSingle<T>(this T[] list, out string recipeHint) where T : FactorioObject {
+        return @internal(list, true, out recipeHint) ?? @internal(list, false, out recipeHint);
 
-                if (x.specialType != y.specialType) {
-                    return x.specialType - y.specialType;
-                }
-
-                var msx = GetMilestoneOrder(x.id);
-                var msy = GetMilestoneOrder(y.id);
-                if (msx != msy) {
-                    return msx.CompareTo(msy);
-                }
-
-                return similarComparison(x, y);
+        static T? @internal(T[] list, bool excludeSpecial, out string recipeHint) {
+            HashSet<FactorioObject> userFavorites = Project.current.preferences.favorites;
+            bool acceptOnlyFavorites = false;
+            T? element = null;
+            if (list.Any(t => t.IsAccessible())) {
+                recipeHint = "Hint: Complete milestones to enable ctrl+click";
             }
-        }
-
-        public static Solver CreateSolver() {
-            Solver solver = Solver.CreateSolver("GLOP_LINEAR_PROGRAMMING");
-            // Relax solver parameters as returning imprecise solution is better than no solution at all
-            // It is not like we need 8 digits of precision after all, most computations in YAFC are done in singles
-            // see all properties here: https://github.com/google/or-tools/blob/stable/ortools/glop/parameters.proto
-            _ = solver.SetSolverSpecificParametersAsString("solution_feasibility_tolerance:1e-1");
-            return solver;
-        }
-
-        public static Solver.ResultStatus TrySolveWithDifferentSeeds(this Solver solver) {
-            for (int i = 0; i < 3; i++) {
-                Stopwatch time = Stopwatch.StartNew();
-                var result = solver.Solve();
-                logger.Information("Solution completed in {ElapsedTime}ms with result {result}", time.ElapsedMilliseconds, result);
-                if (result == Solver.ResultStatus.ABNORMAL) {
-                    _ = solver.SetSolverSpecificParametersAsString("random_seed:" + random.Next());
+            else {
+                recipeHint = "Hint: Mark a recipe as accessible to enable ctrl+click";
+            }
+            foreach (T elem in list) {
+                // Always consider normal entries. A list with two normals and one special should select nothing, rather than selecting the only special item.
+                if (!elem.IsAccessibleWithCurrentMilestones() || (elem.specialType != FactorioObjectSpecialType.Normal && excludeSpecial)) {
                     continue;
-                } /*else 
-                    VerySlowTryFindBadObjective(solver);*/
-                return result;
-            }
-            return Solver.ResultStatus.ABNORMAL;
-        }
-
-        public static void VerySlowTryFindBadObjective(Solver solver) {
-            var vars = solver.variables();
-            var obj = solver.Objective();
-            logger.Information(solver.ExportModelAsLpFormat(false));
-            foreach (var v in vars) {
-                obj.SetCoefficient(v, 0);
-                var result = solver.Solve();
-                if (result == Solver.ResultStatus.OPTIMAL) {
-                    logger.Warning("Infeasibility candidate: {candidate}", v.Name());
-                    return;
                 }
-            }
-        }
 
-        public static bool RemoveValue<TKey, TValue>(this Dictionary<TKey, TValue> dict, TValue value) where TKey : notnull {
-            var comparer = EqualityComparer<TValue>.Default;
-            foreach (var (k, v) in dict) {
-                if (comparer.Equals(v, value)) {
-                    _ = dict.Remove(k);
-                    return true;
+                if (userFavorites.Contains(elem)) {
+                    if (!acceptOnlyFavorites || element == null) {
+                        element = elem;
+                        recipeHint = "Hint: ctrl+click to add your favorited recipe";
+                        acceptOnlyFavorites = true;
+                    }
+                    else {
+                        recipeHint = "Hint: Cannot ctrl+click with multiple favorited recipes";
+                        return null;
+                    }
+                }
+                else if (!acceptOnlyFavorites) {
+                    if (element == null) {
+                        element = elem;
+                        recipeHint = excludeSpecial ? "Hint: ctrl+click to add the accessible normal recipe" : "Hint: ctrl+click to add the accessible recipe";
+                    }
+                    else {
+                        element = null;
+                        recipeHint = "Hint: Set a favorite recipe to add it with ctrl+click";
+                        acceptOnlyFavorites = true;
+                    }
                 }
             }
 
+            return element;
+        }
+    }
+
+    public static void SetupForProject(Project project) {
+        FavoriteFuel = new FavoritesComparer<Goods>(project, FuelOrdering);
+        FavoriteCrafter = new FavoritesComparer<EntityCrafter>(project, CrafterOrdering);
+        FavoriteModule = new FavoritesComparer<Module>(project, DefaultOrdering);
+    }
+
+    private class FactorioObjectDeterministicComparer : IComparer<FactorioObject> {
+        public int Compare(FactorioObject? x, FactorioObject? y) => Comparer<int?>.Default.Compare((int?)x?.id, (int?)y?.id); // id comparison is deterministic because objects are sorted deterministically
+    }
+
+    private class FluidTemperatureComparerImp : IComparer<Fluid> {
+        public int Compare(Fluid? x, Fluid? y) => Comparer<int?>.Default.Compare(x?.temperature, y?.temperature);
+    }
+
+    public class FactorioObjectComparer<T>(Comparison<T> similarComparison) : IComparer<T> where T : FactorioObject {
+        private readonly Comparison<T> similarComparison = similarComparison;
+
+        public int Compare(T? x, T? y) {
+            if (x == null) {
+                return y == null ? 0 : 1;
+            }
+
+            if (y == null) {
+                return -1;
+            }
+
+            if (x.specialType != y.specialType) {
+                return x.specialType - y.specialType;
+            }
+
+            var msx = GetMilestoneOrder(x.id);
+            var msy = GetMilestoneOrder(y.id);
+            if (msx != msy) {
+                return msx.CompareTo(msy);
+            }
+
+            return similarComparison(x, y);
+        }
+    }
+
+    public static Solver CreateSolver() {
+        Solver solver = Solver.CreateSolver("GLOP_LINEAR_PROGRAMMING");
+        // Relax solver parameters as returning imprecise solution is better than no solution at all
+        // It is not like we need 8 digits of precision after all, most computations in YAFC are done in singles
+        // see all properties here: https://github.com/google/or-tools/blob/stable/ortools/glop/parameters.proto
+        _ = solver.SetSolverSpecificParametersAsString("solution_feasibility_tolerance:1e-1");
+        return solver;
+    }
+
+    public static Solver.ResultStatus TrySolveWithDifferentSeeds(this Solver solver) {
+        for (int i = 0; i < 3; i++) {
+            Stopwatch time = Stopwatch.StartNew();
+            var result = solver.Solve();
+            logger.Information("Solution completed in {ElapsedTime}ms with result {result}", time.ElapsedMilliseconds, result);
+            if (result == Solver.ResultStatus.ABNORMAL) {
+                _ = solver.SetSolverSpecificParametersAsString("random_seed:" + random.Next());
+                continue;
+            } /*else
+                VerySlowTryFindBadObjective(solver);*/
+            return result;
+        }
+        return Solver.ResultStatus.ABNORMAL;
+    }
+
+    public static void VerySlowTryFindBadObjective(Solver solver) {
+        var vars = solver.variables();
+        var obj = solver.Objective();
+        logger.Information(solver.ExportModelAsLpFormat(false));
+        foreach (var v in vars) {
+            obj.SetCoefficient(v, 0);
+            var result = solver.Solve();
+            if (result == Solver.ResultStatus.OPTIMAL) {
+                logger.Warning("Infeasibility candidate: {candidate}", v.Name());
+                return;
+            }
+        }
+    }
+
+    public static bool RemoveValue<TKey, TValue>(this Dictionary<TKey, TValue> dict, TValue value) where TKey : notnull {
+        var comparer = EqualityComparer<TValue>.Default;
+        foreach (var (k, v) in dict) {
+            if (comparer.Equals(v, value)) {
+                _ = dict.Remove(k);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static void SetCoefficientCheck(this Constraint cstr, Variable var, float amount, ref Variable prev) {
+        if (prev == var) {
+            amount += (float)cstr.GetCoefficient(var);
+        }
+        else {
+            prev = var;
+        }
+
+        cstr.SetCoefficient(var, amount);
+    }
+
+    public class FavoritesComparer<T>(Project project, IComparer<T> def) : IComparer<T> where T : FactorioObject {
+        private readonly Dictionary<T, int> bumps = [];
+        private readonly IComparer<T> def = def;
+        private readonly HashSet<FactorioObject> userFavorites = project.preferences.favorites;
+
+        public void AddToFavorite(T x, int amount = 1) {
+            if (x == null) {
+                return;
+            }
+
+            _ = bumps.TryGetValue(x, out int prev);
+            bumps[x] = prev + amount;
+        }
+        public int Compare(T? x, T? y) {
+            if (x is null || y is null) {
+                return Comparer<object>.Default.Compare(x, y);
+            }
+
+            bool hasX = userFavorites.Contains(x);
+            bool hasY = userFavorites.Contains(y);
+            if (hasX != hasY) {
+                return hasY.CompareTo(hasX);
+            }
+
+            _ = bumps.TryGetValue(x, out int ix);
+            _ = bumps.TryGetValue(y, out int iy);
+            if (ix == iy) {
+                return def.Compare(x, y);
+            }
+
+            return iy.CompareTo(ix);
+        }
+    }
+
+    public static float GetProductionPerRecipe(this RecipeOrTechnology recipe, Goods product) {
+        float amount = 0f;
+        foreach (var p in recipe.products) {
+            if (p.goods == product) {
+                amount += p.amount;
+            }
+        }
+        return amount;
+    }
+
+    public static float GetProductionForRow(this RecipeRow row, Goods product) {
+        float amount = 0f;
+        foreach (var p in row.recipe.products) {
+            if (p.goods == product) {
+                amount += p.GetAmountForRow(row);
+            }
+        }
+        return amount;
+    }
+
+    public static float GetConsumptionPerRecipe(this RecipeOrTechnology recipe, Goods product) {
+        float amount = 0f;
+        foreach (var ingredient in recipe.ingredients) {
+            if (ingredient.ContainsVariant(product)) {
+                amount += ingredient.amount;
+            }
+        }
+        return amount;
+    }
+
+    public static float GetConsumptionForRow(this RecipeRow row, Goods ingredient) {
+        float amount = 0f;
+        foreach (var i in row.recipe.ingredients) {
+            if (i.ContainsVariant(ingredient)) {
+                amount += i.amount * (float)row.recipesPerSecond;
+            }
+        }
+        return amount;
+    }
+
+    public static FactorioObjectComparer<Recipe> GetRecipeComparerFor(Goods goods) => new FactorioObjectComparer<Recipe>((x, y) => (x.Cost(true) / x.GetProductionPerRecipe(goods)).CompareTo(y.Cost(true) / y.GetProductionPerRecipe(goods)));
+
+    public static T? AutoSelect<T>(this IEnumerable<T> list, IComparer<T>? comparer = default) {
+        if (comparer == null) {
+            if (DefaultOrdering is IComparer<T> defaultComparer) {
+                comparer = defaultComparer;
+            }
+            else {
+                comparer = Comparer<T>.Default;
+            }
+        }
+        bool first = true;
+        T? best = default;
+        foreach (var elem in list) {
+            if (first || comparer.Compare(best, elem) > 0) {
+                first = false;
+                best = elem;
+            }
+        }
+        return best;
+    }
+
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> values) where T : notnull => values.Where(x => x is not null)!; // null-forgiving: We're filtering out the nulls.
+
+    /// <summary>
+    /// As <see cref="Enumerable.SingleOrDefault{TSource}(IEnumerable{TSource})"/>, but multiple values do not cause an exception when
+    /// <paramref name="throwIfMultiple"/> is <see langword="false"/>. in that case, this method returns the default value for <typeparamref name="T"/> instead.
+    /// </summary>
+    public static T? SingleOrDefault<T>(this IEnumerable<T> values, bool throwIfMultiple)
+        => throwIfMultiple ? values.SingleOrDefault() : values.SingleOrDefault(null!, false); // null-forgiving: Our SingleOrDefault allows a null predicate when throwIfMultiple is false.
+
+    /// <summary>
+    /// As <see cref="Enumerable.SingleOrDefault{TSource}(IEnumerable{TSource}, Func{TSource, bool})"/>, but multiple matching values do not cause an exception when
+    /// <paramref name="throwIfMultiple"/> is <see langword="false"/>. in that case, this method returns the default value for <typeparamref name="T"/> instead.
+    /// </summary>
+    public static T? SingleOrDefault<T>(this IEnumerable<T> values, Func<T, bool> predicate, bool throwIfMultiple) {
+        if (throwIfMultiple) {
+            return values.SingleOrDefault(predicate);
+        }
+        bool found = false;
+        T? foundItem = default;
+        foreach (T item in values) {
+            if (predicate?.Invoke(item) ?? true) { // defend against null here to allow the other overload to pass null, rather than re-implementing the loop.
+                if (found) {
+                    return default;
+                }
+                found = true;
+                foundItem = item;
+            }
+        }
+        return foundItem;
+    }
+
+    public static void MoveListElementIndex<T>(this IList<T> list, int from, int to) {
+        var moving = list[from];
+        if (from > to) {
+            for (int i = from - 1; i >= to; i--) {
+                list[i + 1] = list[i];
+            }
+        }
+        else {
+            for (int i = from; i < to; i++) {
+                list[i] = list[i + 1];
+            }
+        }
+
+        list[to] = moving;
+    }
+
+    public static T RecordUndo<T>(this T target, bool visualOnly = false) where T : ModelObject {
+        target.CreateUndoSnapshot(visualOnly);
+        return target;
+    }
+
+    public static T RecordChange<T>(this T target) where T : ModelObject {
+        target.undo.RecordChange();
+        return target;
+    }
+
+    public static void MoveListElement<T>(this IList<T> list, T from, T to) where T : notnull {
+        int fromIndex = list.IndexOf(from);
+        int toIndex = list.IndexOf(to);
+        if (fromIndex >= 0 && toIndex >= 0) {
+            MoveListElementIndex(list, fromIndex, toIndex);
+        }
+    }
+
+    private const char NO = (char)0;
+    public static readonly (char suffix, float multiplier, string format)[] FormatSpec =
+    [
+        ('μ', 1e6f, "0.##"),
+        ('μ', 1e6f, "0.##"),
+        ('μ', 1e6f, "0.#"),
+        ('μ', 1e6f, "0"),
+        ('μ', 1e6f, "0"), // skipping m (milli-) because too similar to M (mega-)
+        (NO, 1e0f, "0.####"),
+        (NO, 1e0f, "0.###"),
+        (NO, 1e0f, "0.##"),
+        (NO, 1e0f, "0.##"), // [1-10]
+        (NO, 1e0f, "0.#"),
+        (NO, 1e0f, "0"),
+        ('k', 1e-3f, "0.##"),
+        ('k', 1e-3f, "0.#"),
+        ('k', 1e-3f, "0"),
+        ('M', 1e-6f, "0.##"),
+        ('M', 1e-6f, "0.#"),
+        ('M', 1e-6f, "0"),
+        ('G', 1e-9f, "0.##"),
+        ('G', 1e-9f, "0.#"),
+        ('G', 1e-9f, "0"),
+        ('T', 1e-12f, "0.##"),
+        ('T', 1e-12f, "0.#"),
+    ];
+
+    public static readonly (char suffix, float multiplier, string format)[] PreciseFormat =
+    [
+        ('μ', 1e6f, "0.000000"),
+        ('μ', 1e6f, "0.000000"),
+        ('μ', 1e6f, "0.00000"),
+        ('μ', 1e6f, "0.0000"),
+        ('μ', 1e6f, "0.0000"), // skipping m (milli-) because too similar to M (mega-)
+        (NO, 1e0f, "0.00000000"),
+        (NO, 1e0f, "0.0000000"),
+        (NO, 1e0f, "0.000000"),
+        (NO, 1e0f, "0.000000"), // [1-10]
+        (NO, 1e0f, "00.00000"),
+        (NO, 1e0f, "000.0000"),
+        (NO, 1e0f, "0 000.000"),
+        (NO, 1e0f, "00 000.00"),
+        (NO, 1e0f, "000 000.0"),
+        (NO, 1e0f, "0 000 000"),
+    ];
+
+    private static readonly StringBuilder amountBuilder = new StringBuilder();
+    public static bool HasFlags<T>(this T enumeration, T flags) where T : unmanaged, Enum {
+        int target = Unsafe.As<T, int>(ref flags);
+        return (Unsafe.As<T, int>(ref enumeration) & target) == target;
+    }
+
+    public static bool HasFlagAny<T>(this T enumeration, T flags) where T : unmanaged, Enum => (Unsafe.As<T, int>(ref enumeration) & Unsafe.As<T, int>(ref flags)) != 0;
+
+    public static string FormatTime(float time) {
+        _ = amountBuilder.Clear();
+        if (time < 10f) {
+            return $"{time:#.#} seconds";
+        }
+
+        if (time < 60f) {
+            return $"{time:#} seconds";
+        }
+
+        if (time < 600f) {
+            return $"{time / 60f:#.#} minutes";
+        }
+
+        if (time < 3600f) {
+            return $"{time / 60f:#} minutes";
+        }
+
+        if (time < 36000f) {
+            return $"{time / 3600f:#.#} hours";
+        }
+
+        return $"{time / 3600f:#} hours";
+    }
+
+    public static string FormatAmount(float amount, UnitOfMeasure unit, string? prefix = null, string? suffix = null, bool precise = false) {
+        var (multiplier, unitSuffix) = Project.current == null ? (1f, null) : Project.current.ResolveUnitOfMeasure(unit);
+        return FormatAmountRaw(amount, multiplier, unitSuffix, precise ? PreciseFormat : FormatSpec, prefix, suffix);
+    }
+
+    public static string FormatAmountRaw(float amount, float unitMultiplier, string? unitSuffix, (char suffix, float multiplier, string format)[] formatSpec, string? prefix = null, string? suffix = null) {
+        if (float.IsNaN(amount) || float.IsInfinity(amount)) {
+            return "-";
+        }
+
+        if (amount == 0f) {
+            return "0";
+        }
+
+        _ = amountBuilder.Clear();
+        if (prefix != null) {
+            _ = amountBuilder.Append(prefix);
+        }
+
+        if (amount < 0) {
+            _ = amountBuilder.Append('-');
+            amount = -amount;
+        }
+
+        amount *= unitMultiplier;
+        int idx = MathUtils.Clamp(MathUtils.Floor(MathF.Log10(amount)) + 8, 0, formatSpec.Length - 1);
+        var val = formatSpec[idx];
+        _ = amountBuilder.Append((amount * val.multiplier).ToString(val.format));
+        if (val.suffix != NO) {
+            _ = amountBuilder.Append(val.suffix);
+        }
+
+        _ = amountBuilder.Append(unitSuffix);
+        if (suffix != null) {
+            _ = amountBuilder.Append(suffix);
+        }
+
+        return amountBuilder.ToString();
+    }
+
+    [GeneratedRegex(@"^([-+0-9.e]+)([μukmgt]?)(/[hmst]|[WJsbp%]?)$", RegexOptions.IgnoreCase)]
+    private static partial Regex ParseAmountRegex();
+
+    /// <summary>
+    /// Tries to parse a user-supplied production rate into the standard internal format, as specified by <paramref name="unit"/>.
+    /// Values are accepted in any format that YAFC can display, and consist of:<br/>
+    /// * A floating point number<br/>
+    /// * An optional SI prefix from μukMGT, case sensitive only for u and μ. (For historical reasons, m and M are both mega-; the milli- prefix is unused and unavailable.)<br/>
+    /// * An optional W, J, s, b, p, %, /s, /m, /h, or /t, case insensitive and permitted when appropriate (e.g. W only for power; no b on fluids; p only if Project.current.preferences.fluidUnit has a value).
+    /// </summary>
+    /// <param name="str">The string to parse.</param>
+    /// <param name="amount">The parsed amount, or an unspecified value if the string could not be parsed.</param>
+    /// <param name="unit">The unit that applies to this value. <see cref="UnitOfMeasure.Celsius"/> is not supported.</param>
+    /// <returns>True if the string could be parsed as the specified unit, false otherwise.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="unit"/> is <see cref="UnitOfMeasure.Celsius"/>.</exception>
+    public static bool TryParseAmount(string str, out float amount, UnitOfMeasure unit) {
+        if (unit is UnitOfMeasure.Celsius) { throw new ArgumentException("Parsing to UnitOfMeasure.Celcius is not supported.", nameof(unit)); }
+
+        var (mul, _) = Project.current.ResolveUnitOfMeasure(unit);
+        float multiplier = unit is UnitOfMeasure.Megawatt or UnitOfMeasure.Megajoule ? 1e6f : 1f;
+
+        str = str.Replace(" ", ""); // Remove spaces to support parsing from the "10 000" precise format, and to simplify the regex.
+        var groups = ParseAmountRegex().Match(str).Groups;
+        amount = 0;
+        if (groups.Count < 4 || !float.TryParse(groups[1].Value, out amount)) {
             return false;
         }
 
-        public static void SetCoefficientCheck(this Constraint cstr, Variable var, float amount, ref Variable prev) {
-            if (prev == var) {
-                amount += (float)cstr.GetCoefficient(var);
-            }
-            else {
-                prev = var;
-            }
-
-            cstr.SetCoefficient(var, amount);
+        switch (groups[2].Value.SingleOrDefault()) { // μukMGT
+            case 'u' or 'μ':
+                multiplier = 1e-6f;
+                break;
+            case 'k' or 'K':
+                multiplier = 1e3f;
+                break;
+            case 'm' or 'M':
+                multiplier = 1e6f;
+                break;
+            case 'g' or 'G':
+                multiplier = 1e9f;
+                break;
+            case 't' or 'T':
+                multiplier = 1e12f;
+                break;
+            case 'U' or 'Μ' or 'K': // capital u or μ, or Kelvin symbol; false positive in the regex match
+                return false;
         }
 
-        public class FavoritesComparer<T>(Project project, IComparer<T> def) : IComparer<T> where T : FactorioObject {
-            private readonly Dictionary<T, int> bumps = [];
-            private readonly IComparer<T> def = def;
-            private readonly HashSet<FactorioObject> userFavorites = project.preferences.favorites;
-
-            public void AddToFavorite(T x, int amount = 1) {
-                if (x == null) {
-                    return;
+        switch (groups[3].Value.ToUpperInvariant()) { // JWsbp% or /hms
+            case "W" when unit is UnitOfMeasure.Megawatt:
+            case "J" when unit is UnitOfMeasure.Megajoule:
+                if (groups[2].Value.Length == 0) {
+                    // "10", "10M" and "10MW" should all be parsed as ten megawatts, but "10W" should be parsed as ten watts.
+                    multiplier = 1;
                 }
-
-                _ = bumps.TryGetValue(x, out int prev);
-                bumps[x] = prev + amount;
-            }
-            public int Compare(T? x, T? y) {
-                if (x is null || y is null) {
-                    return Comparer<object>.Default.Compare(x, y);
+                break;
+            case "S" when unit is UnitOfMeasure.Second:
+            case "%" when unit is UnitOfMeasure.Percent:
+                break;
+            case "W" or "J" or "S" or "%":
+                // Text units that don't match the expected units.
+                return false;
+            case not "" when unit is not UnitOfMeasure.ItemPerSecond and not UnitOfMeasure.FluidPerSecond and not UnitOfMeasure.PerSecond:
+                // Time-based modifiers on non-time-based units.
+                return false;
+            case "B":
+                if (unit != UnitOfMeasure.ItemPerSecond) {
+                    return false; // allow belts for items only
                 }
-
-                bool hasX = userFavorites.Contains(x);
-                bool hasY = userFavorites.Contains(y);
-                if (hasX != hasY) {
-                    return hasY.CompareTo(hasX);
+                if (Project.current.preferences.itemUnit > 0) {
+                    mul = 1 / Project.current.preferences.itemUnit;
                 }
-
-                _ = bumps.TryGetValue(x, out int ix);
-                _ = bumps.TryGetValue(y, out int iy);
-                if (ix == iy) {
-                    return def.Compare(x, y);
-                }
-
-                return iy.CompareTo(ix);
-            }
-        }
-
-        public static float GetProductionPerRecipe(this RecipeOrTechnology recipe, Goods product) {
-            float amount = 0f;
-            foreach (var p in recipe.products) {
-                if (p.goods == product) {
-                    amount += p.amount;
-                }
-            }
-            return amount;
-        }
-
-        public static float GetProductionForRow(this RecipeRow row, Goods product) {
-            float amount = 0f;
-            foreach (var p in row.recipe.products) {
-                if (p.goods == product) {
-                    amount += p.GetAmountForRow(row);
-                }
-            }
-            return amount;
-        }
-
-        public static float GetConsumptionPerRecipe(this RecipeOrTechnology recipe, Goods product) {
-            float amount = 0f;
-            foreach (var ingredient in recipe.ingredients) {
-                if (ingredient.ContainsVariant(product)) {
-                    amount += ingredient.amount;
-                }
-            }
-            return amount;
-        }
-
-        public static float GetConsumptionForRow(this RecipeRow row, Goods ingredient) {
-            float amount = 0f;
-            foreach (var i in row.recipe.ingredients) {
-                if (i.ContainsVariant(ingredient)) {
-                    amount += i.amount * (float)row.recipesPerSecond;
-                }
-            }
-            return amount;
-        }
-
-        public static FactorioObjectComparer<Recipe> GetRecipeComparerFor(Goods goods) => new FactorioObjectComparer<Recipe>((x, y) => (x.Cost(true) / x.GetProductionPerRecipe(goods)).CompareTo(y.Cost(true) / y.GetProductionPerRecipe(goods)));
-
-        public static T? AutoSelect<T>(this IEnumerable<T> list, IComparer<T>? comparer = default) {
-            if (comparer == null) {
-                if (DefaultOrdering is IComparer<T> defaultComparer) {
-                    comparer = defaultComparer;
+                else if (Project.current.preferences.defaultBelt is not null) {
+                    mul = 1 / Project.current.preferences.defaultBelt.beltItemsPerSecond;
                 }
                 else {
-                    comparer = Comparer<T>.Default;
+                    return false; // I don't know what to divide by when setting mul
                 }
-            }
-            bool first = true;
-            T? best = default;
-            foreach (var elem in list) {
-                if (first || comparer.Compare(best, elem) > 0) {
-                    first = false;
-                    best = elem;
-                }
-            }
-            return best;
-        }
-
-        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> values) where T : notnull => values.Where(x => x is not null)!; // null-forgiving: We're filtering out the nulls.
-
-        /// <summary>
-        /// As <see cref="Enumerable.SingleOrDefault{TSource}(IEnumerable{TSource})"/>, but multiple values do not cause an exception when
-        /// <paramref name="throwIfMultiple"/> is <see langword="false"/>. in that case, this method returns the default value for <typeparamref name="T"/> instead.
-        /// </summary>
-        public static T? SingleOrDefault<T>(this IEnumerable<T> values, bool throwIfMultiple)
-            => throwIfMultiple ? values.SingleOrDefault() : values.SingleOrDefault(null!, false); // null-forgiving: Our SingleOrDefault allows a null predicate when throwIfMultiple is false.
-
-        /// <summary>
-        /// As <see cref="Enumerable.SingleOrDefault{TSource}(IEnumerable{TSource}, Func{TSource, bool})"/>, but multiple matching values do not cause an exception when
-        /// <paramref name="throwIfMultiple"/> is <see langword="false"/>. in that case, this method returns the default value for <typeparamref name="T"/> instead.
-        /// </summary>
-        public static T? SingleOrDefault<T>(this IEnumerable<T> values, Func<T, bool> predicate, bool throwIfMultiple) {
-            if (throwIfMultiple) {
-                return values.SingleOrDefault(predicate);
-            }
-            bool found = false;
-            T? foundItem = default;
-            foreach (T item in values) {
-                if (predicate?.Invoke(item) ?? true) { // defend against null here to allow the other overload to pass null, rather than re-implementing the loop.
-                    if (found) {
-                        return default;
-                    }
-                    found = true;
-                    foundItem = item;
-                }
-            }
-            return foundItem;
-        }
-
-        public static void MoveListElementIndex<T>(this IList<T> list, int from, int to) {
-            var moving = list[from];
-            if (from > to) {
-                for (int i = from - 1; i >= to; i--) {
-                    list[i + 1] = list[i];
-                }
-            }
-            else {
-                for (int i = from; i < to; i++) {
-                    list[i] = list[i + 1];
-                }
-            }
-
-            list[to] = moving;
-        }
-
-        public static T RecordUndo<T>(this T target, bool visualOnly = false) where T : ModelObject {
-            target.CreateUndoSnapshot(visualOnly);
-            return target;
-        }
-
-        public static T RecordChange<T>(this T target) where T : ModelObject {
-            target.undo.RecordChange();
-            return target;
-        }
-
-        public static void MoveListElement<T>(this IList<T> list, T from, T to) where T : notnull {
-            int fromIndex = list.IndexOf(from);
-            int toIndex = list.IndexOf(to);
-            if (fromIndex >= 0 && toIndex >= 0) {
-                MoveListElementIndex(list, fromIndex, toIndex);
-            }
-        }
-
-        private const char NO = (char)0;
-        public static readonly (char suffix, float multiplier, string format)[] FormatSpec =
-        [
-            ('μ', 1e6f, "0.##"),
-            ('μ', 1e6f, "0.##"),
-            ('μ', 1e6f, "0.#"),
-            ('μ', 1e6f, "0"),
-            ('μ', 1e6f, "0"), // skipping m (milli-) because too similar to M (mega-)
-            (NO, 1e0f, "0.####"),
-            (NO, 1e0f, "0.###"),
-            (NO, 1e0f, "0.##"),
-            (NO, 1e0f, "0.##"), // [1-10]
-            (NO, 1e0f, "0.#"),
-            (NO, 1e0f, "0"),
-            ('k', 1e-3f, "0.##"),
-            ('k', 1e-3f, "0.#"),
-            ('k', 1e-3f, "0"),
-            ('M', 1e-6f, "0.##"),
-            ('M', 1e-6f, "0.#"),
-            ('M', 1e-6f, "0"),
-            ('G', 1e-9f, "0.##"),
-            ('G', 1e-9f, "0.#"),
-            ('G', 1e-9f, "0"),
-            ('T', 1e-12f, "0.##"),
-            ('T', 1e-12f, "0.#"),
-        ];
-
-        public static readonly (char suffix, float multiplier, string format)[] PreciseFormat =
-        [
-            ('μ', 1e6f, "0.000000"),
-            ('μ', 1e6f, "0.000000"),
-            ('μ', 1e6f, "0.00000"),
-            ('μ', 1e6f, "0.0000"),
-            ('μ', 1e6f, "0.0000"), // skipping m (milli-) because too similar to M (mega-)
-            (NO, 1e0f, "0.00000000"),
-            (NO, 1e0f, "0.0000000"),
-            (NO, 1e0f, "0.000000"),
-            (NO, 1e0f, "0.000000"), // [1-10]
-            (NO, 1e0f, "00.00000"),
-            (NO, 1e0f, "000.0000"),
-            (NO, 1e0f, "0 000.000"),
-            (NO, 1e0f, "00 000.00"),
-            (NO, 1e0f, "000 000.0"),
-            (NO, 1e0f, "0 000 000"),
-        ];
-
-        private static readonly StringBuilder amountBuilder = new StringBuilder();
-        public static bool HasFlags<T>(this T enumeration, T flags) where T : unmanaged, Enum {
-            int target = Unsafe.As<T, int>(ref flags);
-            return (Unsafe.As<T, int>(ref enumeration) & target) == target;
-        }
-
-        public static bool HasFlagAny<T>(this T enumeration, T flags) where T : unmanaged, Enum => (Unsafe.As<T, int>(ref enumeration) & Unsafe.As<T, int>(ref flags)) != 0;
-
-        public static string FormatTime(float time) {
-            _ = amountBuilder.Clear();
-            if (time < 10f) {
-                return $"{time:#.#} seconds";
-            }
-
-            if (time < 60f) {
-                return $"{time:#} seconds";
-            }
-
-            if (time < 600f) {
-                return $"{time / 60f:#.#} minutes";
-            }
-
-            if (time < 3600f) {
-                return $"{time / 60f:#} minutes";
-            }
-
-            if (time < 36000f) {
-                return $"{time / 3600f:#.#} hours";
-            }
-
-            return $"{time / 3600f:#} hours";
-        }
-
-        public static string FormatAmount(float amount, UnitOfMeasure unit, string? prefix = null, string? suffix = null, bool precise = false) {
-            var (multiplier, unitSuffix) = Project.current == null ? (1f, null) : Project.current.ResolveUnitOfMeasure(unit);
-            return FormatAmountRaw(amount, multiplier, unitSuffix, precise ? PreciseFormat : FormatSpec, prefix, suffix);
-        }
-
-        public static string FormatAmountRaw(float amount, float unitMultiplier, string? unitSuffix, (char suffix, float multiplier, string format)[] formatSpec, string? prefix = null, string? suffix = null) {
-            if (float.IsNaN(amount) || float.IsInfinity(amount)) {
-                return "-";
-            }
-
-            if (amount == 0f) {
-                return "0";
-            }
-
-            _ = amountBuilder.Clear();
-            if (prefix != null) {
-                _ = amountBuilder.Append(prefix);
-            }
-
-            if (amount < 0) {
-                _ = amountBuilder.Append('-');
-                amount = -amount;
-            }
-
-            amount *= unitMultiplier;
-            int idx = MathUtils.Clamp(MathUtils.Floor(MathF.Log10(amount)) + 8, 0, formatSpec.Length - 1);
-            var val = formatSpec[idx];
-            _ = amountBuilder.Append((amount * val.multiplier).ToString(val.format));
-            if (val.suffix != NO) {
-                _ = amountBuilder.Append(val.suffix);
-            }
-
-            _ = amountBuilder.Append(unitSuffix);
-            if (suffix != null) {
-                _ = amountBuilder.Append(suffix);
-            }
-
-            return amountBuilder.ToString();
-        }
-
-        [GeneratedRegex(@"^([-+0-9.e]+)([μukmgt]?)(/[hmst]|[WJsbp%]?)$", RegexOptions.IgnoreCase)]
-        private static partial Regex ParseAmountRegex();
-
-        /// <summary>
-        /// Tries to parse a user-supplied production rate into the standard internal format, as specified by <paramref name="unit"/>.
-        /// Values are accepted in any format that YAFC can display, and consist of:<br/>
-        /// * A floating point number<br/>
-        /// * An optional SI prefix from μukMGT, case sensitive only for u and μ. (For historical reasons, m and M are both mega-; the milli- prefix is unused and unavailable.)<br/>
-        /// * An optional W, J, s, b, p, %, /s, /m, /h, or /t, case insensitive and permitted when appropriate (e.g. W only for power; no b on fluids; p only if Project.current.preferences.fluidUnit has a value).
-        /// </summary>
-        /// <param name="str">The string to parse.</param>
-        /// <param name="amount">The parsed amount, or an unspecified value if the string could not be parsed.</param>
-        /// <param name="unit">The unit that applies to this value. <see cref="UnitOfMeasure.Celsius"/> is not supported.</param>
-        /// <returns>True if the string could be parsed as the specified unit, false otherwise.</returns>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="unit"/> is <see cref="UnitOfMeasure.Celsius"/>.</exception>
-        public static bool TryParseAmount(string str, out float amount, UnitOfMeasure unit) {
-            if (unit is UnitOfMeasure.Celsius) { throw new ArgumentException("Parsing to UnitOfMeasure.Celcius is not supported.", nameof(unit)); }
-
-            var (mul, _) = Project.current.ResolveUnitOfMeasure(unit);
-            float multiplier = unit is UnitOfMeasure.Megawatt or UnitOfMeasure.Megajoule ? 1e6f : 1f;
-
-            str = str.Replace(" ", ""); // Remove spaces to support parsing from the "10 000" precise format, and to simplify the regex.
-            var groups = ParseAmountRegex().Match(str).Groups;
-            amount = 0;
-            if (groups.Count < 4 || !float.TryParse(groups[1].Value, out amount)) {
-                return false;
-            }
-
-            switch (groups[2].Value.SingleOrDefault()) { // μukMGT
-                case 'u' or 'μ':
-                    multiplier = 1e-6f;
-                    break;
-                case 'k' or 'K':
-                    multiplier = 1e3f;
-                    break;
-                case 'm' or 'M':
-                    multiplier = 1e6f;
-                    break;
-                case 'g' or 'G':
-                    multiplier = 1e9f;
-                    break;
-                case 't' or 'T':
-                    multiplier = 1e12f;
-                    break;
-                case 'U' or 'Μ' or 'K': // capital u or μ, or Kelvin symbol; false positive in the regex match
-                    return false;
-            }
-
-            switch (groups[3].Value.ToUpperInvariant()) { // JWsbp% or /hms
-                case "W" when unit is UnitOfMeasure.Megawatt:
-                case "J" when unit is UnitOfMeasure.Megajoule:
-                    if (groups[2].Value.Length == 0) {
-                        // "10", "10M" and "10MW" should all be parsed as ten megawatts, but "10W" should be parsed as ten watts.
-                        multiplier = 1;
-                    }
-                    break;
-                case "S" when unit is UnitOfMeasure.Second:
-                case "%" when unit is UnitOfMeasure.Percent:
-                    break;
-                case "W" or "J" or "S" or "%":
-                    // Text units that don't match the expected units.
-                    return false;
-                case not "" when unit is not UnitOfMeasure.ItemPerSecond and not UnitOfMeasure.FluidPerSecond and not UnitOfMeasure.PerSecond:
-                    // Time-based modifiers on non-time-based units.
-                    return false;
-                case "B":
-                    if (unit != UnitOfMeasure.ItemPerSecond) {
-                        return false; // allow belts for items only
-                    }
-                    if (Project.current.preferences.itemUnit > 0) {
-                        mul = 1 / Project.current.preferences.itemUnit;
-                    }
-                    else if (Project.current.preferences.defaultBelt is not null) {
-                        mul = 1 / Project.current.preferences.defaultBelt.beltItemsPerSecond;
-                    }
-                    else {
-                        return false; // I don't know what to divide by when setting mul
-                    }
-                    break;
-                case "P":
-                    // allow pipes only for fluids, and only when the pipe throughput is specified
-                    if (unit != UnitOfMeasure.FluidPerSecond || Project.current.preferences.fluidUnit == 0) {
-                        return false;
-                    }
-                    mul = 1 / Project.current.preferences.fluidUnit;
-                    break;
-                case "/S":
-                    mul = 1;
-                    break;
-                case "/M":
-                    mul = 60;
-                    break;
-                case "/H":
-                    mul = 3600;
-                    break;
-                case "/T":
-                    (mul, _) = Project.current.preferences.GetPerTimeUnit();
-                    break;
-            }
-            multiplier /= mul;
-            amount *= multiplier;
-            return amount is <= 1e15f and >= -1e15f;
-        }
-
-        public static void WriteException(this TextWriter writer, Exception ex) {
-            writer.WriteLine("Exception: " + ex.Message);
-            writer.WriteLine(ex.StackTrace);
-        }
-
-        public static string? ReadLine(byte[] buffer, ref int position) {
-            if (position > buffer.Length) {
-                return null;
-            }
-
-            int nextPosition = Array.IndexOf(buffer, (byte)'\n', position);
-            if (nextPosition == -1) {
-                nextPosition = buffer.Length;
-            }
-
-            string str = Encoding.UTF8.GetString(buffer, position, nextPosition - position);
-            position = nextPosition + 1;
-            return str;
-        }
-
-        public static bool Match(this FactorioObject? obj, SearchQuery query) {
-            if (query.empty) {
-                return true;
-            }
-
-            if (obj == null) {
-                return false;
-            }
-
-            foreach (string token in query.tokens) {
-                if (obj.name.IndexOf(token, StringComparison.OrdinalIgnoreCase) < 0 &&
-                    obj.locName.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0 &&
-                    (obj.locDescr == null || obj.locDescr.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0) &&
-                    (obj.factorioType == null || obj.factorioType.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0)) {
+                break;
+            case "P":
+                // allow pipes only for fluids, and only when the pipe throughput is specified
+                if (unit != UnitOfMeasure.FluidPerSecond || Project.current.preferences.fluidUnit == 0) {
                     return false;
                 }
-            }
+                mul = 1 / Project.current.preferences.fluidUnit;
+                break;
+            case "/S":
+                mul = 1;
+                break;
+            case "/M":
+                mul = 60;
+                break;
+            case "/H":
+                mul = 3600;
+                break;
+            case "/T":
+                (mul, _) = Project.current.preferences.GetPerTimeUnit();
+                break;
+        }
+        multiplier /= mul;
+        amount *= multiplier;
+        return amount is <= 1e15f and >= -1e15f;
+    }
 
+    public static void WriteException(this TextWriter writer, Exception ex) {
+        writer.WriteLine("Exception: " + ex.Message);
+        writer.WriteLine(ex.StackTrace);
+    }
+
+    public static string? ReadLine(byte[] buffer, ref int position) {
+        if (position > buffer.Length) {
+            return null;
+        }
+
+        int nextPosition = Array.IndexOf(buffer, (byte)'\n', position);
+        if (nextPosition == -1) {
+            nextPosition = buffer.Length;
+        }
+
+        string str = Encoding.UTF8.GetString(buffer, position, nextPosition - position);
+        position = nextPosition + 1;
+        return str;
+    }
+
+    public static bool Match(this FactorioObject? obj, SearchQuery query) {
+        if (query.empty) {
             return true;
         }
 
-        public static bool IsSourceResource(this FactorioObject? obj) => Project.current.preferences.sourceResources.Contains(obj!); // null-forgiving: non-nullable collections are happy to report they don't contain null values.
+        if (obj == null) {
+            return false;
+        }
+
+        foreach (string token in query.tokens) {
+            if (obj.name.IndexOf(token, StringComparison.OrdinalIgnoreCase) < 0 &&
+                obj.locName.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0 &&
+                (obj.locDescr == null || obj.locDescr.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0) &&
+                (obj.factorioType == null || obj.factorioType.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    public enum UnitOfMeasure {
-        None,
-        Percent,
-        Second,
-        PerSecond,
-        ItemPerSecond,
-        FluidPerSecond,
-        Megawatt,
-        Megajoule,
-        Celsius,
-    }
+    public static bool IsSourceResource(this FactorioObject? obj) => Project.current.preferences.sourceResources.Contains(obj!); // null-forgiving: non-nullable collections are happy to report they don't contain null values.
+}
+
+public enum UnitOfMeasure {
+    None,
+    Percent,
+    Second,
+    PerSecond,
+    ItemPerSecond,
+    FluidPerSecond,
+    Megawatt,
+    Megajoule,
+    Celsius,
 }

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -4,256 +4,255 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace Yafc.Model {
-    public static class Database {
-        // null-forgiveness for all static properties here:
-        public static FactorioObject[] rootAccessible { get; internal set; } = null!;
-        public static Item[] allSciencePacks { get; internal set; } = null!;
-        public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
-        public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
-        public static Goods voidEnergy { get; internal set; } = null!;
-        public static Goods researchUnit { get; internal set; } = null!;
-        public static Goods electricity { get; internal set; } = null!;
-        public static Recipe electricityGeneration { get; internal set; } = null!;
-        public static Goods heat { get; internal set; } = null!;
-        public static Entity? character { get; internal set; }
-        public static EntityCrafter[] allCrafters { get; internal set; } = null!;
-        public static Module[] allModules { get; internal set; } = null!;
-        public static EntityBeacon[] allBeacons { get; internal set; } = null!;
-        public static EntityBelt[] allBelts { get; internal set; } = null!;
-        public static EntityInserter[] allInserters { get; internal set; } = null!;
-        public static EntityAccumulator[] allAccumulators { get; internal set; } = null!;
-        public static EntityContainer[] allContainers { get; internal set; } = null!;
-        public static FactorioIdRange<FactorioObject> objects { get; internal set; } = null!;
-        public static FactorioIdRange<Goods> goods { get; internal set; } = null!;
-        public static FactorioIdRange<Special> specials { get; internal set; } = null!;
-        public static FactorioIdRange<Item> items { get; internal set; } = null!;
-        public static FactorioIdRange<Fluid> fluids { get; internal set; } = null!;
-        public static FactorioIdRange<Recipe> recipes { get; internal set; } = null!;
-        public static FactorioIdRange<Mechanics> mechanics { get; internal set; } = null!;
-        public static FactorioIdRange<RecipeOrTechnology> recipesAndTechnologies { get; internal set; } = null!;
-        public static FactorioIdRange<Technology> technologies { get; internal set; } = null!;
-        public static FactorioIdRange<Entity> entities { get; internal set; } = null!;
-        public static int constantCombinatorCapacity { get; internal set; } = 18;
+namespace Yafc.Model;
+public static class Database {
+    // null-forgiveness for all static properties here:
+    public static FactorioObject[] rootAccessible { get; internal set; } = null!;
+    public static Item[] allSciencePacks { get; internal set; } = null!;
+    public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
+    public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
+    public static Goods voidEnergy { get; internal set; } = null!;
+    public static Goods researchUnit { get; internal set; } = null!;
+    public static Goods electricity { get; internal set; } = null!;
+    public static Recipe electricityGeneration { get; internal set; } = null!;
+    public static Goods heat { get; internal set; } = null!;
+    public static Entity? character { get; internal set; }
+    public static EntityCrafter[] allCrafters { get; internal set; } = null!;
+    public static Module[] allModules { get; internal set; } = null!;
+    public static EntityBeacon[] allBeacons { get; internal set; } = null!;
+    public static EntityBelt[] allBelts { get; internal set; } = null!;
+    public static EntityInserter[] allInserters { get; internal set; } = null!;
+    public static EntityAccumulator[] allAccumulators { get; internal set; } = null!;
+    public static EntityContainer[] allContainers { get; internal set; } = null!;
+    public static FactorioIdRange<FactorioObject> objects { get; internal set; } = null!;
+    public static FactorioIdRange<Goods> goods { get; internal set; } = null!;
+    public static FactorioIdRange<Special> specials { get; internal set; } = null!;
+    public static FactorioIdRange<Item> items { get; internal set; } = null!;
+    public static FactorioIdRange<Fluid> fluids { get; internal set; } = null!;
+    public static FactorioIdRange<Recipe> recipes { get; internal set; } = null!;
+    public static FactorioIdRange<Mechanics> mechanics { get; internal set; } = null!;
+    public static FactorioIdRange<RecipeOrTechnology> recipesAndTechnologies { get; internal set; } = null!;
+    public static FactorioIdRange<Technology> technologies { get; internal set; } = null!;
+    public static FactorioIdRange<Entity> entities { get; internal set; } = null!;
+    public static int constantCombinatorCapacity { get; internal set; } = 18;
 
-        /// <summary>
-        /// Returns the set of beacons filtered to only those that can accept at least one module.
-        /// </summary>
-        public static IEnumerable<EntityBeacon> usableBeacons => allBeacons.Where(b => allModules.Any(m => b.CanAcceptModule(m.moduleSpecification)));
+    /// <summary>
+    /// Returns the set of beacons filtered to only those that can accept at least one module.
+    /// </summary>
+    public static IEnumerable<EntityBeacon> usableBeacons => allBeacons.Where(b => allModules.Any(m => b.CanAcceptModule(m.moduleSpecification)));
 
-        /// <summary>
-        /// Fetches a module that can be used in this beacon, or <see langword="null"/> if no beacon was specified or no module could be found.
-        /// </summary>
-        /// <param name="beacon">The beacon to receive a module. If <see langword="null"/>, <paramref name="module"/> will be set to null and this method will return <see langword="false"/>.</param>
-        /// <param name="module">A module that can be placed in that beacon, if such a module exists.</param>
-        /// <returns><see langword="true"/> if a module could be found, or <see langword="false"/> if the supplied beacon does not accept any modules or was <see langword="null"/>.</returns>
-        public static bool GetDefaultModuleFor(EntityBeacon? beacon, [NotNullWhen(true)] out Module? module) {
-            module = allModules.FirstOrDefault(m => EntityWithModules.CanAcceptModule(m.moduleSpecification, beacon?.allowedEffects ?? AllowedEffects.None));
-            return module != null;
+    /// <summary>
+    /// Fetches a module that can be used in this beacon, or <see langword="null"/> if no beacon was specified or no module could be found.
+    /// </summary>
+    /// <param name="beacon">The beacon to receive a module. If <see langword="null"/>, <paramref name="module"/> will be set to null and this method will return <see langword="false"/>.</param>
+    /// <param name="module">A module that can be placed in that beacon, if such a module exists.</param>
+    /// <returns><see langword="true"/> if a module could be found, or <see langword="false"/> if the supplied beacon does not accept any modules or was <see langword="null"/>.</returns>
+    public static bool GetDefaultModuleFor(EntityBeacon? beacon, [NotNullWhen(true)] out Module? module) {
+        module = allModules.FirstOrDefault(m => EntityWithModules.CanAcceptModule(m.moduleSpecification, beacon?.allowedEffects ?? AllowedEffects.None));
+        return module != null;
+    }
+
+    public static FactorioObject? FindClosestVariant(string id) {
+        string baseId;
+        int temperature;
+        int splitter = id.IndexOf('@');
+        if (splitter >= 0) {
+            baseId = id[..splitter];
+            _ = int.TryParse(id[(splitter + 1)..], out temperature);
+        }
+        else {
+            baseId = id;
+            temperature = 0;
         }
 
-        public static FactorioObject? FindClosestVariant(string id) {
-            string baseId;
-            int temperature;
-            int splitter = id.IndexOf('@');
-            if (splitter >= 0) {
-                baseId = id[..splitter];
-                _ = int.TryParse(id[(splitter + 1)..], out temperature);
-            }
-            else {
-                baseId = id;
-                temperature = 0;
-            }
+        if (objectsByTypeName.TryGetValue(baseId, out var result)) {
+            return result;
+        }
 
-            if (objectsByTypeName.TryGetValue(baseId, out var result)) {
-                return result;
-            }
-
-            if (fluidVariants.TryGetValue(baseId, out var variants)) {
-                var prev = variants[0];
-                for (int i = 1; i < variants.Count; i++) {
-                    var cur = variants[i];
-                    if (cur.temperature >= temperature) {
-                        return cur.temperature - temperature > temperature - prev.temperature ? prev : cur;
-                    }
-
-                    prev = cur;
+        if (fluidVariants.TryGetValue(baseId, out var variants)) {
+            var prev = variants[0];
+            for (int i = 1; i < variants.Count; i++) {
+                var cur = variants[i];
+                if (cur.temperature >= temperature) {
+                    return cur.temperature - temperature > temperature - prev.temperature ? prev : cur;
                 }
-                return prev;
-            }
 
-            return null;
+                prev = cur;
+            }
+            return prev;
+        }
+
+        return null;
+    }
+}
+
+// Since Factorio objects are sorted by type, objects of one type always occupy continuous range.
+// Because of that we can replace Dictionary<SomeFactorioObjectSubtype, T> with just plain array indexed with object id with range offset
+// This is mostly useful for analysis algorithms that needs a bunch of these constructs
+public class FactorioIdRange<T> where T : FactorioObject {
+    internal readonly int start;
+    public int count { get; }
+    public T[] all { get; }
+    public IEnumerable<T> explorable => all.Where(o => o.showInExplorers);
+
+    public FactorioIdRange(int start, int end, List<FactorioObject> source) {
+        this.start = start;
+        count = end - start;
+        all = new T[count];
+        for (int i = 0; i < count; i++) {
+            all[i] = (T)source[i + start];
         }
     }
 
-    // Since Factorio objects are sorted by type, objects of one type always occupy continuous range.
-    // Because of that we can replace Dictionary<SomeFactorioObjectSubtype, T> with just plain array indexed with object id with range offset
-    // This is mostly useful for analysis algorithms that needs a bunch of these constructs
-    public class FactorioIdRange<T> where T : FactorioObject {
-        internal readonly int start;
-        public int count { get; }
-        public T[] all { get; }
-        public IEnumerable<T> explorable => all.Where(o => o.showInExplorers);
+    public T this[int i] => all[i];
+    public T this[FactorioId id] => all[(int)id - start];
 
-        public FactorioIdRange(int start, int end, List<FactorioObject> source) {
-            this.start = start;
-            count = end - start;
-            all = new T[count];
-            for (int i = 0; i < count; i++) {
-                all[i] = (T)source[i + start];
-            }
+    public Mapping<T, TValue> CreateMapping<TValue>() {
+        return new Mapping<T, TValue>(this);
+    }
+
+    public Mapping<T, TOther, TValue> CreateMapping<TOther, TValue>(FactorioIdRange<TOther> other) where TOther : FactorioObject {
+        return new Mapping<T, TOther, TValue>(this, other);
+    }
+
+    public Mapping<T, TValue> CreateMapping<TValue>(Func<T, TValue> mapFunc) {
+        var map = CreateMapping<TValue>();
+        foreach (var o in all) {
+            map[o] = mapFunc(o);
         }
 
-        public T this[int i] => all[i];
-        public T this[FactorioId id] => all[(int)id - start];
+        return map;
+    }
+}
 
-        public Mapping<T, TValue> CreateMapping<TValue>() {
-            return new Mapping<T, TValue>(this);
+// Mapping[TKey, TValue] is almost like a dictionary where TKey is FactorioObject but it is an array wrapper and therefore very fast. This is preferable way to add custom properties to FactorioObjects
+public readonly struct Mapping<TKey, TValue>(FactorioIdRange<TKey> source) : IDictionary<TKey, TValue> where TKey : FactorioObject {
+    private readonly int offset = source.start;
+    private readonly FactorioIdRange<TKey> source = source;
+
+    public void Add(TKey key, TValue value) {
+        this[key] = value;
+    }
+
+    public bool ContainsKey(TKey key) {
+        return true;
+    }
+
+    public bool Remove(TKey key) {
+        throw new NotSupportedException();
+    }
+
+    public bool TryGetValue(TKey key, out TValue value) {
+        value = this[key];
+        return true;
+    }
+
+    TValue IDictionary<TKey, TValue>.this[TKey key] {
+        get => this[key];
+        set => this[key] = value;
+    }
+
+    public Mapping<TKey, TOther> Remap<TOther>(Func<TKey, TValue, TOther> remap) {
+        var remapped = source.CreateMapping<TOther>();
+        foreach (var key in source.all) {
+            remapped[key] = remap(key, this[key]);
         }
 
-        public Mapping<T, TOther, TValue> CreateMapping<TOther, TValue>(FactorioIdRange<TOther> other) where TOther : FactorioObject {
-            return new Mapping<T, TOther, TValue>(this, other);
-        }
+        return remapped;
+    }
 
-        public Mapping<T, TValue> CreateMapping<TValue>(Func<T, TValue> mapFunc) {
-            var map = CreateMapping<TValue>();
-            foreach (var o in all) {
-                map[o] = mapFunc(o);
-            }
+    public ref TValue this[TKey index] => ref Values[(int)index.id - offset];
+    public ref TValue this[FactorioId id] => ref Values[(int)(id - offset)];
+    //public ref TValue this[int id] => ref data[id];
+    public void Clear() {
+        Array.Clear(Values, 0, Values.Length);
+    }
 
-            return map;
+    public bool Remove(KeyValuePair<TKey, TValue> item) {
+        return Remove(item.Key);
+    }
+
+    public int Count => Values.Length;
+    public bool IsReadOnly => false;
+    public TKey[] Keys => source.all;
+    public TValue[] Values { get; } = new TValue[source.count];
+    ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
+    ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    public Enumerator GetEnumerator() {
+        return new Enumerator(this);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    public void Add(KeyValuePair<TKey, TValue> item) {
+        this[item.Key] = item.Value;
+    }
+
+    public bool Contains(KeyValuePair<TKey, TValue> item) {
+        return EqualityComparer<TValue>.Default.Equals(this[item.Key], item.Value);
+    }
+
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) {
+        for (int i = 0; i < Values.Length; i++) {
+            array[i + arrayIndex] = new KeyValuePair<TKey, TValue>(source[i], Values[i]);
         }
     }
 
-    // Mapping[TKey, TValue] is almost like a dictionary where TKey is FactorioObject but it is an array wrapper and therefore very fast. This is preferable way to add custom properties to FactorioObjects
-    public readonly struct Mapping<TKey, TValue>(FactorioIdRange<TKey> source) : IDictionary<TKey, TValue> where TKey : FactorioObject {
-        private readonly int offset = source.start;
-        private readonly FactorioIdRange<TKey> source = source;
-
-        public void Add(TKey key, TValue value) {
-            this[key] = value;
+    public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>> {
+        private int index;
+        private readonly TKey[] keys;
+        private readonly TValue[] values;
+        internal Enumerator(Mapping<TKey, TValue> mapping) {
+            index = -1;
+            keys = mapping.source.all;
+            values = mapping.Values;
+        }
+        public bool MoveNext() {
+            return ++index < keys.Length;
         }
 
-        public bool ContainsKey(TKey key) {
-            return true;
+        public void Reset() {
+            index = -1;
         }
 
-        public bool Remove(TKey key) {
-            throw new NotSupportedException();
+        public readonly KeyValuePair<TKey, TValue> Current => new KeyValuePair<TKey, TValue>(keys[index], values[index]);
+        readonly object IEnumerator.Current => Current;
+        public readonly void Dispose() { }
+    }
+}
+
+public readonly struct Mapping<TKey1, TKey2, TValue> where TKey1 : FactorioObject where TKey2 : FactorioObject {
+    private readonly int offset1, offset2, count1;
+    private readonly TValue[] data;
+    internal Mapping(FactorioIdRange<TKey1> key1, FactorioIdRange<TKey2> key2) {
+        offset1 = key1.start;
+        offset2 = key2.start;
+        count1 = key1.count;
+        data = new TValue[count1 * key2.count];
+    }
+    public ref TValue this[TKey1 x, TKey2 y] => ref data[(((int)x.id - offset1) * count1) + ((int)y.id - offset2)];
+
+    public void CopyRow(TKey1 from, TKey1 to) {
+        if (from == to) {
+            return;
         }
 
-        public bool TryGetValue(TKey key, out TValue value) {
-            value = this[key];
-            return true;
-        }
-
-        TValue IDictionary<TKey, TValue>.this[TKey key] {
-            get => this[key];
-            set => this[key] = value;
-        }
-
-        public Mapping<TKey, TOther> Remap<TOther>(Func<TKey, TValue, TOther> remap) {
-            var remapped = source.CreateMapping<TOther>();
-            foreach (var key in source.all) {
-                remapped[key] = remap(key, this[key]);
-            }
-
-            return remapped;
-        }
-
-        public ref TValue this[TKey index] => ref Values[(int)index.id - offset];
-        public ref TValue this[FactorioId id] => ref Values[(int)(id - offset)];
-        //public ref TValue this[int id] => ref data[id];
-        public void Clear() {
-            Array.Clear(Values, 0, Values.Length);
-        }
-
-        public bool Remove(KeyValuePair<TKey, TValue> item) {
-            return Remove(item.Key);
-        }
-
-        public int Count => Values.Length;
-        public bool IsReadOnly => false;
-        public TKey[] Keys => source.all;
-        public TValue[] Values { get; } = new TValue[source.count];
-        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
-        ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
-        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() {
-            return GetEnumerator();
-        }
-
-        public Enumerator GetEnumerator() {
-            return new Enumerator(this);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() {
-            return GetEnumerator();
-        }
-
-        public void Add(KeyValuePair<TKey, TValue> item) {
-            this[item.Key] = item.Value;
-        }
-
-        public bool Contains(KeyValuePair<TKey, TValue> item) {
-            return EqualityComparer<TValue>.Default.Equals(this[item.Key], item.Value);
-        }
-
-        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) {
-            for (int i = 0; i < Values.Length; i++) {
-                array[i + arrayIndex] = new KeyValuePair<TKey, TValue>(source[i], Values[i]);
-            }
-        }
-
-        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>> {
-            private int index;
-            private readonly TKey[] keys;
-            private readonly TValue[] values;
-            internal Enumerator(Mapping<TKey, TValue> mapping) {
-                index = -1;
-                keys = mapping.source.all;
-                values = mapping.Values;
-            }
-            public bool MoveNext() {
-                return ++index < keys.Length;
-            }
-
-            public void Reset() {
-                index = -1;
-            }
-
-            public readonly KeyValuePair<TKey, TValue> Current => new KeyValuePair<TKey, TValue>(keys[index], values[index]);
-            readonly object IEnumerator.Current => Current;
-            public readonly void Dispose() { }
-        }
+        int fromId = ((int)from.id - offset1) * count1;
+        int toId = ((int)to.id - offset1) * count1;
+        Array.Copy(data, fromId, data, toId, count1);
     }
 
-    public readonly struct Mapping<TKey1, TKey2, TValue> where TKey1 : FactorioObject where TKey2 : FactorioObject {
-        private readonly int offset1, offset2, count1;
-        private readonly TValue[] data;
-        internal Mapping(FactorioIdRange<TKey1> key1, FactorioIdRange<TKey2> key2) {
-            offset1 = key1.start;
-            offset2 = key2.start;
-            count1 = key1.count;
-            data = new TValue[count1 * key2.count];
-        }
-        public ref TValue this[TKey1 x, TKey2 y] => ref data[(((int)x.id - offset1) * count1) + ((int)y.id - offset2)];
+    public ArraySegment<TValue> GetSlice(TKey1 row) {
+        return new ArraySegment<TValue>(data, ((int)row.id - offset1) * count1, count1);
+    }
 
-        public void CopyRow(TKey1 from, TKey1 to) {
-            if (from == to) {
-                return;
-            }
-
-            int fromId = ((int)from.id - offset1) * count1;
-            int toId = ((int)to.id - offset1) * count1;
-            Array.Copy(data, fromId, data, toId, count1);
-        }
-
-        public ArraySegment<TValue> GetSlice(TKey1 row) {
-            return new ArraySegment<TValue>(data, ((int)row.id - offset1) * count1, count1);
-        }
-
-        public FactorioId IndexToId(int index) {
-            return (FactorioId)(index + offset2);
-        }
+    public FactorioId IndexToId(int index) {
+        return (FactorioId)(index + offset2);
     }
 }

--- a/Yafc.Model/Data/PageReference.cs
+++ b/Yafc.Model/Data/PageReference.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 
-namespace Yafc.Model {
-    public sealed class PageReference(Guid guid) {
-        public PageReference(ProjectPage page) : this(page.guid) {
-            _page = page;
-        }
+namespace Yafc.Model;
+public sealed class PageReference(Guid guid) {
+    public PageReference(ProjectPage page) : this(page.guid) {
+        _page = page;
+    }
 
-        public Guid guid { get; } = guid;
-        private ProjectPage? _page;
+    public Guid guid { get; } = guid;
+    private ProjectPage? _page;
 
-        public ProjectPage? page {
-            get {
-                if (_page == null) {
-                    _page = Project.current.FindPage(guid);
-                }
-                else if (_page.deleted) {
-                    return null;
-                }
-
-                return _page;
+    public ProjectPage? page {
+        get {
+            if (_page == null) {
+                _page = Project.current.FindPage(guid);
             }
+            else if (_page.deleted) {
+                return null;
+            }
+
+            return _page;
         }
     }
 }

--- a/Yafc.Model/Math/Bits.cs
+++ b/Yafc.Model/Math/Bits.cs
@@ -2,322 +2,321 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
-namespace Yafc.Model {
-    public struct Bits {
-        private int _length;
-        public int length {
-            readonly get => _length;
-            [MemberNotNull(nameof(data))] // Setting length is guaranteed to set a non-null data.
-            private set {
-                Array.Resize(ref data, (int)Math.Ceiling(value / 64f));
-                _length = value;
-            }
+namespace Yafc.Model;
+public struct Bits {
+    private int _length;
+    public int length {
+        readonly get => _length;
+        [MemberNotNull(nameof(data))] // Setting length is guaranteed to set a non-null data.
+        private set {
+            Array.Resize(ref data, (int)Math.Ceiling(value / 64f));
+            _length = value;
         }
+    }
 
-        // Turning Bits into a struct this lets us guarantee Bits variables are non-null, but we have to handle data being null instead.
-        // Arrays of Bits are initialized to zeros (nulls), even if we added a default constructor that said otherwise.
-        private ulong[]? data;
+    // Turning Bits into a struct this lets us guarantee Bits variables are non-null, but we have to handle data being null instead.
+    // Arrays of Bits are initialized to zeros (nulls), even if we added a default constructor that said otherwise.
+    private ulong[]? data;
 
-        public bool this[int i] {
-            readonly get {
-                ArgumentOutOfRangeException.ThrowIfNegative(i, nameof(i));
-                if (data is null || length <= i) {
-                    return false;
-                }
-                return (data[i / 64] & (1ul << (i % 64))) != 0;
-            }
-            [MemberNotNull(nameof(data))]
-            set {
-                ArgumentOutOfRangeException.ThrowIfNegative(i, nameof(i));
-                if (length <= i) {
-                    length = i + 1;
-                }
-                // null-forgiving: length must be non-zero, meaning data cannot be null.
-                if (value) {
-                    // set bit
-                    data![i / 64] |= 1ul << (i % 64);
-                }
-                else {
-                    // clear bit
-                    data![i / 64] &= ~(1ul << (i % 64));
-                }
-            }
-        }
-
-        public Bits() { }
-
-        public Bits(bool setBit0) {
-            if (setBit0) {
-                this[0] = true;
-            }
-        }
-
-        // Make a copy of Bits
-        public Bits(Bits original) {
-            data = (ulong[]?)original.data?.Clone();
-            _length = original.length;
-        }
-
-        public static Bits operator &(Bits a, Bits b) {
-            if (a.data is null || b.data is null) {
-                return default;
-            }
-
-            Bits result = default;
-            result.length = Math.Max(a.length, b.length);
-
-            for (int i = 0; i < result.data.Length; i++) {
-                if (a.data.Length <= i || b.data.Length <= i) {
-                    result.data[i] = 0;
-                }
-                else {
-                    result.data[i] = a.data[i] & b.data[i];
-                }
-            }
-
-            return result;
-        }
-
-        public static Bits operator |(Bits a, Bits b) {
-            if (a.data is null) { return new(b); }
-            if (b.data is null) { return new(a); }
-
-            Bits result = default;
-            result.length = Math.Max(a.length, b.length);
-
-            for (int i = 0; i < result.data.Length; i++) {
-                if (a.data.Length <= i) {
-                    result.data[i] = b.data[i];
-                }
-                else if (b.data.Length <= i) {
-                    result.data[i] = a.data[i];
-                }
-                else {
-                    result.data[i] = a.data[i] | b.data[i];
-                }
-            }
-
-            return result;
-        }
-
-        public static Bits operator <<(Bits a, int shift) {
-            if (shift != 1) {
-                throw new NotImplementedException("only shifting by 1 is supported");
-            }
-            if (a.data is null) { return default; }
-
-            Bits result = default;
-            result.length = a.length + 1;
-
-            // bits that 'fell off' in the previous shifting operation
-            ulong carrier = 0ul;
-            for (int i = 0; i < a.data.Length; i++) {
-                result.data[i] = (a.data[i] << shift) | carrier;
-                carrier = a.data[i] & ~(~0ul >> shift); // Mask with 'shift amount of MSB'
-            }
-            if (carrier != 0) {
-                // Reason why only shift == 1 is supported, it is messy to map the separate bits back on data[length] and data[length - 1]
-                // Since shift != 1 is never used, its implementation is omitted
-                result[result.length] = true;
-            }
-
-            return result;
-        }
-
-        public static bool operator <(Bits a, Bits b) {
-            if (b.data is null) {
-                // b doesn't have a value (treat as zero), so a >= b
+    public bool this[int i] {
+        readonly get {
+            ArgumentOutOfRangeException.ThrowIfNegative(i, nameof(i));
+            if (data is null || length <= i) {
                 return false;
             }
-
-            if (a.data is null) {
-                // true if b has a bit set (a == 0 and b > 0)
-                return !b.IsClear();
+            return (data[i / 64] & (1ul << (i % 64))) != 0;
+        }
+        [MemberNotNull(nameof(data))]
+        set {
+            ArgumentOutOfRangeException.ThrowIfNegative(i, nameof(i));
+            if (length <= i) {
+                length = i + 1;
             }
-
-            int maxLength = Math.Max(a.data.Length, b.data.Length);
-            for (int i = maxLength - 1; i >= 0; i--) {
-                if (a.data.Length <= i) {
-                    if (b.data[i] != 0) {
-                        // b is larger, so a < b
-                        return true;
-                    }
-                }
-                else if (b.data.Length <= i) {
-                    if (a.data[i] != 0) {
-                        // a is larger, so a > b
-                        return false;
-                    }
-                }
-                else if (a.data[i] < b.data[i]) {
-                    return true;
-                }
-                else if (a.data[i] > b.data[i]) {
-                    return false;
-                }
-
-                // bits are equal, go to next pair
+            // null-forgiving: length must be non-zero, meaning data cannot be null.
+            if (value) {
+                // set bit
+                data![i / 64] |= 1ul << (i % 64);
             }
+            else {
+                // clear bit
+                data![i / 64] &= ~(1ul << (i % 64));
+            }
+        }
+    }
 
-            // a and b are fully equal, so not a < b
+    public Bits() { }
+
+    public Bits(bool setBit0) {
+        if (setBit0) {
+            this[0] = true;
+        }
+    }
+
+    // Make a copy of Bits
+    public Bits(Bits original) {
+        data = (ulong[]?)original.data?.Clone();
+        _length = original.length;
+    }
+
+    public static Bits operator &(Bits a, Bits b) {
+        if (a.data is null || b.data is null) {
+            return default;
+        }
+
+        Bits result = default;
+        result.length = Math.Max(a.length, b.length);
+
+        for (int i = 0; i < result.data.Length; i++) {
+            if (a.data.Length <= i || b.data.Length <= i) {
+                result.data[i] = 0;
+            }
+            else {
+                result.data[i] = a.data[i] & b.data[i];
+            }
+        }
+
+        return result;
+    }
+
+    public static Bits operator |(Bits a, Bits b) {
+        if (a.data is null) { return new(b); }
+        if (b.data is null) { return new(a); }
+
+        Bits result = default;
+        result.length = Math.Max(a.length, b.length);
+
+        for (int i = 0; i < result.data.Length; i++) {
+            if (a.data.Length <= i) {
+                result.data[i] = b.data[i];
+            }
+            else if (b.data.Length <= i) {
+                result.data[i] = a.data[i];
+            }
+            else {
+                result.data[i] = a.data[i] | b.data[i];
+            }
+        }
+
+        return result;
+    }
+
+    public static Bits operator <<(Bits a, int shift) {
+        if (shift != 1) {
+            throw new NotImplementedException("only shifting by 1 is supported");
+        }
+        if (a.data is null) { return default; }
+
+        Bits result = default;
+        result.length = a.length + 1;
+
+        // bits that 'fell off' in the previous shifting operation
+        ulong carrier = 0ul;
+        for (int i = 0; i < a.data.Length; i++) {
+            result.data[i] = (a.data[i] << shift) | carrier;
+            carrier = a.data[i] & ~(~0ul >> shift); // Mask with 'shift amount of MSB'
+        }
+        if (carrier != 0) {
+            // Reason why only shift == 1 is supported, it is messy to map the separate bits back on data[length] and data[length - 1]
+            // Since shift != 1 is never used, its implementation is omitted
+            result[result.length] = true;
+        }
+
+        return result;
+    }
+
+    public static bool operator <(Bits a, Bits b) {
+        if (b.data is null) {
+            // b doesn't have a value (treat as zero), so a >= b
             return false;
         }
 
-        public static bool operator >(Bits a, Bits b) {
-            if (a.data is null) {
-                // a doesn't have a possible value, so b >= a
-                return false;
-            }
+        if (a.data is null) {
+            // true if b has a bit set (a == 0 and b > 0)
+            return !b.IsClear();
+        }
 
-            if (b.data is null) {
-                // true if a has a bit set
-                return !a.IsClear();
-            }
-
-            int maxLength = Math.Max(a.data.Length, b.data.Length);
-            for (int i = maxLength - 1; i >= 0; i--) {
-                if (a.data.Length <= i) {
-                    if (b.data[i] != 0) {
-                        // b is larger, so a < b
-                        return false;
-                    }
-                }
-                else if (b.data.Length <= i) {
-                    if (a.data[i] != 0) {
-                        // a is larger, so a > b
-                        return true;
-                    }
-                }
-                else if (a.data[i] < b.data[i]) {
-                    return false;
-                }
-                else if (a.data[i] > b.data[i]) {
+        int maxLength = Math.Max(a.data.Length, b.data.Length);
+        for (int i = maxLength - 1; i >= 0; i--) {
+            if (a.data.Length <= i) {
+                if (b.data[i] != 0) {
+                    // b is larger, so a < b
                     return true;
                 }
-
-                // bits are equal, go to next pair
             }
-
-            // a and b are equal, so not a > b
-            return false;
-        }
-
-        public static Bits operator -(Bits a, ulong b) {
-            if (a.IsClear()) {
-                throw new ArgumentOutOfRangeException(nameof(a), "a is 0, so the result would become negative!");
-            }
-
-            if (b != 1) {
-                throw new NotImplementedException("only subtracting by 1 is supported");
-            }
-
-            Bits result = new Bits(a);
-
-            // Only works for subtracting by 1!
-            // subtract by 1: find lowest bit that is set, unset this bit and set all previous bits
-            int index = 0;
-            while (result[index] == false) {
-                result[index] = true;
-                index++;
-            }
-            result[index] = false;
-
-            return result;
-        }
-
-
-        // Check if the first ulong of a equals to b, rest of a needs to be 0
-        public static bool operator ==(Bits a, ulong b) {
-            if (a.length == 0) {
-                return b == 0;
-            }
-
-            if (a.data![0] != b) {
-                return false;
-            }
-
-            for (int i = 1; i < a.data.Length; i++) {
+            else if (b.data.Length <= i) {
                 if (a.data[i] != 0) {
+                    // a is larger, so a > b
                     return false;
                 }
             }
+            else if (a.data[i] < b.data[i]) {
+                return true;
+            }
+            else if (a.data[i] > b.data[i]) {
+                return false;
+            }
 
-            return true;
+            // bits are equal, go to next pair
         }
 
-        public static bool operator ==(Bits a, Bits b) {
-            if (a.data is null && b.data is null) {
+        // a and b are fully equal, so not a < b
+        return false;
+    }
+
+    public static bool operator >(Bits a, Bits b) {
+        if (a.data is null) {
+            // a doesn't have a possible value, so b >= a
+            return false;
+        }
+
+        if (b.data is null) {
+            // true if a has a bit set
+            return !a.IsClear();
+        }
+
+        int maxLength = Math.Max(a.data.Length, b.data.Length);
+        for (int i = maxLength - 1; i >= 0; i--) {
+            if (a.data.Length <= i) {
+                if (b.data[i] != 0) {
+                    // b is larger, so a < b
+                    return false;
+                }
+            }
+            else if (b.data.Length <= i) {
+                if (a.data[i] != 0) {
+                    // a is larger, so a > b
+                    return true;
+                }
+            }
+            else if (a.data[i] < b.data[i]) {
+                return false;
+            }
+            else if (a.data[i] > b.data[i]) {
                 return true;
             }
 
-            if (a.data is null || b.data is null) {
+            // bits are equal, go to next pair
+        }
+
+        // a and b are equal, so not a > b
+        return false;
+    }
+
+    public static Bits operator -(Bits a, ulong b) {
+        if (a.IsClear()) {
+            throw new ArgumentOutOfRangeException(nameof(a), "a is 0, so the result would become negative!");
+        }
+
+        if (b != 1) {
+            throw new NotImplementedException("only subtracting by 1 is supported");
+        }
+
+        Bits result = new Bits(a);
+
+        // Only works for subtracting by 1!
+        // subtract by 1: find lowest bit that is set, unset this bit and set all previous bits
+        int index = 0;
+        while (result[index] == false) {
+            result[index] = true;
+            index++;
+        }
+        result[index] = false;
+
+        return result;
+    }
+
+
+    // Check if the first ulong of a equals to b, rest of a needs to be 0
+    public static bool operator ==(Bits a, ulong b) {
+        if (a.length == 0) {
+            return b == 0;
+        }
+
+        if (a.data![0] != b) {
+            return false;
+        }
+
+        for (int i = 1; i < a.data.Length; i++) {
+            if (a.data[i] != 0) {
                 return false;
             }
+        }
 
-            // Check if a and b have the same 'width' (ignoring zeroed bits)
-            if (a.HighestBitSet() != b.HighestBitSet()) {
-                return false;
-            }
+        return true;
+    }
 
-            for (int i = Math.Min(a.data.Length, b.data.Length) - 1; i >= 0; i--) {
-                if (a.data[i] != b.data[i]) {
-                    return false;
-                }
-            }
-
+    public static bool operator ==(Bits a, Bits b) {
+        if (a.data is null && b.data is null) {
             return true;
         }
 
-
-        public static bool operator !=(Bits a, Bits b) => !(a == b);
-
-        public static bool operator !=(Bits a, ulong b) => !(a == b);
-
-        public override readonly bool Equals(object? obj) => obj is Bits b && this == b;
-
-        public override readonly int GetHashCode() {
-            int hash = 7;
-            unchecked {
-                foreach (ulong i in data ?? []) {
-                    hash = (hash * 31) + (int)i;
-                }
-            }
-
-            return hash;
+        if (a.data is null || b.data is null) {
+            return false;
         }
 
-        public readonly bool IsClear() => HighestBitSet() == -1;
+        // Check if a and b have the same 'width' (ignoring zeroed bits)
+        if (a.HighestBitSet() != b.HighestBitSet()) {
+            return false;
+        }
 
-        public readonly int HighestBitSet() {
-            int result = -1;
-            if (data is null) {
-                return result;
+        for (int i = Math.Min(a.data.Length, b.data.Length) - 1; i >= 0; i--) {
+            if (a.data[i] != b.data[i]) {
+                return false;
             }
-            for (int i = 0; i < data.Length; i++) {
-                if (data[i] != 0) {
-                    // data[i] contains a (new) highest bit
-                    result = (i * 64) + BitOperations.Log2(data[i]);
-                }
-            }
+        }
 
+        return true;
+    }
+
+
+    public static bool operator !=(Bits a, Bits b) => !(a == b);
+
+    public static bool operator !=(Bits a, ulong b) => !(a == b);
+
+    public override readonly bool Equals(object? obj) => obj is Bits b && this == b;
+
+    public override readonly int GetHashCode() {
+        int hash = 7;
+        unchecked {
+            foreach (ulong i in data ?? []) {
+                hash = (hash * 31) + (int)i;
+            }
+        }
+
+        return hash;
+    }
+
+    public readonly bool IsClear() => HighestBitSet() == -1;
+
+    public readonly int HighestBitSet() {
+        int result = -1;
+        if (data is null) {
             return result;
         }
-
-        public readonly int CompareTo(Bits b) {
-            if (this == b) {
-                return 0;
+        for (int i = 0; i < data.Length; i++) {
+            if (data[i] != 0) {
+                // data[i] contains a (new) highest bit
+                result = (i * 64) + BitOperations.Log2(data[i]);
             }
-            return this < b ? -1 : 1;
         }
 
-        public override readonly string ToString() {
-            System.Text.StringBuilder bitsString = new System.Text.StringBuilder(8);
+        return result;
+    }
 
-            foreach (ulong bits in data ?? []) {
-                _ = bitsString.Append(Convert.ToString((long)bits, 2));
-            }
-
-            return bitsString.ToString();
+    public readonly int CompareTo(Bits b) {
+        if (this == b) {
+            return 0;
         }
+        return this < b ? -1 : 1;
+    }
+
+    public override readonly string ToString() {
+        System.Text.StringBuilder bitsString = new System.Text.StringBuilder(8);
+
+        foreach (ulong bits in data ?? []) {
+            _ = bitsString.Append(Convert.ToString((long)bits, 2));
+        }
+
+        return bitsString.ToString();
     }
 }

--- a/Yafc.Model/Math/Graph.cs
+++ b/Yafc.Model/Math/Graph.cs
@@ -2,170 +2,169 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Yafc.Model {
-    public class Graph<T> : IEnumerable<Graph<T>.Node> where T : notnull {
-        private readonly Dictionary<T, Node> nodes = [];
-        private readonly List<Node> allNodes = [];
+namespace Yafc.Model;
+public class Graph<T> : IEnumerable<Graph<T>.Node> where T : notnull {
+    private readonly Dictionary<T, Node> nodes = [];
+    private readonly List<Node> allNodes = [];
 
-        private Node GetNode(T src) {
-            if (nodes.TryGetValue(src, out var node)) {
-                return node;
+    private Node GetNode(T src) {
+        if (nodes.TryGetValue(src, out var node)) {
+            return node;
+        }
+
+        return nodes[src] = new Node(this, src);
+    }
+
+    public void Connect(T from, T to) {
+        GetNode(from).AddArc(GetNode(to));
+    }
+
+    public bool HasConnection(T from, T to) {
+        return GetNode(from).HasConnection(GetNode(to));
+    }
+
+    public ArraySegment<Node> GetConnections(T from) {
+        return GetNode(from).Connections;
+    }
+
+    public List<Node>.Enumerator GetEnumerator() {
+        return allNodes.GetEnumerator();
+    }
+
+    IEnumerator<Node> IEnumerable<Node>.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    public class Node {
+        public readonly T userData;
+        public readonly Graph<T> graph;
+        public readonly int id;
+        internal int state;
+        internal int extra;
+        private int arcCount;
+        private Node[] arcs = [];
+        public Node(Graph<T> graph, T userData) {
+            this.userData = userData;
+            this.graph = graph;
+            id = graph.allNodes.Count;
+            graph.allNodes.Add(this);
+        }
+
+        public void AddArc(Node node) {
+            if (Array.IndexOf(arcs, node, 0, arcCount) != -1) {
+                return;
             }
 
-            return nodes[src] = new Node(this, src);
-        }
-
-        public void Connect(T from, T to) {
-            GetNode(from).AddArc(GetNode(to));
-        }
-
-        public bool HasConnection(T from, T to) {
-            return GetNode(from).HasConnection(GetNode(to));
-        }
-
-        public ArraySegment<Node> GetConnections(T from) {
-            return GetNode(from).Connections;
-        }
-
-        public List<Node>.Enumerator GetEnumerator() {
-            return allNodes.GetEnumerator();
-        }
-
-        IEnumerator<Node> IEnumerable<Node>.GetEnumerator() {
-            return GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() {
-            return GetEnumerator();
-        }
-
-        public class Node {
-            public readonly T userData;
-            public readonly Graph<T> graph;
-            public readonly int id;
-            internal int state;
-            internal int extra;
-            private int arcCount;
-            private Node[] arcs = [];
-            public Node(Graph<T> graph, T userData) {
-                this.userData = userData;
-                this.graph = graph;
-                id = graph.allNodes.Count;
-                graph.allNodes.Add(this);
+            if (arcCount == arcs.Length) {
+                Array.Resize(ref arcs, Math.Max(arcs.Length * 2, 4));
             }
 
-            public void AddArc(Node node) {
-                if (Array.IndexOf(arcs, node, 0, arcCount) != -1) {
-                    return;
-                }
+            arcs[arcCount++] = node;
+        }
 
-                if (arcCount == arcs.Length) {
-                    Array.Resize(ref arcs, Math.Max(arcs.Length * 2, 4));
-                }
+        public ArraySegment<Node> Connections => new ArraySegment<Node>(arcs, 0, arcCount);
 
-                arcs[arcCount++] = node;
-            }
+        public bool HasConnection(Node node) {
+            return Array.IndexOf(arcs, node, 0, arcCount) >= 0;
+        }
+    }
 
-            public ArraySegment<Node> Connections => new ArraySegment<Node>(arcs, 0, arcCount);
-
-            public bool HasConnection(Node node) {
-                return Array.IndexOf(arcs, node, 0, arcCount) >= 0;
+    public Graph<TMap> Remap<TMap>(Dictionary<T, TMap> mapping) where TMap : notnull {
+        Graph<TMap> remapped = new Graph<TMap>();
+        foreach (var node in allNodes) {
+            var remappedNode = mapping[node.userData];
+            foreach (var connection in node.Connections) {
+                remapped.Connect(remappedNode, mapping[connection.userData]);
             }
         }
 
-        public Graph<TMap> Remap<TMap>(Dictionary<T, TMap> mapping) where TMap : notnull {
-            Graph<TMap> remapped = new Graph<TMap>();
-            foreach (var node in allNodes) {
-                var remappedNode = mapping[node.userData];
-                foreach (var connection in node.Connections) {
-                    remapped.Connect(remappedNode, mapping[connection.userData]);
-                }
-            }
+        return remapped;
+    }
 
-            return remapped;
+    public Dictionary<T, TValue> Aggregate<TValue>(Func<T, TValue> create, Action<TValue, T, TValue> connection) {
+        Dictionary<T, TValue> aggregation = [];
+        foreach (var node in allNodes) {
+            _ = AggregateInternal(node, create, connection, aggregation);
         }
 
-        public Dictionary<T, TValue> Aggregate<TValue>(Func<T, TValue> create, Action<TValue, T, TValue> connection) {
-            Dictionary<T, TValue> aggregation = [];
-            foreach (var node in allNodes) {
-                _ = AggregateInternal(node, create, connection, aggregation);
-            }
+        return aggregation;
+    }
 
-            return aggregation;
-        }
-
-        private TValue AggregateInternal<TValue>(Node node, Func<T, TValue> create, Action<TValue, T, TValue> connection, Dictionary<T, TValue> dict) {
-            if (dict.TryGetValue(node.userData, out var result)) {
-                return result;
-            }
-
-            result = create(node.userData);
-            dict[node.userData] = result;
-            foreach (var con in node.Connections) {
-                connection(result, con.userData, AggregateInternal(con, create, connection, dict));
-            }
-
+    private TValue AggregateInternal<TValue>(Node node, Func<T, TValue> create, Action<TValue, T, TValue> connection, Dictionary<T, TValue> dict) {
+        if (dict.TryGetValue(node.userData, out var result)) {
             return result;
         }
 
-        public Graph<(T? single, T[]? list)> MergeStrongConnectedComponents() {
-            foreach (var node in allNodes) {
-                node.state = -1;
-            }
-
-            Dictionary<T, (T?, T[]?)> remap = [];
-            List<Node> stack = [];
-            int index = 0;
-            foreach (var node in allNodes) {
-                if (node.state == -1) {
-                    StrongConnect(stack, node, remap, ref index);
-                }
-            }
-
-            return Remap(remap);
+        result = create(node.userData);
+        dict[node.userData] = result;
+        foreach (var con in node.Connections) {
+            connection(result, con.userData, AggregateInternal(con, create, connection, dict));
         }
 
-        private void StrongConnect(List<Node> stack, Node root, Dictionary<T, (T?, T[]?)> remap, ref int index) {
-            // Algorithm from https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
-            // index => state
-            // lowlink => extra
-            // index is undefined => state == -1
-            // notOnStack => state = -2
-            // v => root
-            // w => neighbor
-            root.extra = root.state = index++;
-            stack.Add(root);
-            foreach (var neighbor in root.Connections) {
-                if (neighbor.state == -1) {
-                    StrongConnect(stack, neighbor, remap, ref index);
-                    root.extra = Math.Min(root.extra, neighbor.extra);
-                }
-                else if (neighbor.state >= 0) {
-                    root.extra = Math.Min(root.extra, neighbor.state);
+        return result;
+    }
+
+    public Graph<(T? single, T[]? list)> MergeStrongConnectedComponents() {
+        foreach (var node in allNodes) {
+            node.state = -1;
+        }
+
+        Dictionary<T, (T?, T[]?)> remap = [];
+        List<Node> stack = [];
+        int index = 0;
+        foreach (var node in allNodes) {
+            if (node.state == -1) {
+                StrongConnect(stack, node, remap, ref index);
+            }
+        }
+
+        return Remap(remap);
+    }
+
+    private void StrongConnect(List<Node> stack, Node root, Dictionary<T, (T?, T[]?)> remap, ref int index) {
+        // Algorithm from https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+        // index => state
+        // lowlink => extra
+        // index is undefined => state == -1
+        // notOnStack => state = -2
+        // v => root
+        // w => neighbor
+        root.extra = root.state = index++;
+        stack.Add(root);
+        foreach (var neighbor in root.Connections) {
+            if (neighbor.state == -1) {
+                StrongConnect(stack, neighbor, remap, ref index);
+                root.extra = Math.Min(root.extra, neighbor.extra);
+            }
+            else if (neighbor.state >= 0) {
+                root.extra = Math.Min(root.extra, neighbor.state);
+            }
+        }
+
+        if (root.extra == root.state) {
+            int rootIndex = stack.LastIndexOf(root);
+            int count = stack.Count - rootIndex;
+            if (count == 1 && !root.HasConnection(root)) {
+                remap[root.userData] = (root.userData, null);
+            }
+            else {
+                T[] range = new T[count];
+                for (int i = 0; i < count; i++) {
+                    var userData = stack[rootIndex + i].userData;
+                    range[i] = userData;
+                    remap[userData] = (default, range);
                 }
             }
 
-            if (root.extra == root.state) {
-                int rootIndex = stack.LastIndexOf(root);
-                int count = stack.Count - rootIndex;
-                if (count == 1 && !root.HasConnection(root)) {
-                    remap[root.userData] = (root.userData, null);
-                }
-                else {
-                    T[] range = new T[count];
-                    for (int i = 0; i < count; i++) {
-                        var userData = stack[rootIndex + i].userData;
-                        range[i] = userData;
-                        remap[userData] = (default, range);
-                    }
-                }
-
-                for (int i = stack.Count - 1; i >= rootIndex; i--) {
-                    stack[i].state = -2;
-                }
-
-                stack.RemoveRange(rootIndex, count);
+            for (int i = stack.Count - 1; i >= rootIndex; i--) {
+                stack[i].state = -2;
             }
+
+            stack.RemoveRange(rootIndex, count);
         }
     }
 }

--- a/Yafc.Model/Model/AutoPlanner.cs
+++ b/Yafc.Model/Model/AutoPlanner.cs
@@ -8,241 +8,240 @@ using Yafc.UI;
 
 #nullable disable warnings // Disabling nullable in legacy code.
 
-namespace Yafc.Model {
-    [Serializable]
-    public class AutoPlannerGoal {
-        private Goods _item;
-        public Goods item {
-            get => _item;
-            set => _item = value ?? throw new ArgumentNullException(nameof(value), "Auto planner goal no longer exist");
+namespace Yafc.Model;
+[Serializable]
+public class AutoPlannerGoal {
+    private Goods _item;
+    public Goods item {
+        get => _item;
+        set => _item = value ?? throw new ArgumentNullException(nameof(value), "Auto planner goal no longer exist");
+    }
+    public float amount { get; set; }
+}
+
+public class AutoPlannerRecipe {
+    public Recipe recipe;
+    public int tier;
+    public float recipesPerSecond;
+    public HashSet<Recipe> downstream = [];
+    public HashSet<Recipe> upstream = [];
+}
+
+public class AutoPlanner(ModelObject page) : ProjectPageContents(page) {
+    private static readonly ILogger logger = Logging.GetLogger<AutoPlanner>();
+    public List<AutoPlannerGoal> goals { get; } = [];
+    public HashSet<Recipe> done { get; } = [];
+    public HashSet<Goods> roots { get; } = [];
+
+    public AutoPlannerRecipe[][] tiers { get; private set; }
+
+    public override async Task<string> Solve(ProjectPage page) {
+        var processedGoods = Database.goods.CreateMapping<Constraint>();
+        var processedRecipes = Database.recipes.CreateMapping<Variable>();
+        Queue<Goods> processingStack = new Queue<Goods>();
+        var bestFlowSolver = DataUtils.CreateSolver();
+        var rootConstraint = bestFlowSolver.MakeConstraint();
+        foreach (var root in roots) {
+            processedGoods[root] = rootConstraint;
         }
-        public float amount { get; set; }
-    }
 
-    public class AutoPlannerRecipe {
-        public Recipe recipe;
-        public int tier;
-        public float recipesPerSecond;
-        public HashSet<Recipe> downstream = [];
-        public HashSet<Recipe> upstream = [];
-    }
+        foreach (var goal in goals) {
+            processedGoods[goal.item] = bestFlowSolver.MakeConstraint(goal.amount, double.PositiveInfinity, goal.item.name);
+            processingStack.Enqueue(goal.item);
+        }
 
-    public class AutoPlanner(ModelObject page) : ProjectPageContents(page) {
-        private static readonly ILogger logger = Logging.GetLogger<AutoPlanner>();
-        public List<AutoPlannerGoal> goals { get; } = [];
-        public HashSet<Recipe> done { get; } = [];
-        public HashSet<Goods> roots { get; } = [];
+        await Ui.ExitMainThread();
+        var objective = bestFlowSolver.Objective();
+        objective.SetMinimization();
+        processingStack.Enqueue(null); // depth marker;
+        int depth = 0;
 
-        public AutoPlannerRecipe[][] tiers { get; private set; }
-
-        public override async Task<string> Solve(ProjectPage page) {
-            var processedGoods = Database.goods.CreateMapping<Constraint>();
-            var processedRecipes = Database.recipes.CreateMapping<Variable>();
-            Queue<Goods> processingStack = new Queue<Goods>();
-            var bestFlowSolver = DataUtils.CreateSolver();
-            var rootConstraint = bestFlowSolver.MakeConstraint();
-            foreach (var root in roots) {
-                processedGoods[root] = rootConstraint;
+        List<Recipe> allRecipes = [];
+        while (processingStack.Count > 1) {
+            var item = processingStack.Dequeue();
+            if (item == null) {
+                processingStack.Enqueue(null);
+                depth++;
+                continue;
             }
 
-            foreach (var goal in goals) {
-                processedGoods[goal.item] = bestFlowSolver.MakeConstraint(goal.amount, double.PositiveInfinity, goal.item.name);
-                processingStack.Enqueue(goal.item);
-            }
-
-            await Ui.ExitMainThread();
-            var objective = bestFlowSolver.Objective();
-            objective.SetMinimization();
-            processingStack.Enqueue(null); // depth marker;
-            int depth = 0;
-
-            List<Recipe> allRecipes = [];
-            while (processingStack.Count > 1) {
-                var item = processingStack.Dequeue();
-                if (item == null) {
-                    processingStack.Enqueue(null);
-                    depth++;
+            var constraint = processedGoods[item];
+            foreach (var recipe in item.production) {
+                if (!recipe.IsAccessibleWithCurrentMilestones()) {
                     continue;
                 }
 
-                var constraint = processedGoods[item];
-                foreach (var recipe in item.production) {
-                    if (!recipe.IsAccessibleWithCurrentMilestones()) {
-                        continue;
-                    }
+                if (processedRecipes[recipe] is Variable var) {
+                    constraint.SetCoefficient(var, constraint.GetCoefficient(var) + recipe.GetProductionPerRecipe(item));
+                }
+                else {
+                    allRecipes.Add(recipe);
+                    var = bestFlowSolver.MakeNumVar(0, double.PositiveInfinity, recipe.name);
+                    objective.SetCoefficient(var, recipe.RecipeBaseCost() * (1 + (depth * 0.5)));
+                    processedRecipes[recipe] = var;
 
-                    if (processedRecipes[recipe] is Variable var) {
-                        constraint.SetCoefficient(var, constraint.GetCoefficient(var) + recipe.GetProductionPerRecipe(item));
-                    }
-                    else {
-                        allRecipes.Add(recipe);
-                        var = bestFlowSolver.MakeNumVar(0, double.PositiveInfinity, recipe.name);
-                        objective.SetCoefficient(var, recipe.RecipeBaseCost() * (1 + (depth * 0.5)));
-                        processedRecipes[recipe] = var;
-
-                        foreach (var product in recipe.products) {
-                            if (processedGoods[product.goods] is Constraint constr && !processingStack.Contains(product.goods)) {
-                                constr.SetCoefficient(var, constr.GetCoefficient(var) + product.amount);
-                            }
-                        }
-
-                        foreach (var ingredient in recipe.ingredients) {
-                            var proc = processedGoods[ingredient.goods];
-                            if (proc == rootConstraint) {
-                                continue;
-                            }
-
-                            if (processedGoods[ingredient.goods] is Constraint constr) {
-                                constr.SetCoefficient(var, constr.GetCoefficient(var) - ingredient.amount);
-                            }
-                            else {
-                                constr = bestFlowSolver.MakeConstraint(0, double.PositiveInfinity, ingredient.goods.name);
-                                processedGoods[ingredient.goods] = constr;
-                                processingStack.Enqueue(ingredient.goods);
-                                constr.SetCoefficient(var, -ingredient.amount);
-                            }
+                    foreach (var product in recipe.products) {
+                        if (processedGoods[product.goods] is Constraint constr && !processingStack.Contains(product.goods)) {
+                            constr.SetCoefficient(var, constr.GetCoefficient(var) + product.amount);
                         }
                     }
-                }
-            }
 
-            var solverResult = bestFlowSolver.Solve();
-            logger.Information("Solution completed with result {result}", solverResult);
-            if (solverResult is not Solver.ResultStatus.OPTIMAL and not Solver.ResultStatus.FEASIBLE) {
-                logger.Information(bestFlowSolver.ExportModelAsLpFormat(false));
-                this.tiers = null;
-                return "Model has no solution";
-            }
-
-            Graph<Recipe> graph = new Graph<Recipe>();
-            _ = allRecipes.RemoveAll(x => {
-                if (processedRecipes[x] is not Variable variable) {
-                    return true;
-                }
-
-                if (variable.BasisStatus() != Solver.BasisStatus.BASIC || variable.SolutionValue() <= 1e-6d) {
-                    processedRecipes[x] = null;
-                    return true;
-                }
-                return false;
-            });
-
-            foreach (var recipe in allRecipes) {
-                foreach (var ingredient in recipe.ingredients) {
-                    foreach (var productionRecipe in ingredient.goods.production) {
-                        if (processedRecipes[productionRecipe] != null) {
-                            // TODO think about heuristics for selecting first recipe. Now chooses first (essentially random)
-                            graph.Connect(recipe, productionRecipe);
-                            //break;
+                    foreach (var ingredient in recipe.ingredients) {
+                        var proc = processedGoods[ingredient.goods];
+                        if (proc == rootConstraint) {
+                            continue;
                         }
-                    }
-                }
-            }
 
-            var subgraph = graph.MergeStrongConnectedComponents();
-            var allDependencies = subgraph.Aggregate(x => new HashSet<(Recipe, Recipe[])>(), (set, item, subset) => {
-                _ = set.Add(item);
-                set.UnionWith(subset);
-            });
-            Dictionary<Recipe, HashSet<Recipe>> downstream = [];
-            Dictionary<Recipe, HashSet<Recipe>> upstream = [];
-            foreach (var ((single, list), dependencies) in allDependencies) {
-                HashSet<Recipe> deps = [];
-                foreach (var (singleDep, listDep) in dependencies) {
-                    var elem = singleDep;
-                    if (listDep != null) {
-                        deps.UnionWith(listDep);
-                        elem = listDep[0];
-                    }
-                    else {
-                        _ = deps.Add(singleDep);
-                    }
-
-                    if (!upstream.TryGetValue(elem, out var set)) {
-                        set = [];
-                        if (listDep != null) {
-                            foreach (var recipe in listDep) {
-                                upstream[recipe] = set;
-                            }
+                        if (processedGoods[ingredient.goods] is Constraint constr) {
+                            constr.SetCoefficient(var, constr.GetCoefficient(var) - ingredient.amount);
                         }
                         else {
-                            upstream[singleDep] = set;
+                            constr = bestFlowSolver.MakeConstraint(0, double.PositiveInfinity, ingredient.goods.name);
+                            processedGoods[ingredient.goods] = constr;
+                            processingStack.Enqueue(ingredient.goods);
+                            constr.SetCoefficient(var, -ingredient.amount);
                         }
                     }
+                }
+            }
+        }
 
-                    if (list != null) {
-                        set.UnionWith(list);
+        var solverResult = bestFlowSolver.Solve();
+        logger.Information("Solution completed with result {result}", solverResult);
+        if (solverResult is not Solver.ResultStatus.OPTIMAL and not Solver.ResultStatus.FEASIBLE) {
+            logger.Information(bestFlowSolver.ExportModelAsLpFormat(false));
+            this.tiers = null;
+            return "Model has no solution";
+        }
+
+        Graph<Recipe> graph = new Graph<Recipe>();
+        _ = allRecipes.RemoveAll(x => {
+            if (processedRecipes[x] is not Variable variable) {
+                return true;
+            }
+
+            if (variable.BasisStatus() != Solver.BasisStatus.BASIC || variable.SolutionValue() <= 1e-6d) {
+                processedRecipes[x] = null;
+                return true;
+            }
+            return false;
+        });
+
+        foreach (var recipe in allRecipes) {
+            foreach (var ingredient in recipe.ingredients) {
+                foreach (var productionRecipe in ingredient.goods.production) {
+                    if (processedRecipes[productionRecipe] != null) {
+                        // TODO think about heuristics for selecting first recipe. Now chooses first (essentially random)
+                        graph.Connect(recipe, productionRecipe);
+                        //break;
+                    }
+                }
+            }
+        }
+
+        var subgraph = graph.MergeStrongConnectedComponents();
+        var allDependencies = subgraph.Aggregate(x => new HashSet<(Recipe, Recipe[])>(), (set, item, subset) => {
+            _ = set.Add(item);
+            set.UnionWith(subset);
+        });
+        Dictionary<Recipe, HashSet<Recipe>> downstream = [];
+        Dictionary<Recipe, HashSet<Recipe>> upstream = [];
+        foreach (var ((single, list), dependencies) in allDependencies) {
+            HashSet<Recipe> deps = [];
+            foreach (var (singleDep, listDep) in dependencies) {
+                var elem = singleDep;
+                if (listDep != null) {
+                    deps.UnionWith(listDep);
+                    elem = listDep[0];
+                }
+                else {
+                    _ = deps.Add(singleDep);
+                }
+
+                if (!upstream.TryGetValue(elem, out var set)) {
+                    set = [];
+                    if (listDep != null) {
+                        foreach (var recipe in listDep) {
+                            upstream[recipe] = set;
+                        }
                     }
                     else {
-                        _ = set.Add(single);
+                        upstream[singleDep] = set;
                     }
                 }
 
                 if (list != null) {
-                    foreach (var recipe in list) {
-                        downstream[recipe] = deps;
-                    }
+                    set.UnionWith(list);
                 }
                 else {
-                    downstream[single] = deps;
+                    _ = set.Add(single);
                 }
             }
 
-            HashSet<(Recipe, Recipe[])> remainingNodes = new HashSet<(Recipe, Recipe[])>(subgraph.Select(x => x.userData));
-            List<(Recipe, Recipe[])> nodesToClear = [];
-            List<AutoPlannerRecipe[]> tiers = [];
-            List<Recipe> currentTier = [];
-            while (remainingNodes.Count > 0) {
-                currentTier.Clear();
-                // First attempt to create tier: Immediately accessible recipe
-                foreach (var node in remainingNodes) {
-                    if (node.Item2 != null && currentTier.Count > 0) {
-                        continue;
-                    }
-
-                    foreach (var dependency in subgraph.GetConnections(node)) {
-                        if (dependency.userData != node && remainingNodes.Contains(dependency.userData)) {
-                            goto nope;
-                        }
-                    }
-
-                    nodesToClear.Add(node);
-                    if (node.Item2 != null) {
-                        currentTier.AddRange(node.Item2);
-                        break;
-                    }
-                    currentTier.Add(node.Item1);
-nope:;
+            if (list != null) {
+                foreach (var recipe in list) {
+                    downstream[recipe] = deps;
                 }
-                remainingNodes.ExceptWith(nodesToClear);
-
-                if (currentTier.Count == 0) // whoops, give up
-                {
-                    foreach (var (single, multiple) in remainingNodes) {
-                        if (multiple != null) {
-                            currentTier.AddRange(multiple);
-                        }
-                        else {
-                            currentTier.Add(single);
-                        }
-                    }
-                    remainingNodes.Clear();
-                    logger.Information("Tier creation failure");
-                }
-                tiers.Add(currentTier.Select(x => new AutoPlannerRecipe {
-                    recipe = x,
-                    tier = tiers.Count,
-                    recipesPerSecond = (float)processedRecipes[x].SolutionValue(),
-                    downstream = downstream.TryGetValue(x, out var res) ? res : null,
-                    upstream = upstream.TryGetValue(x, out var res2) ? res2 : null
-                }).ToArray());
             }
-            bestFlowSolver.Dispose();
-            await Ui.EnterMainThread();
-
-            this.tiers = [.. tiers];
-            return null;
+            else {
+                downstream[single] = deps;
+            }
         }
 
+        HashSet<(Recipe, Recipe[])> remainingNodes = new HashSet<(Recipe, Recipe[])>(subgraph.Select(x => x.userData));
+        List<(Recipe, Recipe[])> nodesToClear = [];
+        List<AutoPlannerRecipe[]> tiers = [];
+        List<Recipe> currentTier = [];
+        while (remainingNodes.Count > 0) {
+            currentTier.Clear();
+            // First attempt to create tier: Immediately accessible recipe
+            foreach (var node in remainingNodes) {
+                if (node.Item2 != null && currentTier.Count > 0) {
+                    continue;
+                }
+
+                foreach (var dependency in subgraph.GetConnections(node)) {
+                    if (dependency.userData != node && remainingNodes.Contains(dependency.userData)) {
+                        goto nope;
+                    }
+                }
+
+                nodesToClear.Add(node);
+                if (node.Item2 != null) {
+                    currentTier.AddRange(node.Item2);
+                    break;
+                }
+                currentTier.Add(node.Item1);
+nope:;
+            }
+            remainingNodes.ExceptWith(nodesToClear);
+
+            if (currentTier.Count == 0) // whoops, give up
+            {
+                foreach (var (single, multiple) in remainingNodes) {
+                    if (multiple != null) {
+                        currentTier.AddRange(multiple);
+                    }
+                    else {
+                        currentTier.Add(single);
+                    }
+                }
+                remainingNodes.Clear();
+                logger.Information("Tier creation failure");
+            }
+            tiers.Add(currentTier.Select(x => new AutoPlannerRecipe {
+                recipe = x,
+                tier = tiers.Count,
+                recipesPerSecond = (float)processedRecipes[x].SolutionValue(),
+                downstream = downstream.TryGetValue(x, out var res) ? res : null,
+                upstream = upstream.TryGetValue(x, out var res2) ? res2 : null
+            }).ToArray());
+        }
+        bestFlowSolver.Dispose();
+        await Ui.EnterMainThread();
+
+        this.tiers = [.. tiers];
+        return null;
     }
+
 }

--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -3,254 +3,253 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Yafc.Model {
-    /// <summary>
-    /// An entry in the per-crafter beacon override configuration. It must specify both a beacon and a module, but it may specify zero beacons.
-    /// </summary>
-    /// <param name="beacon">The beacon to use for this crafter.</param>
-    /// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
-    /// <param name="beaconModule">The module to place in the beacon.</param>
-    [Serializable]
-    public record BeaconOverrideConfiguration(EntityBeacon beacon, int beaconCount, Module beaconModule);
+namespace Yafc.Model;
+/// <summary>
+/// An entry in the per-crafter beacon override configuration. It must specify both a beacon and a module, but it may specify zero beacons.
+/// </summary>
+/// <param name="beacon">The beacon to use for this crafter.</param>
+/// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
+/// <param name="beaconModule">The module to place in the beacon.</param>
+[Serializable]
+public record BeaconOverrideConfiguration(EntityBeacon beacon, int beaconCount, Module beaconModule);
 
-    /// <summary>
-    /// The result of applying the various beacon preferences to a crafter; this may result in a desired configuration where the beacon or module is not specified.
-    /// </summary>
-    /// <param name="beacon">The beacon to use for this crafter, or <see langword="null"/> if no beacons or beacon modules should be used.</param>
-    /// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
-    /// <param name="beaconModule">The module to place in the beacon, or <see langword="null"/> if no beacons or beacon modules should be used.</param>
-    [Serializable]
-    public record BeaconConfiguration(EntityBeacon? beacon, int beaconCount, Module? beaconModule) {
-        public static implicit operator BeaconConfiguration(BeaconOverrideConfiguration beaconConfiguration) => new(beaconConfiguration.beacon, beaconConfiguration.beaconCount, beaconConfiguration.beaconModule);
+/// <summary>
+/// The result of applying the various beacon preferences to a crafter; this may result in a desired configuration where the beacon or module is not specified.
+/// </summary>
+/// <param name="beacon">The beacon to use for this crafter, or <see langword="null"/> if no beacons or beacon modules should be used.</param>
+/// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
+/// <param name="beaconModule">The module to place in the beacon, or <see langword="null"/> if no beacons or beacon modules should be used.</param>
+[Serializable]
+public record BeaconConfiguration(EntityBeacon? beacon, int beaconCount, Module? beaconModule) {
+    public static implicit operator BeaconConfiguration(BeaconOverrideConfiguration beaconConfiguration) => new(beaconConfiguration.beacon, beaconConfiguration.beaconCount, beaconConfiguration.beaconModule);
+}
+
+/// <summary>
+/// The settings (used by root <see cref="ProductionTable"/>s) for what modules and beacons should be used for a recipe, in the absence of any per-<see cref="RecipeRow"/> settings.
+/// </summary>
+/// <remarks>This class handles its own <see cref="DataUtils.RecordUndo{T}(T, bool)"/> calls.</remarks>
+[Serializable]
+public class ModuleFillerParameters : ModelObject<ModelObject> {
+    private bool _fillMiners;
+    private float _autoFillPayback;
+    private Module? _fillerModule;
+    private EntityBeacon? _beacon;
+    private Module? _beaconModule;
+    private int _beaconsPerBuilding = 8;
+
+    public ModuleFillerParameters(ModelObject owner) : base(owner) => overrideCrafterBeacons.OverrideSettingChanging += ModuleFillerParametersChanging;
+
+    public bool fillMiners {
+        get => _fillMiners;
+        set => ChangeModuleFillerParameters(ref _fillMiners, value);
+    }
+    public float autoFillPayback {
+        get => _autoFillPayback;
+        set => ChangeModuleFillerParameters(ref _autoFillPayback, value);
+    }
+    public Module? fillerModule {
+        get => _fillerModule;
+        set => ChangeModuleFillerParameters(ref _fillerModule, value);
+    }
+    public EntityBeacon? beacon {
+        get => _beacon;
+        set => ChangeModuleFillerParameters(ref _beacon, value);
+    }
+    public Module? beaconModule {
+        get => _beaconModule;
+        set => ChangeModuleFillerParameters(ref _beaconModule, value);
+    }
+    public int beaconsPerBuilding {
+        get => _beaconsPerBuilding;
+        set => ChangeModuleFillerParameters(ref _beaconsPerBuilding, value);
+    }
+    public OverrideCrafterBeacons overrideCrafterBeacons { get; } = [];
+
+    [Obsolete("Moved to project settings", true)]
+    public int miningProductivity {
+        set {
+            if (GetRoot() is Project rootProject && rootProject.settings.miningProductivity < value * 0.01f) {
+                rootProject.settings.miningProductivity = value * 0.01f;
+            }
+        }
+    }
+
+    private void ChangeModuleFillerParameters<T>(ref T field, T value) {
+        Action? action = ModuleFillerParametersChanging();
+        field = value;
+        action?.Invoke();
+    }
+
+    private Action? ModuleFillerParametersChanging(EntityCrafter? crafter = null) {
+        if (SerializationMap.IsDeserializing) { return null; } // Deserializing; don't do anything fancy.
+
+        this.RecordUndo();
+        ModelObject parent = owner;
+        while (parent.ownerObject is not ProjectPage and not null) {
+            parent = parent.ownerObject;
+        }
+        ProductionTable table = (ProductionTable)parent;
+
+        Action? result = null;
+        foreach (RecipeRow recipe in table.GetAllRecipes()) {
+            if (crafter == null || crafter == recipe.entity) {
+                result += recipe.ModuleFillerParametersChanging();
+            }
+        }
+        return result;
     }
 
     /// <summary>
-    /// The settings (used by root <see cref="ProductionTable"/>s) for what modules and beacons should be used for a recipe, in the absence of any per-<see cref="RecipeRow"/> settings.
+    /// Given a building that accepts beacon effects, return the type and number of beacons that should affect that building, along with the module to place in those beacons.
     /// </summary>
-    /// <remarks>This class handles its own <see cref="DataUtils.RecordUndo{T}(T, bool)"/> calls.</remarks>
-    [Serializable]
-    public class ModuleFillerParameters : ModelObject<ModelObject> {
-        private bool _fillMiners;
-        private float _autoFillPayback;
-        private Module? _fillerModule;
-        private EntityBeacon? _beacon;
-        private Module? _beaconModule;
-        private int _beaconsPerBuilding = 8;
-
-        public ModuleFillerParameters(ModelObject owner) : base(owner) => overrideCrafterBeacons.OverrideSettingChanging += ModuleFillerParametersChanging;
-
-        public bool fillMiners {
-            get => _fillMiners;
-            set => ChangeModuleFillerParameters(ref _fillMiners, value);
-        }
-        public float autoFillPayback {
-            get => _autoFillPayback;
-            set => ChangeModuleFillerParameters(ref _autoFillPayback, value);
-        }
-        public Module? fillerModule {
-            get => _fillerModule;
-            set => ChangeModuleFillerParameters(ref _fillerModule, value);
-        }
-        public EntityBeacon? beacon {
-            get => _beacon;
-            set => ChangeModuleFillerParameters(ref _beacon, value);
-        }
-        public Module? beaconModule {
-            get => _beaconModule;
-            set => ChangeModuleFillerParameters(ref _beaconModule, value);
-        }
-        public int beaconsPerBuilding {
-            get => _beaconsPerBuilding;
-            set => ChangeModuleFillerParameters(ref _beaconsPerBuilding, value);
-        }
-        public OverrideCrafterBeacons overrideCrafterBeacons { get; } = [];
-
-        [Obsolete("Moved to project settings", true)]
-        public int miningProductivity {
-            set {
-                if (GetRoot() is Project rootProject && rootProject.settings.miningProductivity < value * 0.01f) {
-                    rootProject.settings.miningProductivity = value * 0.01f;
-                }
-            }
-        }
-
-        private void ChangeModuleFillerParameters<T>(ref T field, T value) {
-            Action? action = ModuleFillerParametersChanging();
-            field = value;
-            action?.Invoke();
-        }
-
-        private Action? ModuleFillerParametersChanging(EntityCrafter? crafter = null) {
-            if (SerializationMap.IsDeserializing) { return null; } // Deserializing; don't do anything fancy.
-
-            this.RecordUndo();
-            ModelObject parent = owner;
-            while (parent.ownerObject is not ProjectPage and not null) {
-                parent = parent.ownerObject;
-            }
-            ProductionTable table = (ProductionTable)parent;
-
-            Action? result = null;
-            foreach (RecipeRow recipe in table.GetAllRecipes()) {
-                if (crafter == null || crafter == recipe.entity) {
-                    result += recipe.ModuleFillerParametersChanging();
-                }
-            }
+    /// <param name="crafter">The building to be affected by beacons.</param>
+    /// <returns>The type and number of beacons to apply to that type of building, along with the module that will be placed in the beacons.</returns>
+    public BeaconConfiguration GetBeaconsForCrafter(EntityCrafter? crafter) {
+        if (crafter is not null && overrideCrafterBeacons.TryGetValue(crafter, out var result)) {
             return result;
         }
+        return new(beacon, beaconsPerBuilding, beaconModule);
+    }
 
-        /// <summary>
-        /// Given a building that accepts beacon effects, return the type and number of beacons that should affect that building, along with the module to place in those beacons.
-        /// </summary>
-        /// <param name="crafter">The building to be affected by beacons.</param>
-        /// <returns>The type and number of beacons to apply to that type of building, along with the module that will be placed in the beacons.</returns>
-        public BeaconConfiguration GetBeaconsForCrafter(EntityCrafter? crafter) {
-            if (crafter is not null && overrideCrafterBeacons.TryGetValue(crafter, out var result)) {
-                return result;
-            }
-            return new(beacon, beaconsPerBuilding, beaconModule);
+    internal void AutoFillBeacons(RecipeOrTechnology recipe, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
+        BeaconConfiguration beaconsToUse = GetBeaconsForCrafter(entity);
+        if (!recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity) && beaconsToUse.beacon is EntityBeacon beacon && beaconsToUse.beaconModule != null) {
+            effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beaconCount * beacon.beaconEfficiency * beacon.moduleSlots, entity.allowedEffects);
+            used.beacon = beacon;
+            used.beaconCount = beaconsToUse.beaconCount;
         }
+    }
 
-        internal void AutoFillBeacons(RecipeOrTechnology recipe, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
-            BeaconConfiguration beaconsToUse = GetBeaconsForCrafter(entity);
-            if (!recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity) && beaconsToUse.beacon is EntityBeacon beacon && beaconsToUse.beaconModule != null) {
-                effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beaconCount * beacon.beaconEfficiency * beacon.moduleSlots, entity.allowedEffects);
-                used.beacon = beacon;
-                used.beaconCount = beaconsToUse.beaconCount;
+    private void AutoFillModules((float recipeTime, float fuelUsagePerSecondPerBuilding) partialParams, RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
+        RecipeOrTechnology recipe = row.recipe;
+        if (autoFillPayback > 0 && (fillMiners || !recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity))) {
+            float productivityEconomy = recipe.Cost() / partialParams.recipeTime;
+            float effectivityEconomy = partialParams.fuelUsagePerSecondPerBuilding * row.fuel?.Cost() ?? 0;
+            if (effectivityEconomy < 0f) {
+                effectivityEconomy = 0f;
             }
-        }
 
-        private void AutoFillModules((float recipeTime, float fuelUsagePerSecondPerBuilding) partialParams, RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
-            RecipeOrTechnology recipe = row.recipe;
-            if (autoFillPayback > 0 && (fillMiners || !recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity))) {
-                float productivityEconomy = recipe.Cost() / partialParams.recipeTime;
-                float effectivityEconomy = partialParams.fuelUsagePerSecondPerBuilding * row.fuel?.Cost() ?? 0;
-                if (effectivityEconomy < 0f) {
-                    effectivityEconomy = 0f;
-                }
-
-                float bestEconomy = 0f;
-                Module? usedModule = null;
-                foreach (var module in recipe.modules) {
-                    if (module.IsAccessibleWithCurrentMilestones() && entity.CanAcceptModule(module.moduleSpecification)) {
-                        float economy = (MathF.Max(0f, module.moduleSpecification.productivity) * productivityEconomy) - (module.moduleSpecification.consumption * effectivityEconomy);
-                        if (economy > bestEconomy && module.Cost() / economy <= autoFillPayback) {
-                            bestEconomy = economy;
-                            usedModule = module;
-                        }
-                    }
-                }
-
-                if (usedModule != null) {
-                    int count = effects.GetModuleSoftLimit(usedModule.moduleSpecification, entity.moduleSlots);
-                    if (count > 0) {
-                        effects.AddModules(usedModule.moduleSpecification, count);
-                        used.modules = new[] { (usedModule, count, false) };
-                        return;
+            float bestEconomy = 0f;
+            Module? usedModule = null;
+            foreach (var module in recipe.modules) {
+                if (module.IsAccessibleWithCurrentMilestones() && entity.CanAcceptModule(module.moduleSpecification)) {
+                    float economy = (MathF.Max(0f, module.moduleSpecification.productivity) * productivityEconomy) - (module.moduleSpecification.consumption * effectivityEconomy);
+                    if (economy > bestEconomy && module.Cost() / economy <= autoFillPayback) {
+                        bestEconomy = economy;
+                        usedModule = module;
                     }
                 }
             }
 
-            if (fillerModule?.moduleSpecification != null && entity.CanAcceptModule(fillerModule.moduleSpecification) && recipe.CanAcceptModule(fillerModule)) {
-                AddModuleSimple(fillerModule, ref effects, entity, ref used);
+            if (usedModule != null) {
+                int count = effects.GetModuleSoftLimit(usedModule.moduleSpecification, entity.moduleSlots);
+                if (count > 0) {
+                    effects.AddModules(usedModule.moduleSpecification, count);
+                    used.modules = new[] { (usedModule, count, false) };
+                    return;
+                }
             }
         }
 
-        internal void GetModulesInfo((float recipeTime, float fuelUsagePerSecondPerBuilding) partialParams, RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
-            AutoFillBeacons(row.recipe, entity, ref effects, ref used);
-            AutoFillModules(partialParams, row, entity, ref effects, ref used);
-        }
-
-        private void AddModuleSimple(Module module, ref ModuleEffects effects, EntityCrafter entity, ref UsedModule used) {
-            if (module.moduleSpecification != null) {
-                int fillerLimit = effects.GetModuleSoftLimit(module.moduleSpecification, entity.moduleSlots);
-                effects.AddModules(module.moduleSpecification, fillerLimit);
-                used.modules = new[] { (module, fillerLimit, false) };
-            }
+        if (fillerModule?.moduleSpecification != null && entity.CanAcceptModule(fillerModule.moduleSpecification) && recipe.CanAcceptModule(fillerModule)) {
+            AddModuleSimple(fillerModule, ref effects, entity, ref used);
         }
     }
+
+    internal void GetModulesInfo((float recipeTime, float fuelUsagePerSecondPerBuilding) partialParams, RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
+        AutoFillBeacons(row.recipe, entity, ref effects, ref used);
+        AutoFillModules(partialParams, row, entity, ref effects, ref used);
+    }
+
+    private void AddModuleSimple(Module module, ref ModuleEffects effects, EntityCrafter entity, ref UsedModule used) {
+        if (module.moduleSpecification != null) {
+            int fillerLimit = effects.GetModuleSoftLimit(module.moduleSpecification, entity.moduleSlots);
+            effects.AddModules(module.moduleSpecification, fillerLimit);
+            used.modules = new[] { (module, fillerLimit, false) };
+        }
+    }
+}
+
+/// <summary>
+/// An observable dictionary, that will raise <see cref="OverrideSettingChanging"/> when the settings for a crafter are about to about to change.
+/// </summary>
+public class OverrideCrafterBeacons : IDictionary<EntityCrafter, BeaconOverrideConfiguration> {
+    private readonly SortedList<EntityCrafter, BeaconOverrideConfiguration> storage = new(DataUtils.DeterministicComparer);
 
     /// <summary>
-    /// An observable dictionary, that will raise <see cref="OverrideSettingChanging"/> when the settings for a crafter are about to about to change.
+    /// Raised before changing (including adding/removing) the value associated with a particular crafter.
+    /// The return value, if not <see langword="null"/>, will be called after the change has been performed.
     /// </summary>
-    public class OverrideCrafterBeacons : IDictionary<EntityCrafter, BeaconOverrideConfiguration> {
-        private readonly SortedList<EntityCrafter, BeaconOverrideConfiguration> storage = new(DataUtils.DeterministicComparer);
+    internal event Func<EntityCrafter, Action?>? OverrideSettingChanging;
 
-        /// <summary>
-        /// Raised before changing (including adding/removing) the value associated with a particular crafter.
-        /// The return value, if not <see langword="null"/>, will be called after the change has been performed.
-        /// </summary>
-        internal event Func<EntityCrafter, Action?>? OverrideSettingChanging;
-
-        /// <inheritdoc/>
-        public BeaconOverrideConfiguration this[EntityCrafter key] {
-            get => storage[key];
-            set {
-                Action? action = OverrideSettingChanging?.Invoke(key);
-                storage[key] = value;
-                action?.Invoke();
-            }
-        }
-
-        /// <inheritdoc/>
-        public ICollection<EntityCrafter> Keys => storage.Keys;
-
-        /// <inheritdoc/>
-        public ICollection<BeaconOverrideConfiguration> Values => storage.Values;
-
-        /// <inheritdoc/>
-        public int Count => storage.Count;
-
-        /// <inheritdoc/>
-        bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.IsReadOnly => false;
-
-        /// <inheritdoc/>
-        public void Add(EntityCrafter key, BeaconOverrideConfiguration value) {
+    /// <inheritdoc/>
+    public BeaconOverrideConfiguration this[EntityCrafter key] {
+        get => storage[key];
+        set {
             Action? action = OverrideSettingChanging?.Invoke(key);
-            storage.Add(key, value);
+            storage[key] = value;
             action?.Invoke();
         }
-
-        /// <inheritdoc/>
-        void ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Add(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item)
-            => Add(item.Key, item.Value);
-
-        /// <inheritdoc/>
-        public void Clear() => storage.Clear();
-        /// <inheritdoc/>
-        bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Contains(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item)
-            => ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).Contains(item);
-
-        /// <inheritdoc/>
-        public bool ContainsKey(EntityCrafter key) => storage.ContainsKey(key);
-
-        /// <inheritdoc/>
-        void ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.CopyTo(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>[] array, int arrayIndex)
-            => ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).CopyTo(array, arrayIndex);
-
-        /// <inheritdoc/>
-        public IEnumerator<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>> GetEnumerator() => storage.GetEnumerator();
-
-        /// <inheritdoc/>
-        public bool Remove(EntityCrafter key) {
-            Action? action = OverrideSettingChanging?.Invoke(key);
-            bool result = storage.Remove(key);
-            action?.Invoke();
-            return result;
-        }
-
-        /// <inheritdoc/>
-        bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Remove(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item) {
-            Action? action = OverrideSettingChanging?.Invoke(item.Key);
-            bool result = ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).Remove(item);
-            action?.Invoke();
-            return result;
-        }
-
-        /// <inheritdoc/>
-        public bool TryGetValue(EntityCrafter key, [MaybeNullWhen(false)] out BeaconOverrideConfiguration value) => storage.TryGetValue(key, out value);
-
-        /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator() => storage.GetEnumerator();
     }
+
+    /// <inheritdoc/>
+    public ICollection<EntityCrafter> Keys => storage.Keys;
+
+    /// <inheritdoc/>
+    public ICollection<BeaconOverrideConfiguration> Values => storage.Values;
+
+    /// <inheritdoc/>
+    public int Count => storage.Count;
+
+    /// <inheritdoc/>
+    bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public void Add(EntityCrafter key, BeaconOverrideConfiguration value) {
+        Action? action = OverrideSettingChanging?.Invoke(key);
+        storage.Add(key, value);
+        action?.Invoke();
+    }
+
+    /// <inheritdoc/>
+    void ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Add(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item)
+        => Add(item.Key, item.Value);
+
+    /// <inheritdoc/>
+    public void Clear() => storage.Clear();
+    /// <inheritdoc/>
+    bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Contains(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item)
+        => ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).Contains(item);
+
+    /// <inheritdoc/>
+    public bool ContainsKey(EntityCrafter key) => storage.ContainsKey(key);
+
+    /// <inheritdoc/>
+    void ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.CopyTo(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>[] array, int arrayIndex)
+        => ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).CopyTo(array, arrayIndex);
+
+    /// <inheritdoc/>
+    public IEnumerator<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>> GetEnumerator() => storage.GetEnumerator();
+
+    /// <inheritdoc/>
+    public bool Remove(EntityCrafter key) {
+        Action? action = OverrideSettingChanging?.Invoke(key);
+        bool result = storage.Remove(key);
+        action?.Invoke();
+        return result;
+    }
+
+    /// <inheritdoc/>
+    bool ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>.Remove(KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> item) {
+        Action? action = OverrideSettingChanging?.Invoke(item.Key);
+        bool result = ((ICollection<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>>)storage).Remove(item);
+        action?.Invoke();
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue(EntityCrafter key, [MaybeNullWhen(false)] out BeaconOverrideConfiguration value) => storage.TryGetValue(key, out value);
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => storage.GetEnumerator();
 }

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -3,211 +3,210 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public class ProductionSummaryGroup(ModelObject owner) : ModelObject<ModelObject>(owner), IElementGroup<ProductionSummaryEntry> {
-        public List<ProductionSummaryEntry> elements { get; } = [];
-        [NoUndo]
-        public bool expanded { get; set; }
-        public string? name { get; set; }
+namespace Yafc.Model;
+public class ProductionSummaryGroup(ModelObject owner) : ModelObject<ModelObject>(owner), IElementGroup<ProductionSummaryEntry> {
+    public List<ProductionSummaryEntry> elements { get; } = [];
+    [NoUndo]
+    public bool expanded { get; set; }
+    public string? name { get; set; }
 
-        public void Solve(Dictionary<Goods, float> totalFlow, float multiplier) {
-            foreach (var element in elements) {
-                element.RefreshFlow();
-            }
-
-            totalFlow.Clear();
-            foreach (var row in elements) {
-                foreach (var (item, amount) in row.flow) {
-                    _ = totalFlow.TryGetValue(item, out float prev);
-                    totalFlow[item] = prev + (amount * multiplier);
-                }
-            }
+    public void Solve(Dictionary<Goods, float> totalFlow, float multiplier) {
+        foreach (var element in elements) {
+            element.RefreshFlow();
         }
 
-        public void UpdateFilter(Goods filteredGoods, SearchQuery searchQuery) {
-            foreach (var element in elements) {
-                element.UpdateFilter(filteredGoods, searchQuery);
+        totalFlow.Clear();
+        foreach (var row in elements) {
+            foreach (var (item, amount) in row.flow) {
+                _ = totalFlow.TryGetValue(item, out float prev);
+                totalFlow[item] = prev + (amount * multiplier);
             }
         }
     }
 
-    public class ProductionSummaryEntry(ProductionSummaryGroup owner) : ModelObject<ProductionSummaryGroup>(owner), IGroupedElement<ProductionSummaryGroup> {
-        protected internal override void AfterDeserialize() {
-            // Must be either page reference, or subgroup, not both
-            if (subgroup == null && page == null) {
-                throw new NotSupportedException("Referenced page does not exist");
-            }
+    public void UpdateFilter(Goods filteredGoods, SearchQuery searchQuery) {
+        foreach (var element in elements) {
+            element.UpdateFilter(filteredGoods, searchQuery);
+        }
+    }
+}
 
-            if (subgroup != null && page != null) {
-                page = null;
-            }
-
-            base.AfterDeserialize();
+public class ProductionSummaryEntry(ProductionSummaryGroup owner) : ModelObject<ProductionSummaryGroup>(owner), IGroupedElement<ProductionSummaryGroup> {
+    protected internal override void AfterDeserialize() {
+        // Must be either page reference, or subgroup, not both
+        if (subgroup == null && page == null) {
+            throw new NotSupportedException("Referenced page does not exist");
         }
 
-        public float multiplier { get; set; } = 1;
-        public PageReference? page { get; set; }
-        public ProductionSummaryGroup? subgroup { get; set; }
-        public bool visible { get; private set; } = true;
-        [SkipSerialization] public Dictionary<Goods, float> flow { get; } = [];
-        private bool needRefreshFlow = true;
-
-        public Icon icon {
-            get {
-                if (subgroup != null) {
-                    return Icon.Folder;
-                }
-
-                if (page?.page == null) {
-                    return Icon.Warning;
-                }
-
-                return page.page.icon?.icon ?? Icon.None;
-            }
+        if (subgroup != null && page != null) {
+            page = null;
         }
 
-        public string name {
-            get {
-                if (page != null) {
-                    return page.page?.name ?? "Page missing";
-                }
+        base.AfterDeserialize();
+    }
 
-                return "Broken entry";
-            }
-        }
+    public float multiplier { get; set; } = 1;
+    public PageReference? page { get; set; }
+    public ProductionSummaryGroup? subgroup { get; set; }
+    public bool visible { get; private set; } = true;
+    [SkipSerialization] public Dictionary<Goods, float> flow { get; } = [];
+    private bool needRefreshFlow = true;
 
-        public bool CollectSolvingTasks(List<Task> listToFill) {
-            var solutionTask = SolveIfNecessary();
-            if (solutionTask != null) {
-                listToFill.Add(solutionTask);
-                needRefreshFlow = true;
-            }
-
+    public Icon icon {
+        get {
             if (subgroup != null) {
-                foreach (var element in subgroup.elements) {
-                    needRefreshFlow |= element.CollectSolvingTasks(listToFill);
-                }
+                return Icon.Folder;
             }
-            return needRefreshFlow;
+
+            if (page?.page == null) {
+                return Icon.Warning;
+            }
+
+            return page.page.icon?.icon ?? Icon.None;
+        }
+    }
+
+    public string name {
+        get {
+            if (page != null) {
+                return page.page?.name ?? "Page missing";
+            }
+
+            return "Broken entry";
+        }
+    }
+
+    public bool CollectSolvingTasks(List<Task> listToFill) {
+        var solutionTask = SolveIfNecessary();
+        if (solutionTask != null) {
+            listToFill.Add(solutionTask);
+            needRefreshFlow = true;
         }
 
-        public Task? SolveIfNecessary() {
-            if (page == null) {
-                return null;
+        if (subgroup != null) {
+            foreach (var element in subgroup.elements) {
+                needRefreshFlow |= element.CollectSolvingTasks(listToFill);
             }
+        }
+        return needRefreshFlow;
+    }
 
-            var solutionPagepage = page.page;
-            if (solutionPagepage != null && solutionPagepage.IsSolutionStale()) {
-                return solutionPagepage.ExternalSolve();
-            }
-
+    public Task? SolveIfNecessary() {
+        if (page == null) {
             return null;
         }
 
-        public float GetAmount(Goods goods) {
-            return flow.TryGetValue(goods, out float amount) ? amount : 0;
+        var solutionPagepage = page.page;
+        if (solutionPagepage != null && solutionPagepage.IsSolutionStale()) {
+            return solutionPagepage.ExternalSolve();
         }
 
-        public void RefreshFlow() {
-            if (!needRefreshFlow) {
+        return null;
+    }
+
+    public float GetAmount(Goods goods) {
+        return flow.TryGetValue(goods, out float amount) ? amount : 0;
+    }
+
+    public void RefreshFlow() {
+        if (!needRefreshFlow) {
+            return;
+        }
+
+        needRefreshFlow = false;
+        flow.Clear();
+        if (subgroup != null) {
+            subgroup.Solve(flow, multiplier);
+        }
+        else {
+            if (page?.page?.content is not ProductionTable subTable) {
                 return;
             }
 
-            needRefreshFlow = false;
-            flow.Clear();
-            if (subgroup != null) {
-                subgroup.Solve(flow, multiplier);
-            }
-            else {
-                if (page?.page?.content is not ProductionTable subTable) {
-                    return;
-                }
-
-                foreach (var flowEntry in subTable.flow) {
-                    if (flowEntry.amount != 0) {
-                        flow[flowEntry.goods] = flowEntry.amount * multiplier;
-                    }
-                }
-
-                foreach (var link in subTable.links) {
-                    if (link.amount != 0) {
-                        _ = flow.TryGetValue(link.goods, out float prevValue);
-                        flow[link.goods] = prevValue + (link.amount * multiplier);
-                    }
+            foreach (var flowEntry in subTable.flow) {
+                if (flowEntry.amount != 0) {
+                    flow[flowEntry.goods] = flowEntry.amount * multiplier;
                 }
             }
-        }
 
-        public void SetOwner(ProductionSummaryGroup newOwner) {
-            owner = newOwner;
-        }
-
-        public void UpdateFilter(Goods goods, SearchQuery query) {
-            visible = flow.ContainsKey(goods);
-            subgroup?.UpdateFilter(goods, query);
-        }
-
-        public void SetMultiplier(float newMultiplier) {
-            _ = this.RecordUndo();
-            needRefreshFlow = true;
-            multiplier = newMultiplier;
+            foreach (var link in subTable.links) {
+                if (link.amount != 0) {
+                    _ = flow.TryGetValue(link.goods, out float prevValue);
+                    flow[link.goods] = prevValue + (link.amount * multiplier);
+                }
+            }
         }
     }
 
-    public class ProductionSummaryColumn(ProductionSummary owner, Goods goods) : ModelObject<ProductionSummary>(owner) {
-        public Goods goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
+    public void SetOwner(ProductionSummaryGroup newOwner) {
+        owner = newOwner;
     }
 
-    public class ProductionSummary : ProjectPageContents, IComparer<(Goods goods, float amount)> {
-        public ProductionSummary(ModelObject page) : base(page) {
-            group = new ProductionSummaryGroup(this);
-        }
-        public ProductionSummaryGroup group { get; }
-        public List<ProductionSummaryColumn> columns { get; } = [];
-        [SkipSerialization] public List<(Goods goods, float amount)> sortedFlow { get; } = [];
+    public void UpdateFilter(Goods goods, SearchQuery query) {
+        visible = flow.ContainsKey(goods);
+        subgroup?.UpdateFilter(goods, query);
+    }
 
-        private readonly Dictionary<Goods, float> totalFlow = [];
-        [SkipSerialization] public HashSet<Goods> columnsExist { get; } = [];
+    public void SetMultiplier(float newMultiplier) {
+        _ = this.RecordUndo();
+        needRefreshFlow = true;
+        multiplier = newMultiplier;
+    }
+}
 
-        public override void InitNew() {
-            columns.Add(new ProductionSummaryColumn(this, Database.electricity));
-            base.InitNew();
-        }
+public class ProductionSummaryColumn(ProductionSummary owner, Goods goods) : ModelObject<ProductionSummary>(owner) {
+    public Goods goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
+}
 
-        public float GetTotalFlow(Goods goods) {
-            return totalFlow.TryGetValue(goods, out float amount) ? amount : 0;
-        }
+public class ProductionSummary : ProjectPageContents, IComparer<(Goods goods, float amount)> {
+    public ProductionSummary(ModelObject page) : base(page) {
+        group = new ProductionSummaryGroup(this);
+    }
+    public ProductionSummaryGroup group { get; }
+    public List<ProductionSummaryColumn> columns { get; } = [];
+    [SkipSerialization] public List<(Goods goods, float amount)> sortedFlow { get; } = [];
 
-        public override async Task<string?> Solve(ProjectPage page) {
-            List<Task> taskList = [];
-            foreach (var element in group.elements) {
-                _ = element.CollectSolvingTasks(taskList);
-            }
+    private readonly Dictionary<Goods, float> totalFlow = [];
+    [SkipSerialization] public HashSet<Goods> columnsExist { get; } = [];
 
-            if (taskList.Count > 0) {
-                await Task.WhenAll(taskList);
-            }
+    public override void InitNew() {
+        columns.Add(new ProductionSummaryColumn(this, Database.electricity));
+        base.InitNew();
+    }
 
-            columnsExist.Clear();
-            group.Solve(totalFlow, 1);
+    public float GetTotalFlow(Goods goods) {
+        return totalFlow.TryGetValue(goods, out float amount) ? amount : 0;
+    }
 
-            foreach (var column in columns) {
-                _ = columnsExist.Add(column.goods);
-            }
-
-            sortedFlow.Clear();
-            foreach (var element in totalFlow) {
-                sortedFlow.Add((element.Key, element.Value));
-            }
-
-            sortedFlow.Sort(this);
-            return null;
+    public override async Task<string?> Solve(ProjectPage page) {
+        List<Task> taskList = [];
+        foreach (var element in group.elements) {
+            _ = element.CollectSolvingTasks(taskList);
         }
 
-        public int Compare((Goods goods, float amount) x, (Goods goods, float amount) y) {
-            float amt1 = x.goods.fluid != null ? x.amount / 50f : x.amount;
-            float amt2 = y.goods.fluid != null ? y.amount / 50f : y.amount;
-            return amt1.CompareTo(amt2);
+        if (taskList.Count > 0) {
+            await Task.WhenAll(taskList);
         }
+
+        columnsExist.Clear();
+        group.Solve(totalFlow, 1);
+
+        foreach (var column in columns) {
+            _ = columnsExist.Add(column.goods);
+        }
+
+        sortedFlow.Clear();
+        foreach (var element in totalFlow) {
+            sortedFlow.Add((element.Key, element.Value));
+        }
+
+        sortedFlow.Sort(this);
+        return null;
+    }
+
+    public int Compare((Goods goods, float amount) x, (Goods goods, float amount) y) {
+        float amt1 = x.goods.fluid != null ? x.amount / 50f : x.amount;
+        float amt2 = y.goods.fluid != null ? y.amount / 50f : y.amount;
+        return amt1.CompareTo(amt2);
     }
 }

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -9,645 +9,644 @@ using Google.OrTools.LinearSolver;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public struct ProductionTableFlow(Goods goods, float amount, ProductionLink? link) {
-        public Goods goods = goods;
-        public float amount = amount;
-        public ProductionLink? link = link;
+namespace Yafc.Model;
+public struct ProductionTableFlow(Goods goods, float amount, ProductionLink? link) {
+    public Goods goods = goods;
+    public float amount = amount;
+    public ProductionLink? link = link;
+}
+
+public class ProductionTable : ProjectPageContents, IComparer<ProductionTableFlow>, IElementGroup<RecipeRow> {
+    private static readonly ILogger logger = Logging.GetLogger<ProductionTable>();
+    [SkipSerialization] public Dictionary<Goods, ProductionLink> linkMap { get; } = [];
+    List<RecipeRow> IElementGroup<RecipeRow>.elements => recipes;
+    [NoUndo]
+    public bool expanded { get; set; } = true;
+    public List<ProductionLink> links { get; } = [];
+    public List<RecipeRow> recipes { get; } = [];
+    public ProductionTableFlow[] flow { get; private set; } = [];
+    public ModuleFillerParameters? modules { get; } // If you add a setter for this, ensure it calls RecipeRow.ModuleFillerParametersChanging().
+    public bool containsDesiredProducts { get; private set; }
+
+    public ProductionTable(ModelObject owner) : base(owner) {
+        if (owner is ProjectPage) {
+            modules = new ModuleFillerParameters(this);
+        }
     }
 
-    public class ProductionTable : ProjectPageContents, IComparer<ProductionTableFlow>, IElementGroup<RecipeRow> {
-        private static readonly ILogger logger = Logging.GetLogger<ProductionTable>();
-        [SkipSerialization] public Dictionary<Goods, ProductionLink> linkMap { get; } = [];
-        List<RecipeRow> IElementGroup<RecipeRow>.elements => recipes;
-        [NoUndo]
-        public bool expanded { get; set; } = true;
-        public List<ProductionLink> links { get; } = [];
-        public List<RecipeRow> recipes { get; } = [];
-        public ProductionTableFlow[] flow { get; private set; } = [];
-        public ModuleFillerParameters? modules { get; } // If you add a setter for this, ensure it calls RecipeRow.ModuleFillerParametersChanging().
-        public bool containsDesiredProducts { get; private set; }
+    protected internal override void ThisChanged(bool visualOnly) {
+        RebuildLinkMap();
+        if (owner is ProjectPage page) {
+            page.ContentChanged(visualOnly);
+        }
+        else if (owner is RecipeRow recipe) {
+            recipe.ThisChanged(visualOnly);
+        }
+    }
 
-        public ProductionTable(ModelObject owner) : base(owner) {
-            if (owner is ProjectPage) {
-                modules = new ModuleFillerParameters(this);
+    public void RebuildLinkMap() {
+        linkMap.Clear();
+        foreach (var link in links) {
+            linkMap[link.goods] = link;
+        }
+    }
+
+    private void Setup(List<RecipeRow> allRecipes, List<ProductionLink> allLinks) {
+        containsDesiredProducts = false;
+        foreach (var link in links) {
+            if (link.amount != 0f) {
+                containsDesiredProducts = true;
             }
+
+            allLinks.Add(link);
+            link.capturedRecipes.Clear();
         }
 
-        protected internal override void ThisChanged(bool visualOnly) {
-            RebuildLinkMap();
-            if (owner is ProjectPage page) {
-                page.ContentChanged(visualOnly);
+        foreach (var recipe in recipes) {
+            if (!recipe.enabled) {
+                ClearDisabledRecipeContents(recipe);
+                continue;
             }
-            else if (owner is RecipeRow recipe) {
-                recipe.ThisChanged(visualOnly);
+
+            recipe.hierarchyEnabled = true;
+            allRecipes.Add(recipe);
+            recipe.subgroup?.Setup(allRecipes, allLinks);
+        }
+    }
+
+    private static void ClearDisabledRecipeContents(RecipeRow recipe) {
+        recipe.recipesPerSecond = 0;
+        recipe.parameters = RecipeParameters.Empty;
+        recipe.hierarchyEnabled = false;
+        var subgroup = recipe.subgroup;
+        if (subgroup != null) {
+            subgroup.flow = [];
+            foreach (var link in subgroup.links) {
+                link.flags = 0;
+                link.linkFlow = 0;
+            }
+            foreach (var sub in subgroup.recipes) {
+                ClearDisabledRecipeContents(sub);
             }
         }
+    }
 
-        public void RebuildLinkMap() {
-            linkMap.Clear();
-            foreach (var link in links) {
-                linkMap[link.goods] = link;
-            }
-        }
+    public bool Search(SearchQuery query) {
+        bool hasMatch = false;
 
-        private void Setup(List<RecipeRow> allRecipes, List<ProductionLink> allLinks) {
-            containsDesiredProducts = false;
-            foreach (var link in links) {
-                if (link.amount != 0f) {
-                    containsDesiredProducts = true;
-                }
-
-                allLinks.Add(link);
-                link.capturedRecipes.Clear();
+        foreach (var recipe in recipes) {
+            recipe.visible = false;
+            if (recipe.subgroup != null && recipe.subgroup.Search(query)) {
+                goto match;
             }
 
-            foreach (var recipe in recipes) {
-                if (!recipe.enabled) {
-                    ClearDisabledRecipeContents(recipe);
-                    continue;
-                }
-
-                recipe.hierarchyEnabled = true;
-                allRecipes.Add(recipe);
-                recipe.subgroup?.Setup(allRecipes, allLinks);
+            if (recipe.recipe.Match(query) || recipe.fuel.Match(query) || recipe.entity.Match(query)) {
+                goto match;
             }
-        }
 
-        private static void ClearDisabledRecipeContents(RecipeRow recipe) {
-            recipe.recipesPerSecond = 0;
-            recipe.parameters = RecipeParameters.Empty;
-            recipe.hierarchyEnabled = false;
-            var subgroup = recipe.subgroup;
-            if (subgroup != null) {
-                subgroup.flow = [];
-                foreach (var link in subgroup.links) {
-                    link.flags = 0;
-                    link.linkFlow = 0;
-                }
-                foreach (var sub in subgroup.recipes) {
-                    ClearDisabledRecipeContents(sub);
-                }
-            }
-        }
-
-        public bool Search(SearchQuery query) {
-            bool hasMatch = false;
-
-            foreach (var recipe in recipes) {
-                recipe.visible = false;
-                if (recipe.subgroup != null && recipe.subgroup.Search(query)) {
+            foreach (var ingr in recipe.recipe.ingredients) {
+                if (ingr.goods.Match(query)) {
                     goto match;
                 }
+            }
 
-                if (recipe.recipe.Match(query) || recipe.fuel.Match(query) || recipe.entity.Match(query)) {
+            foreach (var product in recipe.recipe.products) {
+                if (product.goods.Match(query)) {
                     goto match;
                 }
-
-                foreach (var ingr in recipe.recipe.ingredients) {
-                    if (ingr.goods.Match(query)) {
-                        goto match;
-                    }
-                }
-
-                foreach (var product in recipe.recipe.products) {
-                    if (product.goods.Match(query)) {
-                        goto match;
-                    }
-                }
-                continue; // no match;
+            }
+            continue; // no match;
 match:
-                hasMatch = true;
-                recipe.visible = true;
-            }
+            hasMatch = true;
+            recipe.visible = true;
+        }
 
-            if (hasMatch) {
+        if (hasMatch) {
+            return true;
+        }
+
+        foreach (var link in links) {
+            if (link.goods.Match(query)) {
                 return true;
             }
-
-            foreach (var link in links) {
-                if (link.goods.Match(query)) {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
-        /// <summary>
-        /// Add a recipe or technology to this table, and configure the crafter and fuel to reasonable values.
-        /// </summary>
-        /// <param name="recipe">The recipe or technology to add.</param>
-        /// <param name="ingredientVariantComparer">The comparer to use when deciding which fluid variants to use.</param>
-        /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter or lab that can use this fuel, assuming such an entity exists.
-        /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler/lab if any are available.</param>
-        /// <param name="spentFuel"></param>
-        public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods> ingredientVariantComparer, Goods? selectedFuel = null, Goods? spentFuel = null) {
-            RecipeRow recipeRow = new RecipeRow(this, recipe);
-            this.RecordUndo().recipes.Add(recipeRow);
-            EntityCrafter? selectedFuelCrafter = GetSelectedFuelCrafter(recipe, selectedFuel);
-            EntityCrafter? spentFuelRecipeCrafter = GetSpentFuelCrafter(recipe, spentFuel);
+        return false;
+    }
 
-            recipeRow.entity = selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
-            if (recipeRow.entity != null) {
-                recipeRow.fuel = GetSelectedFuel(selectedFuel, recipeRow)
-                    ?? GetFuelForSpentFuel(spentFuel, recipeRow)
-                    ?? recipeRow.entity.energy?.fuels.AutoSelect(DataUtils.FavoriteFuel);
-            }
+    /// <summary>
+    /// Add a recipe or technology to this table, and configure the crafter and fuel to reasonable values.
+    /// </summary>
+    /// <param name="recipe">The recipe or technology to add.</param>
+    /// <param name="ingredientVariantComparer">The comparer to use when deciding which fluid variants to use.</param>
+    /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter or lab that can use this fuel, assuming such an entity exists.
+    /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler/lab if any are available.</param>
+    /// <param name="spentFuel"></param>
+    public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods> ingredientVariantComparer, Goods? selectedFuel = null, Goods? spentFuel = null) {
+        RecipeRow recipeRow = new RecipeRow(this, recipe);
+        this.RecordUndo().recipes.Add(recipeRow);
+        EntityCrafter? selectedFuelCrafter = GetSelectedFuelCrafter(recipe, selectedFuel);
+        EntityCrafter? spentFuelRecipeCrafter = GetSpentFuelCrafter(recipe, spentFuel);
 
-            foreach (Ingredient ingredient in recipeRow.recipe.ingredients) {
-                if (ingredient.variants != null) {
-                    _ = recipeRow.variants.Add(ingredient.variants.AutoSelect(ingredientVariantComparer)!); // null-forgiving: variants is never empty, and AutoSelect never returns null from a non-empty collection (of non-null items).
-                }
-            }
+        recipeRow.entity = selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
+        if (recipeRow.entity != null) {
+            recipeRow.fuel = GetSelectedFuel(selectedFuel, recipeRow)
+                ?? GetFuelForSpentFuel(spentFuel, recipeRow)
+                ?? recipeRow.entity.energy?.fuels.AutoSelect(DataUtils.FavoriteFuel);
         }
 
-        private static EntityCrafter? GetSelectedFuelCrafter(RecipeOrTechnology recipe, Goods? selectedFuel) =>
-            selectedFuel?.fuelFor.OfType<EntityCrafter>()
-                .Where(e => e.recipes.Contains(recipe))
-                .AutoSelect(DataUtils.FavoriteCrafter);
-
-        private static EntityCrafter? GetSpentFuelCrafter(RecipeOrTechnology recipe, Goods? spentFuel) {
-            if (spentFuel is null) {
-                return null;
+        foreach (Ingredient ingredient in recipeRow.recipe.ingredients) {
+            if (ingredient.variants != null) {
+                _ = recipeRow.variants.Add(ingredient.variants.AutoSelect(ingredientVariantComparer)!); // null-forgiving: variants is never empty, and AutoSelect never returns null from a non-empty collection (of non-null items).
             }
-            return recipe.crafters
-                .Where(c => c.energy.fuels.OfType<Item>().Any(e => e.fuelResult == spentFuel))
-                .AutoSelect(DataUtils.FavoriteCrafter);
         }
+    }
 
-        private static Goods? GetFuelForSpentFuel(Goods? spentFuel, [NotNull] RecipeRow recipeRow) {
-            if (spentFuel is null) {
-                return null;
-            }
-            return recipeRow.entity?.energy.fuels.Where(e => spentFuel.miscSources.Contains(e))
-                .AutoSelect(DataUtils.FavoriteFuel);
+    private static EntityCrafter? GetSelectedFuelCrafter(RecipeOrTechnology recipe, Goods? selectedFuel) =>
+        selectedFuel?.fuelFor.OfType<EntityCrafter>()
+            .Where(e => e.recipes.Contains(recipe))
+            .AutoSelect(DataUtils.FavoriteCrafter);
+
+    private static EntityCrafter? GetSpentFuelCrafter(RecipeOrTechnology recipe, Goods? spentFuel) {
+        if (spentFuel is null) {
+            return null;
         }
+        return recipe.crafters
+            .Where(c => c.energy.fuels.OfType<Item>().Any(e => e.fuelResult == spentFuel))
+            .AutoSelect(DataUtils.FavoriteCrafter);
+    }
 
-        private static Goods? GetSelectedFuel(Goods? selectedFuel, [NotNull] RecipeRow recipeRow) =>
-            // Skipping AutoSelect since there will only be one result at most.
-            recipeRow.entity?.energy?.fuels.FirstOrDefault(e => e == selectedFuel);
+    private static Goods? GetFuelForSpentFuel(Goods? spentFuel, [NotNull] RecipeRow recipeRow) {
+        if (spentFuel is null) {
+            return null;
+        }
+        return recipeRow.entity?.energy.fuels.Where(e => spentFuel.miscSources.Contains(e))
+            .AutoSelect(DataUtils.FavoriteFuel);
+    }
 
-        /// <summary>
-        /// Get all <see cref="RecipeRow"/>s contained in this <see cref="ProductionTable"/>, in a depth-first ordering. (The same as in the UI when all nested tables are expanded.)
-        /// </summary>
-        public IEnumerable<RecipeRow> GetAllRecipes() {
-            return flatten(recipes);
+    private static Goods? GetSelectedFuel(Goods? selectedFuel, [NotNull] RecipeRow recipeRow) =>
+        // Skipping AutoSelect since there will only be one result at most.
+        recipeRow.entity?.energy?.fuels.FirstOrDefault(e => e == selectedFuel);
 
-            static IEnumerable<RecipeRow> flatten(IEnumerable<RecipeRow> rows) {
-                foreach (var row in rows) {
-                    yield return row;
-                    if (row.subgroup is not null) {
-                        foreach (var row2 in flatten(row.subgroup.GetAllRecipes())) {
-                            yield return row2;
-                        }
+    /// <summary>
+    /// Get all <see cref="RecipeRow"/>s contained in this <see cref="ProductionTable"/>, in a depth-first ordering. (The same as in the UI when all nested tables are expanded.)
+    /// </summary>
+    public IEnumerable<RecipeRow> GetAllRecipes() {
+        return flatten(recipes);
+
+        static IEnumerable<RecipeRow> flatten(IEnumerable<RecipeRow> rows) {
+            foreach (var row in rows) {
+                yield return row;
+                if (row.subgroup is not null) {
+                    foreach (var row2 in flatten(row.subgroup.GetAllRecipes())) {
+                        yield return row2;
                     }
                 }
             }
         }
+    }
 
-        private static void AddFlow(RecipeRow recipe, Dictionary<Goods, (double prod, double cons)> summer) {
-            foreach (var product in recipe.recipe.products) {
-                _ = summer.TryGetValue(product.goods, out var prev);
-                double amount = recipe.recipesPerSecond * product.GetAmountPerRecipe(recipe.parameters.productivity);
-                prev.prod += amount;
-                summer[product.goods] = prev;
+    private static void AddFlow(RecipeRow recipe, Dictionary<Goods, (double prod, double cons)> summer) {
+        foreach (var product in recipe.recipe.products) {
+            _ = summer.TryGetValue(product.goods, out var prev);
+            double amount = recipe.recipesPerSecond * product.GetAmountPerRecipe(recipe.parameters.productivity);
+            prev.prod += amount;
+            summer[product.goods] = prev;
+        }
+
+        for (int i = 0; i < recipe.recipe.ingredients.Length; i++) {
+            var ingredient = recipe.recipe.ingredients[i];
+            var linkedGoods = recipe.links.ingredientGoods[i];
+            if (linkedGoods is not null) {
+                _ = summer.TryGetValue(linkedGoods, out var prev);
+                prev.cons += recipe.recipesPerSecond * ingredient.amount;
+                summer[linkedGoods] = prev;
             }
-
-            for (int i = 0; i < recipe.recipe.ingredients.Length; i++) {
-                var ingredient = recipe.recipe.ingredients[i];
-                var linkedGoods = recipe.links.ingredientGoods[i];
-                if (linkedGoods is not null) {
-                    _ = summer.TryGetValue(linkedGoods, out var prev);
-                    prev.cons += recipe.recipesPerSecond * ingredient.amount;
-                    summer[linkedGoods] = prev;
-                }
-                else {
-                    Debug.WriteLine("linkedGoods should not have been null here.");
-                }
-            }
-
-            if (recipe.fuel != null && !float.IsNaN(recipe.parameters.fuelUsagePerSecondPerBuilding)) {
-                _ = summer.TryGetValue(recipe.fuel, out var prev);
-                double fuelUsage = recipe.fuelUsagePerSecond;
-                prev.cons += fuelUsage;
-                summer[recipe.fuel] = prev;
-                if (recipe.fuel.HasSpentFuel(out var spentFuel)) {
-                    _ = summer.TryGetValue(spentFuel, out prev);
-                    prev.prod += fuelUsage;
-                    summer[spentFuel] = prev;
-                }
+            else {
+                Debug.WriteLine("linkedGoods should not have been null here.");
             }
         }
 
-        private void CalculateFlow(RecipeRow? include) {
-            Dictionary<Goods, (double prod, double cons)> flowDict = [];
-            if (include != null) {
-                AddFlow(include, flowDict);
+        if (recipe.fuel != null && !float.IsNaN(recipe.parameters.fuelUsagePerSecondPerBuilding)) {
+            _ = summer.TryGetValue(recipe.fuel, out var prev);
+            double fuelUsage = recipe.fuelUsagePerSecond;
+            prev.cons += fuelUsage;
+            summer[recipe.fuel] = prev;
+            if (recipe.fuel.HasSpentFuel(out var spentFuel)) {
+                _ = summer.TryGetValue(spentFuel, out prev);
+                prev.prod += fuelUsage;
+                summer[spentFuel] = prev;
+            }
+        }
+    }
+
+    private void CalculateFlow(RecipeRow? include) {
+        Dictionary<Goods, (double prod, double cons)> flowDict = [];
+        if (include != null) {
+            AddFlow(include, flowDict);
+        }
+
+        foreach (var recipe in recipes) {
+            if (!recipe.enabled) {
+                continue;
             }
 
-            foreach (var recipe in recipes) {
-                if (!recipe.enabled) {
+            if (recipe.subgroup != null) {
+                recipe.subgroup.CalculateFlow(recipe);
+                foreach (var elem in recipe.subgroup.flow) {
+                    _ = flowDict.TryGetValue(elem.goods, out var prev);
+                    if (elem.amount > 0f) {
+                        prev.prod += elem.amount;
+                    }
+                    else {
+                        prev.cons -= elem.amount;
+                    }
+
+                    flowDict[elem.goods] = prev;
+                }
+            }
+            else {
+                AddFlow(recipe, flowDict);
+            }
+        }
+
+        foreach (ProductionLink link in links) {
+            (double prod, double cons) flowParams;
+            if (!link.flags.HasFlagAny(ProductionLink.Flags.LinkNotMatched)) {
+                _ = flowDict.Remove(link.goods, out flowParams);
+            }
+            else {
+                _ = flowDict.TryGetValue(link.goods, out flowParams);
+                if (Math.Abs(flowParams.prod - flowParams.cons) > 1e-8f && link.owner.owner is RecipeRow recipe && recipe.owner.FindLink(link.goods, out var parent)) {
+                    parent.flags |= ProductionLink.Flags.ChildNotMatched | ProductionLink.Flags.LinkNotMatched;
+                }
+            }
+            link.linkFlow = (float)flowParams.prod;
+        }
+
+        ProductionTableFlow[] flowArr = new ProductionTableFlow[flowDict.Count];
+        int index = 0;
+        foreach (var (k, (prod, cons)) in flowDict) {
+            _ = FindLink(k, out var link);
+            flowArr[index++] = new ProductionTableFlow(k, (float)(prod - cons), link);
+        }
+        Array.Sort(flowArr, 0, flowArr.Length, this);
+        flow = flowArr;
+    }
+
+    /// <summary>
+    /// Add/update the variable value for the constraint with the given amount, and store the recipe to the production link.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AddLinkCoef(Constraint cst, Variable var, ProductionLink link, RecipeRow recipe, float amount) {
+        // GetCoefficient will return 0 when the variable is not available in the constraint
+        amount += (float)cst.GetCoefficient(var);
+        link.capturedRecipes.Add(recipe);
+        cst.SetCoefficient(var, amount);
+    }
+
+    public override async Task<string?> Solve(ProjectPage page) {
+        using var productionTableSolver = DataUtils.CreateSolver();
+        var objective = productionTableSolver.Objective();
+        objective.SetMinimization();
+        List<RecipeRow> allRecipes = [];
+        List<ProductionLink> allLinks = [];
+        Setup(allRecipes, allLinks);
+        Variable[] vars = new Variable[allRecipes.Count];
+        float[] objCoefs = new float[allRecipes.Count];
+
+        for (int i = 0; i < allRecipes.Count; i++) {
+            var recipe = allRecipes[i];
+            recipe.parameters = RecipeParameters.CalculateParameters(recipe);
+            var variable = productionTableSolver.MakeNumVar(0f, double.PositiveInfinity, recipe.recipe.name);
+            if (recipe.fixedBuildings > 0f) {
+                double fixedRps = (double)recipe.fixedBuildings / recipe.parameters.recipeTime;
+                variable.SetBounds(fixedRps, fixedRps);
+            }
+            vars[i] = variable;
+        }
+
+        Constraint[] constraints = new Constraint[allLinks.Count];
+        for (int i = 0; i < allLinks.Count; i++) {
+            var link = allLinks[i];
+            float min = link.algorithm == LinkAlgorithm.AllowOverConsumption ? float.NegativeInfinity : link.amount;
+            float max = link.algorithm == LinkAlgorithm.AllowOverProduction ? float.PositiveInfinity : link.amount;
+            var constraint = productionTableSolver.MakeConstraint(min, max, link.goods.name + "_recipe");
+            constraints[i] = constraint;
+            link.solverIndex = i;
+            link.flags = link.amount > 0 ? ProductionLink.Flags.HasConsumption : link.amount < 0 ? ProductionLink.Flags.HasProduction : 0;
+        }
+
+        for (int i = 0; i < allRecipes.Count; i++) {
+            var recipe = allRecipes[i];
+            var recipeVar = vars[i];
+            var links = recipe.links;
+
+            for (int j = 0; j < recipe.recipe.products.Length; j++) {
+                var product = recipe.recipe.products[j];
+                if (product.amount <= 0f) {
                     continue;
                 }
 
-                if (recipe.subgroup != null) {
-                    recipe.subgroup.CalculateFlow(recipe);
-                    foreach (var elem in recipe.subgroup.flow) {
-                        _ = flowDict.TryGetValue(elem.goods, out var prev);
-                        if (elem.amount > 0f) {
-                            prev.prod += elem.amount;
-                        }
-                        else {
-                            prev.cons -= elem.amount;
-                        }
-
-                        flowDict[elem.goods] = prev;
+                if (recipe.FindLink(product.goods, out var link)) {
+                    link.flags |= ProductionLink.Flags.HasProduction;
+                    float added = product.GetAmountPerRecipe(recipe.parameters.productivity);
+                    AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, added);
+                    float cost = product.goods.Cost();
+                    if (cost > 0f) {
+                        objCoefs[i] += added * cost;
                     }
                 }
-                else {
-                    AddFlow(recipe, flowDict);
-                }
+
+                links.products[j] = link;
             }
 
-            foreach (ProductionLink link in links) {
-                (double prod, double cons) flowParams;
-                if (!link.flags.HasFlagAny(ProductionLink.Flags.LinkNotMatched)) {
-                    _ = flowDict.Remove(link.goods, out flowParams);
+            for (int j = 0; j < recipe.recipe.ingredients.Length; j++) {
+                var ingredient = recipe.recipe.ingredients[j];
+                var option = ingredient.variants == null ? ingredient.goods : recipe.GetVariant(ingredient.variants);
+                if (recipe.FindLink(option, out var link)) {
+                    link.flags |= ProductionLink.Flags.HasConsumption;
+                    AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, -ingredient.amount);
                 }
-                else {
-                    _ = flowDict.TryGetValue(link.goods, out flowParams);
-                    if (Math.Abs(flowParams.prod - flowParams.cons) > 1e-8f && link.owner.owner is RecipeRow recipe && recipe.owner.FindLink(link.goods, out var parent)) {
-                        parent.flags |= ProductionLink.Flags.ChildNotMatched | ProductionLink.Flags.LinkNotMatched;
+
+                links.ingredients[j] = link;
+                links.ingredientGoods[j] = option;
+            }
+
+            links.fuel = links.spentFuel = null;
+
+            if (recipe.fuel != null) {
+                float fuelAmount = recipe.parameters.fuelUsagePerSecondPerRecipe;
+                if (recipe.FindLink(recipe.fuel, out var link)) {
+                    links.fuel = link;
+                    link.flags |= ProductionLink.Flags.HasConsumption;
+                    AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, -fuelAmount);
+                }
+
+                if (recipe.fuel.HasSpentFuel(out var spentFuel) && recipe.FindLink(spentFuel, out link)) {
+                    links.spentFuel = link;
+                    link.flags |= ProductionLink.Flags.HasProduction;
+                    AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, fuelAmount);
+                    if (spentFuel.Cost() > 0f) {
+                        objCoefs[i] += fuelAmount * spentFuel.Cost();
                     }
                 }
-                link.linkFlow = (float)flowParams.prod;
             }
 
-            ProductionTableFlow[] flowArr = new ProductionTableFlow[flowDict.Count];
-            int index = 0;
-            foreach (var (k, (prod, cons)) in flowDict) {
-                _ = FindLink(k, out var link);
-                flowArr[index++] = new ProductionTableFlow(k, (float)(prod - cons), link);
-            }
-            Array.Sort(flowArr, 0, flowArr.Length, this);
-            flow = flowArr;
+            recipe.links = links;
         }
 
-        /// <summary>
-        /// Add/update the variable value for the constraint with the given amount, and store the recipe to the production link.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void AddLinkCoef(Constraint cst, Variable var, ProductionLink link, RecipeRow recipe, float amount) {
-            // GetCoefficient will return 0 when the variable is not available in the constraint
-            amount += (float)cst.GetCoefficient(var);
-            link.capturedRecipes.Add(recipe);
-            cst.SetCoefficient(var, amount);
-        }
-
-        public override async Task<string?> Solve(ProjectPage page) {
-            using var productionTableSolver = DataUtils.CreateSolver();
-            var objective = productionTableSolver.Objective();
-            objective.SetMinimization();
-            List<RecipeRow> allRecipes = [];
-            List<ProductionLink> allLinks = [];
-            Setup(allRecipes, allLinks);
-            Variable[] vars = new Variable[allRecipes.Count];
-            float[] objCoefs = new float[allRecipes.Count];
-
-            for (int i = 0; i < allRecipes.Count; i++) {
-                var recipe = allRecipes[i];
-                recipe.parameters = RecipeParameters.CalculateParameters(recipe);
-                var variable = productionTableSolver.MakeNumVar(0f, double.PositiveInfinity, recipe.recipe.name);
-                if (recipe.fixedBuildings > 0f) {
-                    double fixedRps = (double)recipe.fixedBuildings / recipe.parameters.recipeTime;
-                    variable.SetBounds(fixedRps, fixedRps);
+        foreach (var link in allLinks) {
+            link.notMatchedFlow = 0f;
+            if (!link.flags.HasFlags(ProductionLink.Flags.HasProductionAndConsumption)) {
+                if (!link.flags.HasFlagAny(ProductionLink.Flags.HasProductionAndConsumption) && !link.owner.HasDisabledRecipeReferencing(link.goods)) {
+                    _ = link.owner.RecordUndo(true).links.Remove(link);
                 }
-                vars[i] = variable;
+
+                link.flags |= ProductionLink.Flags.LinkNotMatched;
+                constraints[link.solverIndex].SetBounds(double.NegativeInfinity, double.PositiveInfinity); // remove link constraints
+            }
+        }
+
+        await Ui.ExitMainThread();
+        for (int i = 0; i < allRecipes.Count; i++) {
+            objective.SetCoefficient(vars[i], (allRecipes[i].recipe as Recipe)?.RecipeBaseCost() ?? 0);
+        }
+
+        var result = productionTableSolver.Solve();
+        if (result is not Solver.ResultStatus.FEASIBLE and not Solver.ResultStatus.OPTIMAL) {
+            objective.Clear();
+            var (deadlocks, splits) = GetInfeasibilityCandidates(allRecipes);
+            (Variable? positive, Variable? negative)[] slackVars = new (Variable? positive, Variable? negative)[allLinks.Count];
+            // Solution does not exist. Adding slack variables to find the reason
+            foreach (var link in deadlocks) {
+                // Adding negative slack to possible deadlocks (loops)
+                var constraint = constraints[link.solverIndex];
+                float cost = MathF.Abs(link.goods.Cost());
+                var negativeSlack = productionTableSolver.MakeNumVar(0d, double.PositiveInfinity, "negative-slack." + link.goods.name);
+                constraint.SetCoefficient(negativeSlack, cost);
+                objective.SetCoefficient(negativeSlack, 1f);
+                slackVars[link.solverIndex].negative = negativeSlack;
             }
 
-            Constraint[] constraints = new Constraint[allLinks.Count];
-            for (int i = 0; i < allLinks.Count; i++) {
-                var link = allLinks[i];
-                float min = link.algorithm == LinkAlgorithm.AllowOverConsumption ? float.NegativeInfinity : link.amount;
-                float max = link.algorithm == LinkAlgorithm.AllowOverProduction ? float.PositiveInfinity : link.amount;
-                var constraint = productionTableSolver.MakeConstraint(min, max, link.goods.name + "_recipe");
-                constraints[i] = constraint;
-                link.solverIndex = i;
-                link.flags = link.amount > 0 ? ProductionLink.Flags.HasConsumption : link.amount < 0 ? ProductionLink.Flags.HasProduction : 0;
+            foreach (var link in splits) {
+                // Adding positive slack to splits
+                float cost = MathF.Abs(link.goods.Cost());
+                var constraint = constraints[link.solverIndex];
+                var positiveSlack = productionTableSolver.MakeNumVar(0d, double.PositiveInfinity, "positive-slack." + link.goods.name);
+                constraint.SetCoefficient(positiveSlack, -cost);
+                objective.SetCoefficient(positiveSlack, 1f);
+                slackVars[link.solverIndex].positive = positiveSlack;
             }
 
-            for (int i = 0; i < allRecipes.Count; i++) {
-                var recipe = allRecipes[i];
-                var recipeVar = vars[i];
-                var links = recipe.links;
+            result = productionTableSolver.Solve();
 
-                for (int j = 0; j < recipe.recipe.products.Length; j++) {
-                    var product = recipe.recipe.products[j];
-                    if (product.amount <= 0f) {
+            logger.Information("Solver finished with result {result}", result);
+            await Ui.EnterMainThread();
+
+            if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
+                List<ProductionLink> linkList = [];
+                for (int i = 0; i < allLinks.Count; i++) {
+                    var (posSlack, negSlack) = slackVars[i];
+                    if (posSlack is not null && posSlack.BasisStatus() != Solver.BasisStatus.AT_LOWER_BOUND) {
+                        linkList.Add(allLinks[i]);
+                        allLinks[i].notMatchedFlow += (float)posSlack.SolutionValue();
+                    }
+
+                    if (negSlack is not null && negSlack.BasisStatus() != Solver.BasisStatus.AT_LOWER_BOUND) {
+                        linkList.Add(allLinks[i]);
+                        allLinks[i].notMatchedFlow -= (float)negSlack.SolutionValue();
+                    }
+                }
+
+                foreach (var link in linkList) {
+                    if (link.notMatchedFlow == 0f) {
                         continue;
                     }
 
-                    if (recipe.FindLink(product.goods, out var link)) {
-                        link.flags |= ProductionLink.Flags.HasProduction;
-                        float added = product.GetAmountPerRecipe(recipe.parameters.productivity);
-                        AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, added);
-                        float cost = product.goods.Cost();
-                        if (cost > 0f) {
-                            objCoefs[i] += added * cost;
+                    link.flags |= ProductionLink.Flags.LinkNotMatched | ProductionLink.Flags.LinkRecursiveNotMatched;
+                    RecipeRow? ownerRecipe = link.owner.owner as RecipeRow;
+                    while (ownerRecipe != null) {
+                        if (link.notMatchedFlow > 0f) {
+                            ownerRecipe.parameters.warningFlags |= WarningFlags.OverproductionRequired;
                         }
-                    }
-
-                    links.products[j] = link;
-                }
-
-                for (int j = 0; j < recipe.recipe.ingredients.Length; j++) {
-                    var ingredient = recipe.recipe.ingredients[j];
-                    var option = ingredient.variants == null ? ingredient.goods : recipe.GetVariant(ingredient.variants);
-                    if (recipe.FindLink(option, out var link)) {
-                        link.flags |= ProductionLink.Flags.HasConsumption;
-                        AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, -ingredient.amount);
-                    }
-
-                    links.ingredients[j] = link;
-                    links.ingredientGoods[j] = option;
-                }
-
-                links.fuel = links.spentFuel = null;
-
-                if (recipe.fuel != null) {
-                    float fuelAmount = recipe.parameters.fuelUsagePerSecondPerRecipe;
-                    if (recipe.FindLink(recipe.fuel, out var link)) {
-                        links.fuel = link;
-                        link.flags |= ProductionLink.Flags.HasConsumption;
-                        AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, -fuelAmount);
-                    }
-
-                    if (recipe.fuel.HasSpentFuel(out var spentFuel) && recipe.FindLink(spentFuel, out link)) {
-                        links.spentFuel = link;
-                        link.flags |= ProductionLink.Flags.HasProduction;
-                        AddLinkCoef(constraints[link.solverIndex], recipeVar, link, recipe, fuelAmount);
-                        if (spentFuel.Cost() > 0f) {
-                            objCoefs[i] += fuelAmount * spentFuel.Cost();
-                        }
-                    }
-                }
-
-                recipe.links = links;
-            }
-
-            foreach (var link in allLinks) {
-                link.notMatchedFlow = 0f;
-                if (!link.flags.HasFlags(ProductionLink.Flags.HasProductionAndConsumption)) {
-                    if (!link.flags.HasFlagAny(ProductionLink.Flags.HasProductionAndConsumption) && !link.owner.HasDisabledRecipeReferencing(link.goods)) {
-                        _ = link.owner.RecordUndo(true).links.Remove(link);
-                    }
-
-                    link.flags |= ProductionLink.Flags.LinkNotMatched;
-                    constraints[link.solverIndex].SetBounds(double.NegativeInfinity, double.PositiveInfinity); // remove link constraints
-                }
-            }
-
-            await Ui.ExitMainThread();
-            for (int i = 0; i < allRecipes.Count; i++) {
-                objective.SetCoefficient(vars[i], (allRecipes[i].recipe as Recipe)?.RecipeBaseCost() ?? 0);
-            }
-
-            var result = productionTableSolver.Solve();
-            if (result is not Solver.ResultStatus.FEASIBLE and not Solver.ResultStatus.OPTIMAL) {
-                objective.Clear();
-                var (deadlocks, splits) = GetInfeasibilityCandidates(allRecipes);
-                (Variable? positive, Variable? negative)[] slackVars = new (Variable? positive, Variable? negative)[allLinks.Count];
-                // Solution does not exist. Adding slack variables to find the reason
-                foreach (var link in deadlocks) {
-                    // Adding negative slack to possible deadlocks (loops)
-                    var constraint = constraints[link.solverIndex];
-                    float cost = MathF.Abs(link.goods.Cost());
-                    var negativeSlack = productionTableSolver.MakeNumVar(0d, double.PositiveInfinity, "negative-slack." + link.goods.name);
-                    constraint.SetCoefficient(negativeSlack, cost);
-                    objective.SetCoefficient(negativeSlack, 1f);
-                    slackVars[link.solverIndex].negative = negativeSlack;
-                }
-
-                foreach (var link in splits) {
-                    // Adding positive slack to splits
-                    float cost = MathF.Abs(link.goods.Cost());
-                    var constraint = constraints[link.solverIndex];
-                    var positiveSlack = productionTableSolver.MakeNumVar(0d, double.PositiveInfinity, "positive-slack." + link.goods.name);
-                    constraint.SetCoefficient(positiveSlack, -cost);
-                    objective.SetCoefficient(positiveSlack, 1f);
-                    slackVars[link.solverIndex].positive = positiveSlack;
-                }
-
-                result = productionTableSolver.Solve();
-
-                logger.Information("Solver finished with result {result}", result);
-                await Ui.EnterMainThread();
-
-                if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
-                    List<ProductionLink> linkList = [];
-                    for (int i = 0; i < allLinks.Count; i++) {
-                        var (posSlack, negSlack) = slackVars[i];
-                        if (posSlack is not null && posSlack.BasisStatus() != Solver.BasisStatus.AT_LOWER_BOUND) {
-                            linkList.Add(allLinks[i]);
-                            allLinks[i].notMatchedFlow += (float)posSlack.SolutionValue();
+                        else {
+                            ownerRecipe.parameters.warningFlags |= WarningFlags.DeadlockCandidate;
                         }
 
-                        if (negSlack is not null && negSlack.BasisStatus() != Solver.BasisStatus.AT_LOWER_BOUND) {
-                            linkList.Add(allLinks[i]);
-                            allLinks[i].notMatchedFlow -= (float)negSlack.SolutionValue();
-                        }
+                        ownerRecipe = ownerRecipe.owner.owner as RecipeRow;
                     }
+                }
 
+                foreach (var recipe in allRecipes) {
+                    FindAllRecipeLinks(recipe, linkList, linkList);
                     foreach (var link in linkList) {
-                        if (link.notMatchedFlow == 0f) {
-                            continue;
-                        }
-
-                        link.flags |= ProductionLink.Flags.LinkNotMatched | ProductionLink.Flags.LinkRecursiveNotMatched;
-                        RecipeRow? ownerRecipe = link.owner.owner as RecipeRow;
-                        while (ownerRecipe != null) {
+                        if (link.flags.HasFlags(ProductionLink.Flags.LinkRecursiveNotMatched)) {
                             if (link.notMatchedFlow > 0f) {
-                                ownerRecipe.parameters.warningFlags |= WarningFlags.OverproductionRequired;
+                                recipe.parameters.warningFlags |= WarningFlags.OverproductionRequired;
                             }
                             else {
-                                ownerRecipe.parameters.warningFlags |= WarningFlags.DeadlockCandidate;
-                            }
-
-                            ownerRecipe = ownerRecipe.owner.owner as RecipeRow;
-                        }
-                    }
-
-                    foreach (var recipe in allRecipes) {
-                        FindAllRecipeLinks(recipe, linkList, linkList);
-                        foreach (var link in linkList) {
-                            if (link.flags.HasFlags(ProductionLink.Flags.LinkRecursiveNotMatched)) {
-                                if (link.notMatchedFlow > 0f) {
-                                    recipe.parameters.warningFlags |= WarningFlags.OverproductionRequired;
-                                }
-                                else {
-                                    recipe.parameters.warningFlags |= WarningFlags.DeadlockCandidate;
-                                }
+                                recipe.parameters.warningFlags |= WarningFlags.DeadlockCandidate;
                             }
                         }
                     }
                 }
-                else {
-                    if (result == Solver.ResultStatus.INFEASIBLE) {
-                        return "YAFC failed to solve the model and to find deadlock loops. As a result, the model was not updated.";
-                    }
-
-                    if (result == Solver.ResultStatus.ABNORMAL) {
-                        return "This model has numerical errors (probably too small or too large numbers) and cannot be solved";
-                    }
-
-                    return "Unaccounted error: MODEL_" + result;
-                }
             }
-
-            for (int i = 0; i < allLinks.Count; i++) {
-                var link = allLinks[i];
-                var constraint = constraints[i];
-                link.dualValue = (float)constraint.DualValue();
-                if (constraint == null) {
-                    continue;
+            else {
+                if (result == Solver.ResultStatus.INFEASIBLE) {
+                    return "YAFC failed to solve the model and to find deadlock loops. As a result, the model was not updated.";
                 }
 
-                var basisStatus = constraint.BasisStatus();
-                if ((basisStatus == Solver.BasisStatus.BASIC || basisStatus == Solver.BasisStatus.FREE) && (link.notMatchedFlow != 0 || link.algorithm != LinkAlgorithm.Match)) {
-                    link.flags |= ProductionLink.Flags.LinkNotMatched;
+                if (result == Solver.ResultStatus.ABNORMAL) {
+                    return "This model has numerical errors (probably too small or too large numbers) and cannot be solved";
                 }
 
+                return "Unaccounted error: MODEL_" + result;
             }
-
-            for (int i = 0; i < allRecipes.Count; i++) {
-                var recipe = allRecipes[i];
-                recipe.recipesPerSecond = vars[i].SolutionValue();
-            }
-
-            bool builtCountExceeded = CheckBuiltCountExceeded();
-
-            CalculateFlow(null);
-            return builtCountExceeded ? "This model requires more buildings than are currently built" : null;
         }
 
-        /// <summary>
-        /// Search the disabled recipes in this table and see if any of them produce or consume <paramref name="goods"/>. If they do, the corresponding <see cref="ProductionLink"/> should not be deleted.
-        /// </summary>
-        /// <param name="goods">The <see cref="Goods"/> that might have its link removed.</param>
-        /// <returns><see langword="true"/> if the link should be preserved, or <see langword="false"/> if it is ok to delete the link.</returns>
-        private bool HasDisabledRecipeReferencing(Goods goods)
-            => GetAllRecipes().Any(row => !row.hierarchyEnabled
-            && (row.fuel == goods || row.recipe.ingredients.Any(i => i.goods == goods) || row.recipe.products.Any(p => p.goods == goods)));
+        for (int i = 0; i < allLinks.Count; i++) {
+            var link = allLinks[i];
+            var constraint = constraints[i];
+            link.dualValue = (float)constraint.DualValue();
+            if (constraint == null) {
+                continue;
+            }
 
-        private bool CheckBuiltCountExceeded() {
-            bool builtCountExceeded = false;
-            for (int i = 0; i < recipes.Count; i++) {
-                var recipe = recipes[i];
-                if (recipe.buildingCount > recipe.builtBuildings) {
+            var basisStatus = constraint.BasisStatus();
+            if ((basisStatus == Solver.BasisStatus.BASIC || basisStatus == Solver.BasisStatus.FREE) && (link.notMatchedFlow != 0 || link.algorithm != LinkAlgorithm.Match)) {
+                link.flags |= ProductionLink.Flags.LinkNotMatched;
+            }
+
+        }
+
+        for (int i = 0; i < allRecipes.Count; i++) {
+            var recipe = allRecipes[i];
+            recipe.recipesPerSecond = vars[i].SolutionValue();
+        }
+
+        bool builtCountExceeded = CheckBuiltCountExceeded();
+
+        CalculateFlow(null);
+        return builtCountExceeded ? "This model requires more buildings than are currently built" : null;
+    }
+
+    /// <summary>
+    /// Search the disabled recipes in this table and see if any of them produce or consume <paramref name="goods"/>. If they do, the corresponding <see cref="ProductionLink"/> should not be deleted.
+    /// </summary>
+    /// <param name="goods">The <see cref="Goods"/> that might have its link removed.</param>
+    /// <returns><see langword="true"/> if the link should be preserved, or <see langword="false"/> if it is ok to delete the link.</returns>
+    private bool HasDisabledRecipeReferencing(Goods goods)
+        => GetAllRecipes().Any(row => !row.hierarchyEnabled
+        && (row.fuel == goods || row.recipe.ingredients.Any(i => i.goods == goods) || row.recipe.products.Any(p => p.goods == goods)));
+
+    private bool CheckBuiltCountExceeded() {
+        bool builtCountExceeded = false;
+        for (int i = 0; i < recipes.Count; i++) {
+            var recipe = recipes[i];
+            if (recipe.buildingCount > recipe.builtBuildings) {
+                recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
+                builtCountExceeded = true;
+            }
+            else if (recipe.subgroup != null) {
+                if (recipe.subgroup.CheckBuiltCountExceeded()) {
                     recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
                     builtCountExceeded = true;
                 }
-                else if (recipe.subgroup != null) {
-                    if (recipe.subgroup.CheckBuiltCountExceeded()) {
-                        recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
-                        builtCountExceeded = true;
-                    }
-                }
-            }
-
-            return builtCountExceeded;
-        }
-
-        private static void FindAllRecipeLinks(RecipeRow recipe, List<ProductionLink> sources, List<ProductionLink> targets) {
-            sources.Clear();
-            targets.Clear();
-            foreach (var link in recipe.links.products) {
-                if (link != null) {
-                    targets.Add(link);
-                }
-            }
-
-            foreach (var link in recipe.links.ingredients) {
-                if (link != null) {
-                    sources.Add(link);
-                }
-            }
-
-            if (recipe.links.fuel != null) {
-                sources.Add(recipe.links.fuel);
-            }
-
-            if (recipe.links.spentFuel != null) {
-                targets.Add(recipe.links.spentFuel);
             }
         }
 
-        private static (List<ProductionLink> merges, List<ProductionLink> splits) GetInfeasibilityCandidates(List<RecipeRow> recipes) {
-            Graph<ProductionLink> graph = new Graph<ProductionLink>();
-            List<ProductionLink> sources = [];
-            List<ProductionLink> targets = [];
-            List<ProductionLink> splits = [];
+        return builtCountExceeded;
+    }
 
-            foreach (var recipe in recipes) {
-                FindAllRecipeLinks(recipe, sources, targets);
-                foreach (var src in sources) {
-                    foreach (var tgt in targets) {
-                        graph.Connect(src, tgt);
-                    }
-                }
+    private static void FindAllRecipeLinks(RecipeRow recipe, List<ProductionLink> sources, List<ProductionLink> targets) {
+        sources.Clear();
+        targets.Clear();
+        foreach (var link in recipe.links.products) {
+            if (link != null) {
+                targets.Add(link);
+            }
+        }
 
-                if (targets.Count > 1) {
-                    splits.AddRange(targets);
+        foreach (var link in recipe.links.ingredients) {
+            if (link != null) {
+                sources.Add(link);
+            }
+        }
+
+        if (recipe.links.fuel != null) {
+            sources.Add(recipe.links.fuel);
+        }
+
+        if (recipe.links.spentFuel != null) {
+            targets.Add(recipe.links.spentFuel);
+        }
+    }
+
+    private static (List<ProductionLink> merges, List<ProductionLink> splits) GetInfeasibilityCandidates(List<RecipeRow> recipes) {
+        Graph<ProductionLink> graph = new Graph<ProductionLink>();
+        List<ProductionLink> sources = [];
+        List<ProductionLink> targets = [];
+        List<ProductionLink> splits = [];
+
+        foreach (var recipe in recipes) {
+            FindAllRecipeLinks(recipe, sources, targets);
+            foreach (var src in sources) {
+                foreach (var tgt in targets) {
+                    graph.Connect(src, tgt);
                 }
             }
 
-            var loops = graph.MergeStrongConnectedComponents();
-            sources.Clear();
-            foreach (var possibleLoop in loops) {
-                if (possibleLoop.userData.list != null) {
-                    var list = possibleLoop.userData.list;
-                    var last = list[^1];
-                    sources.Add(last);
-                    for (int i = 0; i < list.Length - 1; i++) {
-                        for (int j = i + 2; j < list.Length; j++) {
-                            if (graph.HasConnection(list[i], list[j])) {
-                                sources.Add(list[i]);
-                                break;
-                            }
+            if (targets.Count > 1) {
+                splits.AddRange(targets);
+            }
+        }
+
+        var loops = graph.MergeStrongConnectedComponents();
+        sources.Clear();
+        foreach (var possibleLoop in loops) {
+            if (possibleLoop.userData.list != null) {
+                var list = possibleLoop.userData.list;
+                var last = list[^1];
+                sources.Add(last);
+                for (int i = 0; i < list.Length - 1; i++) {
+                    for (int j = i + 2; j < list.Length; j++) {
+                        if (graph.HasConnection(list[i], list[j])) {
+                            sources.Add(list[i]);
+                            break;
                         }
                     }
                 }
             }
-
-            return (sources, splits);
         }
 
-        public bool FindLink(Goods goods, [MaybeNullWhen(false)] out ProductionLink link) {
-            if (goods == null) {
-                link = null;
+        return (sources, splits);
+    }
+
+    public bool FindLink(Goods goods, [MaybeNullWhen(false)] out ProductionLink link) {
+        if (goods == null) {
+            link = null;
+            return false;
+        }
+        var searchFrom = this;
+        while (true) {
+            if (searchFrom.linkMap.TryGetValue(goods, out link)) {
+                return true;
+            }
+
+            if (searchFrom.owner is RecipeRow row) {
+                searchFrom = row.owner;
+            }
+            else {
                 return false;
             }
-            var searchFrom = this;
-            while (true) {
-                if (searchFrom.linkMap.TryGetValue(goods, out link)) {
-                    return true;
-                }
-
-                if (searchFrom.owner is RecipeRow row) {
-                    searchFrom = row.owner;
-                }
-                else {
-                    return false;
-                }
-            }
         }
+    }
 
-        public int Compare(ProductionTableFlow x, ProductionTableFlow y) {
-            float amt1 = x.goods.fluid != null ? x.amount / 50f : x.amount;
-            float amt2 = y.goods.fluid != null ? y.amount / 50f : y.amount;
-            return amt1.CompareTo(amt2);
-        }
+    public int Compare(ProductionTableFlow x, ProductionTableFlow y) {
+        float amt1 = x.goods.fluid != null ? x.amount / 50f : x.amount;
+        float amt2 = y.goods.fluid != null ? y.amount / 50f : y.amount;
+        return amt1.CompareTo(amt2);
     }
 }
 

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -5,684 +5,683 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public struct ModuleEffects {
-        public float speed;
-        public float productivity;
-        public float consumption;
-        public readonly float speedMod => MathF.Max(1f + speed, 0.2f);
-        public readonly float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
-        public void AddModules(ModuleSpecification module, float count, AllowedEffects allowedEffects) {
-            if (allowedEffects.HasFlags(AllowedEffects.Speed)) {
-                speed += module.speed * count;
-            }
-
-            if (allowedEffects.HasFlags(AllowedEffects.Productivity) && module.productivity > 0f) {
-                productivity += module.productivity * count;
-            }
-
-            if (allowedEffects.HasFlags(AllowedEffects.Consumption)) {
-                consumption += module.consumption * count;
-            }
+namespace Yafc.Model;
+public struct ModuleEffects {
+    public float speed;
+    public float productivity;
+    public float consumption;
+    public readonly float speedMod => MathF.Max(1f + speed, 0.2f);
+    public readonly float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
+    public void AddModules(ModuleSpecification module, float count, AllowedEffects allowedEffects) {
+        if (allowedEffects.HasFlags(AllowedEffects.Speed)) {
+            speed += module.speed * count;
         }
 
-        public void AddModules(ModuleSpecification module, float count) {
-            speed += module.speed * count;
-            if (module.productivity > 0f) {
-                productivity += module.productivity * count;
-            }
+        if (allowedEffects.HasFlags(AllowedEffects.Productivity) && module.productivity > 0f) {
+            productivity += module.productivity * count;
+        }
 
+        if (allowedEffects.HasFlags(AllowedEffects.Consumption)) {
             consumption += module.consumption * count;
         }
+    }
 
-        public readonly int GetModuleSoftLimit(ModuleSpecification module, int hardLimit) {
-            if (module == null) {
-                return 0;
-            }
+    public void AddModules(ModuleSpecification module, float count) {
+        speed += module.speed * count;
+        if (module.productivity > 0f) {
+            productivity += module.productivity * count;
+        }
 
-            if (module.productivity > 0f || module.speed > 0f || module.pollution < 0f) {
-                return hardLimit;
-            }
+        consumption += module.consumption * count;
+    }
 
-            if (module.consumption < 0f) {
-                return MathUtils.Clamp(MathUtils.Ceil(-(consumption + 0.8f) / module.consumption), 0, hardLimit);
-            }
-
+    public readonly int GetModuleSoftLimit(ModuleSpecification module, int hardLimit) {
+        if (module == null) {
             return 0;
         }
-    }
 
-    /// <summary>
-    /// One module that is (or will be) applied to a <see cref="RecipeRow"/>, and the number of times it should appear.
-    /// </summary>
-    /// <remarks>Immutable. To modify, modify the owning <see cref="ModuleTemplate"/>.</remarks>
-    [Serializable]
-    public class RecipeRowCustomModule(ModuleTemplate owner, Module module, int fixedCount = 0) : ModelObject<ModuleTemplate>(owner) {
-        public Module module { get; } = module ?? throw new ArgumentNullException(nameof(module));
-        public int fixedCount { get; } = fixedCount;
-    }
-
-    /// <summary>
-    /// The template that determines what modules are (or will be) applied to a <see cref="RecipeRow"/>.
-    /// </summary>
-    /// <remarks>Immutable. To modify, call <see cref="GetBuilder"/>, modify the builder, and call <see cref="ModuleTemplateBuilder.Build"/>.</remarks>
-    [Serializable, DeserializeWithNonPublicConstructor]
-    public class ModuleTemplate : ModelObject<ModelObject> {
-        /// <summary>
-        /// The beacon to use, if any, for the associated <see cref="RecipeRow"/>.
-        /// </summary>
-        public EntityBeacon? beacon { get; }
-        /// <summary>
-        /// The modules, if any, to directly insert into the crafting entity.
-        /// </summary>
-        public ReadOnlyCollection<RecipeRowCustomModule> list { get; private set; } = new([]); // Must be a distinct collection object to accomodate the deserializer.
-        /// <summary>
-        /// The modules, if any, to insert into beacons that affect the crafting entity.
-        /// </summary>
-        public ReadOnlyCollection<RecipeRowCustomModule> beaconList { get; private set; } = new([]); // Must be a distinct collection object to accomodate the deserializer.
-
-        private ModuleTemplate(ModelObject owner, EntityBeacon? beacon) : base(owner) => this.beacon = beacon;
-
-        public bool IsCompatibleWith([NotNullWhen(true)] RecipeRow? row) {
-            if (row?.entity == null) {
-                return false;
-            }
-
-            bool hasFloodfillModules = false;
-            bool hasCompatibleFloodfill = false;
-            int totalModules = 0;
-            foreach (var module in list) {
-                bool isCompatibleWithModule = row.recipe.CanAcceptModule(module.module) && row.entity.CanAcceptModule(module.module.moduleSpecification);
-                if (module.fixedCount == 0) {
-                    hasFloodfillModules = true;
-                    hasCompatibleFloodfill |= isCompatibleWithModule;
-                }
-                else {
-                    if (!isCompatibleWithModule) {
-                        return false;
-                    }
-
-                    totalModules += module.fixedCount;
-                }
-            }
-
-            return (!hasFloodfillModules || hasCompatibleFloodfill) && row.entity.moduleSlots >= totalModules;
+        if (module.productivity > 0f || module.speed > 0f || module.pollution < 0f) {
+            return hardLimit;
         }
 
-        internal void GetModulesInfo(RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used, ModuleFillerParameters? filler) {
-            List<(Module module, int count, bool beacon)> buffer = [];
-            int beaconedModules = 0;
-            Item? nonBeacon = null;
-            used.modules = null;
-            int remaining = entity.moduleSlots;
-            foreach (var module in list) {
-                if (!entity.CanAcceptModule(module.module.moduleSpecification) || !row.recipe.CanAcceptModule(module.module)) {
-                    continue;
-                }
+        if (module.consumption < 0f) {
+            return MathUtils.Clamp(MathUtils.Ceil(-(consumption + 0.8f) / module.consumption), 0, hardLimit);
+        }
 
-                if (remaining <= 0) {
-                    break;
-                }
+        return 0;
+    }
+}
 
-                int count = Math.Min(module.fixedCount == 0 ? int.MaxValue : module.fixedCount, remaining);
-                remaining -= count;
-                nonBeacon ??= module.module;
-                buffer.Add((module.module, count, false));
-                effects.AddModules(module.module.moduleSpecification, count);
-            }
+/// <summary>
+/// One module that is (or will be) applied to a <see cref="RecipeRow"/>, and the number of times it should appear.
+/// </summary>
+/// <remarks>Immutable. To modify, modify the owning <see cref="ModuleTemplate"/>.</remarks>
+[Serializable]
+public class RecipeRowCustomModule(ModuleTemplate owner, Module module, int fixedCount = 0) : ModelObject<ModuleTemplate>(owner) {
+    public Module module { get; } = module ?? throw new ArgumentNullException(nameof(module));
+    public int fixedCount { get; } = fixedCount;
+}
 
-            if (beacon != null) {
-                foreach (var module in beaconList) {
-                    beaconedModules += module.fixedCount;
-                    buffer.Add((module.module, module.fixedCount, true));
-                    effects.AddModules(module.module.moduleSpecification, beacon.beaconEfficiency * module.fixedCount);
-                }
+/// <summary>
+/// The template that determines what modules are (or will be) applied to a <see cref="RecipeRow"/>.
+/// </summary>
+/// <remarks>Immutable. To modify, call <see cref="GetBuilder"/>, modify the builder, and call <see cref="ModuleTemplateBuilder.Build"/>.</remarks>
+[Serializable, DeserializeWithNonPublicConstructor]
+public class ModuleTemplate : ModelObject<ModelObject> {
+    /// <summary>
+    /// The beacon to use, if any, for the associated <see cref="RecipeRow"/>.
+    /// </summary>
+    public EntityBeacon? beacon { get; }
+    /// <summary>
+    /// The modules, if any, to directly insert into the crafting entity.
+    /// </summary>
+    public ReadOnlyCollection<RecipeRowCustomModule> list { get; private set; } = new([]); // Must be a distinct collection object to accomodate the deserializer.
+    /// <summary>
+    /// The modules, if any, to insert into beacons that affect the crafting entity.
+    /// </summary>
+    public ReadOnlyCollection<RecipeRowCustomModule> beaconList { get; private set; } = new([]); // Must be a distinct collection object to accomodate the deserializer.
 
-                if (beaconedModules > 0) {
-                    used.beacon = beacon;
-                    used.beaconCount = ((beaconedModules - 1) / beacon.moduleSlots) + 1;
-                }
+    private ModuleTemplate(ModelObject owner, EntityBeacon? beacon) : base(owner) => this.beacon = beacon;
+
+    public bool IsCompatibleWith([NotNullWhen(true)] RecipeRow? row) {
+        if (row?.entity == null) {
+            return false;
+        }
+
+        bool hasFloodfillModules = false;
+        bool hasCompatibleFloodfill = false;
+        int totalModules = 0;
+        foreach (var module in list) {
+            bool isCompatibleWithModule = row.recipe.CanAcceptModule(module.module) && row.entity.CanAcceptModule(module.module.moduleSpecification);
+            if (module.fixedCount == 0) {
+                hasFloodfillModules = true;
+                hasCompatibleFloodfill |= isCompatibleWithModule;
             }
             else {
-                filler?.AutoFillBeacons(row.recipe, entity, ref effects, ref used);
-            }
+                if (!isCompatibleWithModule) {
+                    return false;
+                }
 
-            used.modules = [.. buffer];
+                totalModules += module.fixedCount;
+            }
         }
 
-        public int CalcBeaconCount() {
-            if (beacon is null) {
-                throw new InvalidOperationException($"Must not call {nameof(CalcBeaconCount)} when {nameof(beacon)} is null.");
-            }
-            int moduleCount = 0;
-            foreach (var element in beaconList) {
-                moduleCount += element.fixedCount;
+        return (!hasFloodfillModules || hasCompatibleFloodfill) && row.entity.moduleSlots >= totalModules;
+    }
+
+    internal void GetModulesInfo(RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used, ModuleFillerParameters? filler) {
+        List<(Module module, int count, bool beacon)> buffer = [];
+        int beaconedModules = 0;
+        Item? nonBeacon = null;
+        used.modules = null;
+        int remaining = entity.moduleSlots;
+        foreach (var module in list) {
+            if (!entity.CanAcceptModule(module.module.moduleSpecification) || !row.recipe.CanAcceptModule(module.module)) {
+                continue;
             }
 
-            return ((moduleCount - 1) / beacon.moduleSlots) + 1;
+            if (remaining <= 0) {
+                break;
+            }
+
+            int count = Math.Min(module.fixedCount == 0 ? int.MaxValue : module.fixedCount, remaining);
+            remaining -= count;
+            nonBeacon ??= module.module;
+            buffer.Add((module.module, count, false));
+            effects.AddModules(module.module.moduleSpecification, count);
         }
 
-        /// <summary>
-        /// Get a <see cref="ModuleTemplateBuilder"/> initialized to rebuild the contents of this <see cref="ModuleTemplate"/>.
-        /// </summary>
-        public ModuleTemplateBuilder GetBuilder() => new() {
-            beacon = beacon,
-            list = [.. list.Select(m => (m.module, m.fixedCount))],
-            beaconList = [.. beaconList.Select(m => (m.module, m.fixedCount))]
+        if (beacon != null) {
+            foreach (var module in beaconList) {
+                beaconedModules += module.fixedCount;
+                buffer.Add((module.module, module.fixedCount, true));
+                effects.AddModules(module.module.moduleSpecification, beacon.beaconEfficiency * module.fixedCount);
+            }
+
+            if (beaconedModules > 0) {
+                used.beacon = beacon;
+                used.beaconCount = ((beaconedModules - 1) / beacon.moduleSlots) + 1;
+            }
+        }
+        else {
+            filler?.AutoFillBeacons(row.recipe, entity, ref effects, ref used);
+        }
+
+        used.modules = [.. buffer];
+    }
+
+    public int CalcBeaconCount() {
+        if (beacon is null) {
+            throw new InvalidOperationException($"Must not call {nameof(CalcBeaconCount)} when {nameof(beacon)} is null.");
+        }
+        int moduleCount = 0;
+        foreach (var element in beaconList) {
+            moduleCount += element.fixedCount;
+        }
+
+        return ((moduleCount - 1) / beacon.moduleSlots) + 1;
+    }
+
+    /// <summary>
+    /// Get a <see cref="ModuleTemplateBuilder"/> initialized to rebuild the contents of this <see cref="ModuleTemplate"/>.
+    /// </summary>
+    public ModuleTemplateBuilder GetBuilder() => new() {
+        beacon = beacon,
+        list = [.. list.Select(m => (m.module, m.fixedCount))],
+        beaconList = [.. beaconList.Select(m => (m.module, m.fixedCount))]
+    };
+
+    internal static ModuleTemplate Build(ModelObject owner, ModuleTemplateBuilder builder) {
+#pragma warning disable IDE0017 // False positive: convertList cannot be called before the assignment completes
+        ModuleTemplate modules = new(owner, builder.beacon);
+#pragma warning restore IDE0017
+        modules.list = convertList(builder.list);
+        modules.beaconList = convertList(builder.beaconList);
+        return modules;
+
+        ReadOnlyCollection<RecipeRowCustomModule> convertList(List<(Module module, int fixedCount)> list)
+            => list.Select(m => new RecipeRowCustomModule(modules, m.module, m.fixedCount)).ToList().AsReadOnly();
+    }
+}
+
+/// <summary>
+/// An object that can be used to configure and build a <see cref="ModuleTemplate"/>.
+/// </summary>
+public class ModuleTemplateBuilder {
+    /// <summary>
+    /// The beacon to be stored in <see cref="ModuleTemplate.beacon"/> after building.
+    /// </summary>
+    public EntityBeacon? beacon { get; set; }
+    /// <summary>
+    /// The list of <see cref="Module"/>s and counts to be stored in <see cref="ModuleTemplate.list"/> after building.
+    /// </summary>
+    public List<(Module module, int fixedCount)> list { get; set; } = [];
+    /// <summary>
+    /// The list of <see cref="Module"/>s and counts to be stored in <see cref="ModuleTemplate.beaconList"/> after building.
+    /// </summary>
+    public List<(Module module, int fixedCount)> beaconList { get; set; } = [];
+
+    /// <summary>
+    /// Builds a <see cref="ModuleTemplate"/> from this <see cref="ModuleTemplateBuilder"/>.
+    /// </summary>
+    /// <param name="owner">The <see cref="RecipeRow"/> or <see cref="ProjectModuleTemplate"/> that will own the built <see cref="ModuleTemplate"/>.</param>
+    public ModuleTemplate Build(ModelObject owner) => ModuleTemplate.Build(owner, this);
+}
+
+// Stores collection on ProductionLink recipe was linked to the previous computation
+internal struct RecipeLinks {
+    public Goods[] ingredientGoods;
+    public ProductionLink?[] ingredients;
+    public ProductionLink?[] products;
+    public ProductionLink? fuel;
+    public ProductionLink? spentFuel;
+}
+
+public interface IElementGroup<TElement> {
+    List<TElement> elements { get; }
+    bool expanded { get; set; }
+}
+
+public interface IGroupedElement<TGroup> {
+    void SetOwner(TGroup newOwner);
+    TGroup? subgroup { get; }
+    bool visible { get; }
+}
+
+public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<ProductionTable> {
+    private EntityCrafter? _entity;
+    private Goods? _fuel;
+    private float _fixedBuildings;
+    private Goods? _fixedProduct;
+    private ModuleTemplate? _modules;
+
+    public RecipeOrTechnology recipe { get; }
+    // Variable parameters
+    public EntityCrafter? entity {
+        get => _entity;
+        set {
+            if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _entity == value) {
+                _entity = value;
+            }
+            else if (fixedFuel && !(value?.energy.fuels ?? []).Contains(_fuel)) {
+                // We're changing both the entity and the fuel (changing between electric, fluid-burning, item-burning, heat-powered, and steam-powered crafter categories)
+                // Don't try to preserve fuel consumption in this case.
+                fixedBuildings = 0;
+                _entity = value;
+            }
+            else {
+                using (new ChangeModulesOrEntity(this)) {
+                    _entity = value;
+                }
+            }
+        }
+    }
+    public Goods? fuel {
+        get => _fuel;
+        set {
+            if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _fuel == value) {
+                _fuel = value;
+            }
+            else if (fixedProduct != null && ((fuel as Item)?.fuelResult == fixedProduct || (value as Item)?.fuelResult == fixedProduct)) {
+                if (recipe.products.SingleOrDefault(p => p.goods == fixedProduct, false) is not Product product) {
+                    fixedBuildings = 0; // We couldn't find the Product corresponding to fixedProduct. Just clear the fixed amount.
+                    _fuel = value;
+                }
+                else {
+                    // We're changing the fuel and at least one of the current or new fuel burns to the fixed product
+                    double oldAmount = product.GetAmountForRow(this);
+                    if ((fuel as Item)?.fuelResult == fixedProduct) {
+                        oldAmount += fuelUsagePerSecond;
+                    }
+                    _fuel = value;
+                    parameters = RecipeParameters.CalculateParameters(this);
+                    double newAmount = product.GetAmountForRow(this);
+                    if ((fuel as Item)?.fuelResult == fixedProduct) {
+                        newAmount += fuelUsagePerSecond;
+                    }
+                    fixedBuildings *= (float)(oldAmount / newAmount);
+                }
+            }
+            else if (fixedFuel) {
+                if (value == null || _fuel == null || _fuel.fuelValue == 0) {
+                    fixedBuildings = 0;
+                }
+                else {
+                    fixedBuildings *= value.fuelValue / _fuel.fuelValue;
+                }
+                _fuel = value;
+            }
+            else {
+                _fuel = value;
+            }
+        }
+    }
+    internal RecipeLinks links { get; set; }
+    /// <summary>
+    /// If not zero, the fixed building count entered by the user, or the number of buildings required to generate the specified fixed consumption/production.
+    /// Read <see cref="fixedFuel"/>, <see cref="fixedIngredient"/>, and <see cref="fixedProduct"/> to determine which value was fixed in the UI.
+    /// This property is set/modified so the solver gets the correct answer without testing the values of those properties.
+    /// </summary>
+    public float fixedBuildings {
+        get => _fixedBuildings;
+        set {
+            _fixedBuildings = value;
+            if (value == 0) {
+                fixedFuel = false;
+                fixedIngredient = null;
+                fixedProduct = null;
+            }
+        }
+    }
+    /// <summary>
+    /// If <see langword="true"/>, <see cref="fixedBuildings"/> is set to control the fuel consumption.
+    /// </summary>
+    public bool fixedFuel { get; set; }
+    /// <summary>
+    /// If not <see langword="null"/>, <see cref="fixedBuildings"/> is set to control the consumption of this ingredient.
+    /// </summary>
+    public Goods? fixedIngredient { get; set; }
+    /// <summary>
+    /// If not <see langword="null"/>, <see cref="fixedBuildings"/> is set to control the production of this product.
+    /// </summary>
+    public Goods? fixedProduct {
+        get => _fixedProduct;
+        set {
+            if (value == null) {
+                _fixedProduct = null;
+            }
+            else if (recipe.products.All(p => p.goods != value)) {
+                // The UI doesn't know the difference between a product and a spent fuel, but we care about the difference
+                _fixedProduct = null;
+                fixedFuel = true;
+            }
+            else {
+                _fixedProduct = value;
+            }
+        }
+    }
+    public int? builtBuildings { get; set; }
+    /// <summary>
+    /// If <see langword="true"/>, the enabled checkbox for this recipe is checked.
+    /// </summary>
+    public bool enabled { get; set; } = true;
+    /// <summary>
+    /// If <see langword="true"/>, the enabled checkboxes for this recipe and all its parent recipes are checked.
+    /// If <see langword="false"/>, at least one enabled checkbox for this recipe or its ancestors is unchecked.
+    /// </summary>
+    public bool hierarchyEnabled { get; internal set; }
+    public int tag { get; set; }
+
+    public RowHighlighting highlighting =>
+        tag switch {
+            1 => RowHighlighting.Green,
+            2 => RowHighlighting.Yellow,
+            3 => RowHighlighting.Red,
+            4 => RowHighlighting.Blue,
+            _ => RowHighlighting.None
         };
 
-        internal static ModuleTemplate Build(ModelObject owner, ModuleTemplateBuilder builder) {
-#pragma warning disable IDE0017 // False positive: convertList cannot be called before the assignment completes
-            ModuleTemplate modules = new(owner, builder.beacon);
-#pragma warning restore IDE0017
-            modules.list = convertList(builder.list);
-            modules.beaconList = convertList(builder.beaconList);
-            return modules;
-
-            ReadOnlyCollection<RecipeRowCustomModule> convertList(List<(Module module, int fixedCount)> list)
-                => list.Select(m => new RecipeRowCustomModule(modules, m.module, m.fixedCount)).ToList().AsReadOnly();
+    [Obsolete("Deprecated", true)]
+    public Module module {
+        set {
+            if (value != null) {
+                modules = new ModuleTemplateBuilder { list = { (value, 0) } }.Build(this);
+            }
         }
     }
 
-    /// <summary>
-    /// An object that can be used to configure and build a <see cref="ModuleTemplate"/>.
-    /// </summary>
-    public class ModuleTemplateBuilder {
-        /// <summary>
-        /// The beacon to be stored in <see cref="ModuleTemplate.beacon"/> after building.
-        /// </summary>
-        public EntityBeacon? beacon { get; set; }
-        /// <summary>
-        /// The list of <see cref="Module"/>s and counts to be stored in <see cref="ModuleTemplate.list"/> after building.
-        /// </summary>
-        public List<(Module module, int fixedCount)> list { get; set; } = [];
-        /// <summary>
-        /// The list of <see cref="Module"/>s and counts to be stored in <see cref="ModuleTemplate.beaconList"/> after building.
-        /// </summary>
-        public List<(Module module, int fixedCount)> beaconList { get; set; } = [];
-
-        /// <summary>
-        /// Builds a <see cref="ModuleTemplate"/> from this <see cref="ModuleTemplateBuilder"/>.
-        /// </summary>
-        /// <param name="owner">The <see cref="RecipeRow"/> or <see cref="ProjectModuleTemplate"/> that will own the built <see cref="ModuleTemplate"/>.</param>
-        public ModuleTemplate Build(ModelObject owner) => ModuleTemplate.Build(owner, this);
-    }
-
-    // Stores collection on ProductionLink recipe was linked to the previous computation
-    internal struct RecipeLinks {
-        public Goods[] ingredientGoods;
-        public ProductionLink?[] ingredients;
-        public ProductionLink?[] products;
-        public ProductionLink? fuel;
-        public ProductionLink? spentFuel;
-    }
-
-    public interface IElementGroup<TElement> {
-        List<TElement> elements { get; }
-        bool expanded { get; set; }
-    }
-
-    public interface IGroupedElement<TGroup> {
-        void SetOwner(TGroup newOwner);
-        TGroup? subgroup { get; }
-        bool visible { get; }
-    }
-
-    public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<ProductionTable> {
-        private EntityCrafter? _entity;
-        private Goods? _fuel;
-        private float _fixedBuildings;
-        private Goods? _fixedProduct;
-        private ModuleTemplate? _modules;
-
-        public RecipeOrTechnology recipe { get; }
-        // Variable parameters
-        public EntityCrafter? entity {
-            get => _entity;
-            set {
-                if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _entity == value) {
-                    _entity = value;
-                }
-                else if (fixedFuel && !(value?.energy.fuels ?? []).Contains(_fuel)) {
-                    // We're changing both the entity and the fuel (changing between electric, fluid-burning, item-burning, heat-powered, and steam-powered crafter categories)
-                    // Don't try to preserve fuel consumption in this case.
-                    fixedBuildings = 0;
-                    _entity = value;
-                }
-                else {
-                    using (new ChangeModulesOrEntity(this)) {
-                        _entity = value;
-                    }
-                }
-            }
-        }
-        public Goods? fuel {
-            get => _fuel;
-            set {
-                if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _fuel == value) {
-                    _fuel = value;
-                }
-                else if (fixedProduct != null && ((fuel as Item)?.fuelResult == fixedProduct || (value as Item)?.fuelResult == fixedProduct)) {
-                    if (recipe.products.SingleOrDefault(p => p.goods == fixedProduct, false) is not Product product) {
-                        fixedBuildings = 0; // We couldn't find the Product corresponding to fixedProduct. Just clear the fixed amount.
-                        _fuel = value;
-                    }
-                    else {
-                        // We're changing the fuel and at least one of the current or new fuel burns to the fixed product
-                        double oldAmount = product.GetAmountForRow(this);
-                        if ((fuel as Item)?.fuelResult == fixedProduct) {
-                            oldAmount += fuelUsagePerSecond;
-                        }
-                        _fuel = value;
-                        parameters = RecipeParameters.CalculateParameters(this);
-                        double newAmount = product.GetAmountForRow(this);
-                        if ((fuel as Item)?.fuelResult == fixedProduct) {
-                            newAmount += fuelUsagePerSecond;
-                        }
-                        fixedBuildings *= (float)(oldAmount / newAmount);
-                    }
-                }
-                else if (fixedFuel) {
-                    if (value == null || _fuel == null || _fuel.fuelValue == 0) {
-                        fixedBuildings = 0;
-                    }
-                    else {
-                        fixedBuildings *= value.fuelValue / _fuel.fuelValue;
-                    }
-                    _fuel = value;
-                }
-                else {
-                    _fuel = value;
-                }
-            }
-        }
-        internal RecipeLinks links { get; set; }
-        /// <summary>
-        /// If not zero, the fixed building count entered by the user, or the number of buildings required to generate the specified fixed consumption/production.
-        /// Read <see cref="fixedFuel"/>, <see cref="fixedIngredient"/>, and <see cref="fixedProduct"/> to determine which value was fixed in the UI.
-        /// This property is set/modified so the solver gets the correct answer without testing the values of those properties.
-        /// </summary>
-        public float fixedBuildings {
-            get => _fixedBuildings;
-            set {
-                _fixedBuildings = value;
-                if (value == 0) {
-                    fixedFuel = false;
-                    fixedIngredient = null;
-                    fixedProduct = null;
-                }
-            }
-        }
-        /// <summary>
-        /// If <see langword="true"/>, <see cref="fixedBuildings"/> is set to control the fuel consumption.
-        /// </summary>
-        public bool fixedFuel { get; set; }
-        /// <summary>
-        /// If not <see langword="null"/>, <see cref="fixedBuildings"/> is set to control the consumption of this ingredient.
-        /// </summary>
-        public Goods? fixedIngredient { get; set; }
-        /// <summary>
-        /// If not <see langword="null"/>, <see cref="fixedBuildings"/> is set to control the production of this product.
-        /// </summary>
-        public Goods? fixedProduct {
-            get => _fixedProduct;
-            set {
-                if (value == null) {
-                    _fixedProduct = null;
-                }
-                else if (recipe.products.All(p => p.goods != value)) {
-                    // The UI doesn't know the difference between a product and a spent fuel, but we care about the difference
-                    _fixedProduct = null;
-                    fixedFuel = true;
-                }
-                else {
-                    _fixedProduct = value;
-                }
-            }
-        }
-        public int? builtBuildings { get; set; }
-        /// <summary>
-        /// If <see langword="true"/>, the enabled checkbox for this recipe is checked.
-        /// </summary>
-        public bool enabled { get; set; } = true;
-        /// <summary>
-        /// If <see langword="true"/>, the enabled checkboxes for this recipe and all its parent recipes are checked.
-        /// If <see langword="false"/>, at least one enabled checkbox for this recipe or its ancestors is unchecked.
-        /// </summary>
-        public bool hierarchyEnabled { get; internal set; }
-        public int tag { get; set; }
-
-        public RowHighlighting highlighting =>
-            tag switch {
-                1 => RowHighlighting.Green,
-                2 => RowHighlighting.Yellow,
-                3 => RowHighlighting.Red,
-                4 => RowHighlighting.Blue,
-                _ => RowHighlighting.None
-            };
-
-        [Obsolete("Deprecated", true)]
-        public Module module {
-            set {
-                if (value != null) {
-                    modules = new ModuleTemplateBuilder { list = { (value, 0) } }.Build(this);
-                }
-            }
-        }
-
-        public ModuleTemplate? modules {
-            get => _modules;
-            set {
-                if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _modules == value) {
-                    _modules = value;
-                }
-                else {
-                    using (new ChangeModulesOrEntity(this)) {
-                        _modules = value;
-                    }
-                }
-            }
-        }
-
-        public ProductionTable? subgroup { get; set; }
-        public HashSet<FactorioObject> variants { get; } = [];
-        [SkipSerialization] public ProductionTable linkRoot => subgroup ?? owner;
-
-        public RecipeRowIngredient FuelInformation => new(fuel, fuelUsagePerSecond, links.fuel, (fuel as Fluid)?.variants?.ToArray());
-        public IEnumerable<RecipeRowIngredient> Ingredients {
-            get {
-                return hierarchyEnabled ? @internal() : Enumerable.Repeat<RecipeRowIngredient>((null, 0, null, null), recipe.ingredients.Length);
-
-                IEnumerable<RecipeRowIngredient> @internal() {
-                    for (int i = 0; i < recipe.ingredients.Length; i++) {
-                        Ingredient ingredient = recipe.ingredients[i];
-                        yield return (links.ingredientGoods[i], ingredient.amount * (float)recipesPerSecond, links.ingredients[i], ingredient.variants);
-                    }
-                }
-            }
-        }
-        public IEnumerable<RecipeRowProduct> Products {
-            get {
-                int i = 0;
-                Item? spentFuel = (fuel as Item)?.fuelResult;
-                bool handledFuel = spentFuel == null; // If there's no spent fuel, it's already handled
-                foreach (Product product in recipe.products) {
-                    if (hierarchyEnabled) {
-                        float amount = product.GetAmountForRow(this);
-                        if (product.goods == spentFuel) {
-                            amount += fuelUsagePerSecond;
-                            handledFuel = true;
-                        }
-                        yield return (product.goods, amount, links.products[i++]);
-                    }
-                    else {
-                        yield return (null, 0, null);
-                    }
-                }
-
-                if (!handledFuel) {
-                    yield return hierarchyEnabled ? (spentFuel, fuelUsagePerSecond, links.spentFuel) : (null, 0, null);
-                }
-            }
-        }
-
-        // Computed variables
-        internal RecipeParameters parameters { get; set; } = RecipeParameters.Empty;
-        public double recipesPerSecond { get; internal set; }
-        internal float fuelUsagePerSecond => (float)(parameters.fuelUsagePerSecondPerRecipe * recipesPerSecond);
-        public UsedModule usedModules => parameters.modules;
-        public WarningFlags warningFlags => parameters.warningFlags;
-        public bool FindLink(Goods goods, [MaybeNullWhen(false)] out ProductionLink link) {
-            return linkRoot.FindLink(goods, out link);
-        }
-
-        public T GetVariant<T>(T[] options) where T : FactorioObject {
-            foreach (var option in options) {
-                if (variants.Contains(option)) {
-                    return option;
-                }
-            }
-
-            return options[0];
-        }
-
-        public void ChangeVariant<T>(T was, T now) where T : FactorioObject {
-            _ = variants.Remove(was);
-            _ = variants.Add(now);
-        }
-
-        [MemberNotNullWhen(true, nameof(subgroup))]
-        public bool isOverviewMode => subgroup != null && !subgroup.expanded;
-        public float buildingCount => (float)recipesPerSecond * parameters.recipeTime;
-        public bool visible { get; internal set; } = true;
-
-        public RecipeRow(ProductionTable owner, RecipeOrTechnology recipe) : base(owner) {
-            this.recipe = recipe ?? throw new ArgumentNullException(nameof(recipe), "Recipe does not exist");
-            links = new RecipeLinks {
-                ingredients = new ProductionLink[recipe.ingredients.Length],
-                ingredientGoods = new Goods[recipe.ingredients.Length],
-                products = new ProductionLink[recipe.products.Length]
-            };
-        }
-
-        protected internal override void ThisChanged(bool visualOnly) {
-            owner.ThisChanged(visualOnly);
-        }
-
-        public void SetOwner(ProductionTable parent) {
-            owner = parent;
-        }
-
-        public void RemoveFixedModules() {
-            if (modules == null) {
-                return;
-            }
-
-            CreateUndoSnapshot();
-            modules = null;
-        }
-        public void SetFixedModule(Module? module) {
-            if (module == null) {
-                RemoveFixedModules();
-                return;
-            }
-
-            ModuleTemplateBuilder builder = modules?.GetBuilder() ?? new();
-            builder.list = [(module, 0)];
-            this.RecordUndo().modules = builder.Build(this);
-        }
-
-        public ModuleFillerParameters? GetModuleFiller() {
-            var table = linkRoot;
-            while (table != null) {
-                if (table.modules != null) {
-                    return table.modules;
-                }
-
-                table = (table.owner as RecipeRow)?.owner;
-            }
-
-            return null;
-        }
-
-        internal void GetModulesInfo((float recipeTime, float fuelUsagePerSecondPerBuilding) recipeParams, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
-            ModuleFillerParameters? filler = null;
-            var useModules = modules;
-            if (useModules == null || useModules.beacon == null) {
-                filler = GetModuleFiller();
-            }
-
-            if (useModules == null) {
-                filler?.GetModulesInfo(recipeParams, this, entity, ref effects, ref used);
+    public ModuleTemplate? modules {
+        get => _modules;
+        set {
+            if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _modules == value) {
+                _modules = value;
             }
             else {
-                useModules.GetModulesInfo(this, entity, ref effects, ref used, filler);
-            }
-        }
-
-        /// <summary>
-        /// Call to inform this <see cref="RecipeRow"/> that the applicable <see cref="ModuleFillerParameters"/> are about to change.
-        /// </summary>
-        /// <returns>If not <see langword="null"/>, an <see cref="Action"/> to perform after the change has completed that will update <see cref="fixedBuildings"/> to account for the new modules.</returns>
-        internal Action? ModuleFillerParametersChanging() {
-            if (fixedFuel || fixedIngredient != null || fixedProduct != null) {
-                return new ChangeModulesOrEntity(this).Dispose;
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Handle the <see cref="fixedBuildings"/> changes needed when changing modules or entity, including any bonus work required when the fixed product is also a spent fuel.
-        /// </summary>
-        private class ChangeModulesOrEntity : IDisposable {
-            private readonly RecipeRow row;
-            private readonly Goods? oldFuel;
-            private readonly RecipeParameters oldParameters;
-
-            public ChangeModulesOrEntity(RecipeRow row) {
-                this.row = row;
-                row.RecordUndo(); // Unnecessary (but not harmful) when called by set_modules or set_entity. Required when called by ModuleFillerParametersChanging.
-
-                // Changing the modules or entity requires up to four steps:
-                // (1) Change the fuel to void (boosting fixedBuildings in RecipeRow.set_fuel to account for lost fuel consumption)
-                // (2) Change the actual target value (in the caller)
-                // (3) Update fixedBuildings to account for the value the caller intended to change (in Dispose)
-                // (4) Restore the fuel (row.fuel = oldFuel in Dispose, reducing fixedBuildings in RecipeRow.set_fuel to account for regained fuel consumption)
-                // Step 1 is only performed when the fixed product is the sum of spent fuel and recipe production.
-                // Step 4 is only performed after step 1 and when the possibly-changed entity accepts the old fuel.
-                //      If the entity does not accept the old fuel, a caller must set an appropriate fuel.
-
-                if (row.fixedProduct != null && row.fixedProduct == (row.fuel as Item)?.fuelResult) {
-                    oldFuel = row.fuel;
-                    row.fuel = Database.voidEnergy; // step 1
-                }
-                // Store the current state of the target RecipeRow for the calcualations in Dispose
-                oldParameters = RecipeParameters.CalculateParameters(row);
-            }
-
-            public void Dispose() {
-                row.parameters = RecipeParameters.CalculateParameters(row);
-                if (row.fixedFuel) {
-                    row.fixedBuildings *= oldParameters.fuelUsagePerSecondPerBuilding / row.parameters.fuelUsagePerSecondPerBuilding; // step 3, for fixed fuels
-                }
-                else if (row.fixedIngredient != null) {
-                    row.fixedBuildings *= row.parameters.recipeTime / oldParameters.recipeTime; // step 3, for fixed ingredient consumption
-                }
-                else if (row.fixedProduct != null) {
-                    if (row.recipe.products.SingleOrDefault(p => p.goods == row.fixedProduct, false) is not Product product) {
-                        row.fixedBuildings = 0; // We couldn't find the Product corresponding to fixedProduct. Just clear the fixed amount.
-                    }
-                    else {
-                        float oldAmount = product.GetAmountPerRecipe(oldParameters.productivity) / oldParameters.recipeTime;
-                        float newAmount = product.GetAmountPerRecipe(row.parameters.productivity) / row.parameters.recipeTime;
-                        row.fixedBuildings *= oldAmount / newAmount; // step 3, for fixed production amount
-                    }
-                }
-
-                if (oldFuel != null && (row._entity?.energy.fuels ?? []).Contains(oldFuel)) {
-                    row.fuel = oldFuel; // step 4
+                using (new ChangeModulesOrEntity(this)) {
+                    _modules = value;
                 }
             }
         }
     }
 
-    public enum RowHighlighting {
-        None,
-        Green,
-        Yellow,
-        Red,
-        Blue
+    public ProductionTable? subgroup { get; set; }
+    public HashSet<FactorioObject> variants { get; } = [];
+    [SkipSerialization] public ProductionTable linkRoot => subgroup ?? owner;
+
+    public RecipeRowIngredient FuelInformation => new(fuel, fuelUsagePerSecond, links.fuel, (fuel as Fluid)?.variants?.ToArray());
+    public IEnumerable<RecipeRowIngredient> Ingredients {
+        get {
+            return hierarchyEnabled ? @internal() : Enumerable.Repeat<RecipeRowIngredient>((null, 0, null, null), recipe.ingredients.Length);
+
+            IEnumerable<RecipeRowIngredient> @internal() {
+                for (int i = 0; i < recipe.ingredients.Length; i++) {
+                    Ingredient ingredient = recipe.ingredients[i];
+                    yield return (links.ingredientGoods[i], ingredient.amount * (float)recipesPerSecond, links.ingredients[i], ingredient.variants);
+                }
+            }
+        }
+    }
+    public IEnumerable<RecipeRowProduct> Products {
+        get {
+            int i = 0;
+            Item? spentFuel = (fuel as Item)?.fuelResult;
+            bool handledFuel = spentFuel == null; // If there's no spent fuel, it's already handled
+            foreach (Product product in recipe.products) {
+                if (hierarchyEnabled) {
+                    float amount = product.GetAmountForRow(this);
+                    if (product.goods == spentFuel) {
+                        amount += fuelUsagePerSecond;
+                        handledFuel = true;
+                    }
+                    yield return (product.goods, amount, links.products[i++]);
+                }
+                else {
+                    yield return (null, 0, null);
+                }
+            }
+
+            if (!handledFuel) {
+                yield return hierarchyEnabled ? (spentFuel, fuelUsagePerSecond, links.spentFuel) : (null, 0, null);
+            }
+        }
     }
 
-    public enum LinkAlgorithm {
-        Match,
-        AllowOverProduction,
-        AllowOverConsumption,
+    // Computed variables
+    internal RecipeParameters parameters { get; set; } = RecipeParameters.Empty;
+    public double recipesPerSecond { get; internal set; }
+    internal float fuelUsagePerSecond => (float)(parameters.fuelUsagePerSecondPerRecipe * recipesPerSecond);
+    public UsedModule usedModules => parameters.modules;
+    public WarningFlags warningFlags => parameters.warningFlags;
+    public bool FindLink(Goods goods, [MaybeNullWhen(false)] out ProductionLink link) {
+        return linkRoot.FindLink(goods, out link);
+    }
+
+    public T GetVariant<T>(T[] options) where T : FactorioObject {
+        foreach (var option in options) {
+            if (variants.Contains(option)) {
+                return option;
+            }
+        }
+
+        return options[0];
+    }
+
+    public void ChangeVariant<T>(T was, T now) where T : FactorioObject {
+        _ = variants.Remove(was);
+        _ = variants.Add(now);
+    }
+
+    [MemberNotNullWhen(true, nameof(subgroup))]
+    public bool isOverviewMode => subgroup != null && !subgroup.expanded;
+    public float buildingCount => (float)recipesPerSecond * parameters.recipeTime;
+    public bool visible { get; internal set; } = true;
+
+    public RecipeRow(ProductionTable owner, RecipeOrTechnology recipe) : base(owner) {
+        this.recipe = recipe ?? throw new ArgumentNullException(nameof(recipe), "Recipe does not exist");
+        links = new RecipeLinks {
+            ingredients = new ProductionLink[recipe.ingredients.Length],
+            ingredientGoods = new Goods[recipe.ingredients.Length],
+            products = new ProductionLink[recipe.products.Length]
+        };
+    }
+
+    protected internal override void ThisChanged(bool visualOnly) {
+        owner.ThisChanged(visualOnly);
+    }
+
+    public void SetOwner(ProductionTable parent) {
+        owner = parent;
+    }
+
+    public void RemoveFixedModules() {
+        if (modules == null) {
+            return;
+        }
+
+        CreateUndoSnapshot();
+        modules = null;
+    }
+    public void SetFixedModule(Module? module) {
+        if (module == null) {
+            RemoveFixedModules();
+            return;
+        }
+
+        ModuleTemplateBuilder builder = modules?.GetBuilder() ?? new();
+        builder.list = [(module, 0)];
+        this.RecordUndo().modules = builder.Build(this);
+    }
+
+    public ModuleFillerParameters? GetModuleFiller() {
+        var table = linkRoot;
+        while (table != null) {
+            if (table.modules != null) {
+                return table.modules;
+            }
+
+            table = (table.owner as RecipeRow)?.owner;
+        }
+
+        return null;
+    }
+
+    internal void GetModulesInfo((float recipeTime, float fuelUsagePerSecondPerBuilding) recipeParams, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
+        ModuleFillerParameters? filler = null;
+        var useModules = modules;
+        if (useModules == null || useModules.beacon == null) {
+            filler = GetModuleFiller();
+        }
+
+        if (useModules == null) {
+            filler?.GetModulesInfo(recipeParams, this, entity, ref effects, ref used);
+        }
+        else {
+            useModules.GetModulesInfo(this, entity, ref effects, ref used, filler);
+        }
     }
 
     /// <summary>
-    /// A Link is goods whose production and consumption is attempted to be balanced by YAFC across the sheet.
+    /// Call to inform this <see cref="RecipeRow"/> that the applicable <see cref="ModuleFillerParameters"/> are about to change.
     /// </summary>
-    public class ProductionLink(ProductionTable group, Goods goods) : ModelObject<ProductionTable>(group) {
-        [Flags]
-        public enum Flags {
-            // This enum uses powers of two to represent its state.
-            // 1 << 0 = 1. 1 << 1 = 2. 1 << 2 = 4. 1 << 3 = 8. An so on.
-            // That allows to check Flags state with bit operations. Like a | b.
-            // That is a legit and conventional way to do that.
-            // https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/enum#designing-flag-enums
+    /// <returns>If not <see langword="null"/>, an <see cref="Action"/> to perform after the change has completed that will update <see cref="fixedBuildings"/> to account for the new modules.</returns>
+    internal Action? ModuleFillerParametersChanging() {
+        if (fixedFuel || fixedIngredient != null || fixedProduct != null) {
+            return new ChangeModulesOrEntity(this).Dispose;
+        }
+        return null;
+    }
 
-            LinkNotMatched = 1 << 0,
-            /// <summary>
-            /// Indicates if there is a feedback loop that could not get balanced. 
-            /// It doesn't mean that this link is the problem, but it's a part of the loop.
-            /// </summary>
-            LinkRecursiveNotMatched = 1 << 1,
-            HasConsumption = 1 << 2,
-            HasProduction = 1 << 3,
-            /// <summary>
-            /// The links of a nested table have unmatched production/consumption. These unmatched products are not captured by this link.
-            /// </summary>
-            /// <remarks> This info was taken from ProductionTableView#dropDownContent.</remarks>
-            ChildNotMatched = 1 << 4,
-            HasProductionAndConsumption = HasProduction | HasConsumption,
+    /// <summary>
+    /// Handle the <see cref="fixedBuildings"/> changes needed when changing modules or entity, including any bonus work required when the fixed product is also a spent fuel.
+    /// </summary>
+    private class ChangeModulesOrEntity : IDisposable {
+        private readonly RecipeRow row;
+        private readonly Goods? oldFuel;
+        private readonly RecipeParameters oldParameters;
+
+        public ChangeModulesOrEntity(RecipeRow row) {
+            this.row = row;
+            row.RecordUndo(); // Unnecessary (but not harmful) when called by set_modules or set_entity. Required when called by ModuleFillerParametersChanging.
+
+            // Changing the modules or entity requires up to four steps:
+            // (1) Change the fuel to void (boosting fixedBuildings in RecipeRow.set_fuel to account for lost fuel consumption)
+            // (2) Change the actual target value (in the caller)
+            // (3) Update fixedBuildings to account for the value the caller intended to change (in Dispose)
+            // (4) Restore the fuel (row.fuel = oldFuel in Dispose, reducing fixedBuildings in RecipeRow.set_fuel to account for regained fuel consumption)
+            // Step 1 is only performed when the fixed product is the sum of spent fuel and recipe production.
+            // Step 4 is only performed after step 1 and when the possibly-changed entity accepts the old fuel.
+            //      If the entity does not accept the old fuel, a caller must set an appropriate fuel.
+
+            if (row.fixedProduct != null && row.fixedProduct == (row.fuel as Item)?.fuelResult) {
+                oldFuel = row.fuel;
+                row.fuel = Database.voidEnergy; // step 1
+            }
+            // Store the current state of the target RecipeRow for the calcualations in Dispose
+            oldParameters = RecipeParameters.CalculateParameters(row);
         }
 
-        public Goods goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Linked product does not exist");
-        public float amount { get; set; }
-        public LinkAlgorithm algorithm { get; set; }
+        public void Dispose() {
+            row.parameters = RecipeParameters.CalculateParameters(row);
+            if (row.fixedFuel) {
+                row.fixedBuildings *= oldParameters.fuelUsagePerSecondPerBuilding / row.parameters.fuelUsagePerSecondPerBuilding; // step 3, for fixed fuels
+            }
+            else if (row.fixedIngredient != null) {
+                row.fixedBuildings *= row.parameters.recipeTime / oldParameters.recipeTime; // step 3, for fixed ingredient consumption
+            }
+            else if (row.fixedProduct != null) {
+                if (row.recipe.products.SingleOrDefault(p => p.goods == row.fixedProduct, false) is not Product product) {
+                    row.fixedBuildings = 0; // We couldn't find the Product corresponding to fixedProduct. Just clear the fixed amount.
+                }
+                else {
+                    float oldAmount = product.GetAmountPerRecipe(oldParameters.productivity) / oldParameters.recipeTime;
+                    float newAmount = product.GetAmountPerRecipe(row.parameters.productivity) / row.parameters.recipeTime;
+                    row.fixedBuildings *= oldAmount / newAmount; // step 3, for fixed production amount
+                }
+            }
 
-        // computed variables
-        public Flags flags { get; internal set; }
+            if (oldFuel != null && (row._entity?.energy.fuels ?? []).Contains(oldFuel)) {
+                row.fuel = oldFuel; // step 4
+            }
+        }
+    }
+}
+
+public enum RowHighlighting {
+    None,
+    Green,
+    Yellow,
+    Red,
+    Blue
+}
+
+public enum LinkAlgorithm {
+    Match,
+    AllowOverProduction,
+    AllowOverConsumption,
+}
+
+/// <summary>
+/// A Link is goods whose production and consumption is attempted to be balanced by YAFC across the sheet.
+/// </summary>
+public class ProductionLink(ProductionTable group, Goods goods) : ModelObject<ProductionTable>(group) {
+    [Flags]
+    public enum Flags {
+        // This enum uses powers of two to represent its state.
+        // 1 << 0 = 1. 1 << 1 = 2. 1 << 2 = 4. 1 << 3 = 8. An so on.
+        // That allows to check Flags state with bit operations. Like a | b.
+        // That is a legit and conventional way to do that.
+        // https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/enum#designing-flag-enums
+
+        LinkNotMatched = 1 << 0,
         /// <summary>
-        /// Probably the total production of the goods in the link. TODO: Needs to be investigated if it is indeed so.
+        /// Indicates if there is a feedback loop that could not get balanced.
+        /// It doesn't mean that this link is the problem, but it's a part of the loop.
         /// </summary>
-        public float linkFlow { get; internal set; }
-        public float notMatchedFlow { get; internal set; }
+        LinkRecursiveNotMatched = 1 << 1,
+        HasConsumption = 1 << 2,
+        HasProduction = 1 << 3,
         /// <summary>
-        /// List of recipes belonging to this production link
+        /// The links of a nested table have unmatched production/consumption. These unmatched products are not captured by this link.
         /// </summary>
-        [SkipSerialization] public HashSet<RecipeRow> capturedRecipes { get; } = [];
-        internal int solverIndex;
-        public float dualValue { get; internal set; }
+        /// <remarks> This info was taken from ProductionTableView#dropDownContent.</remarks>
+        ChildNotMatched = 1 << 4,
+        HasProductionAndConsumption = HasProduction | HasConsumption,
+    }
 
-        public IEnumerable<string> LinkWarnings {
-            get {
-                if (!flags.HasFlags(Flags.HasProduction)) {
-                    yield return "This link has no production (Link ignored)";
+    public Goods goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Linked product does not exist");
+    public float amount { get; set; }
+    public LinkAlgorithm algorithm { get; set; }
+
+    // computed variables
+    public Flags flags { get; internal set; }
+    /// <summary>
+    /// Probably the total production of the goods in the link. TODO: Needs to be investigated if it is indeed so.
+    /// </summary>
+    public float linkFlow { get; internal set; }
+    public float notMatchedFlow { get; internal set; }
+    /// <summary>
+    /// List of recipes belonging to this production link
+    /// </summary>
+    [SkipSerialization] public HashSet<RecipeRow> capturedRecipes { get; } = [];
+    internal int solverIndex;
+    public float dualValue { get; internal set; }
+
+    public IEnumerable<string> LinkWarnings {
+        get {
+            if (!flags.HasFlags(Flags.HasProduction)) {
+                yield return "This link has no production (Link ignored)";
+            }
+
+            if (!flags.HasFlags(Flags.HasConsumption)) {
+                yield return "This link has no consumption (Link ignored)";
+            }
+
+            if (flags.HasFlags(Flags.ChildNotMatched)) {
+                yield return "Nested table link has unmatched production/consumption. These unmatched products are not captured by this link.";
+            }
+
+            if (!flags.HasFlags(Flags.HasProductionAndConsumption) && owner.owner is RecipeRow recipeRow && recipeRow.FindLink(goods, out _)) {
+                yield return "Nested tables have their own set of links that DON'T connect to parent links. To connect this product to the outside, remove this link.";
+            }
+
+            if (flags.HasFlags(Flags.LinkRecursiveNotMatched)) {
+                if (notMatchedFlow <= 0f) {
+                    yield return "YAFC was unable to satisfy this link (Negative feedback loop). This doesn't mean that this link is the problem, but it is part of the loop.";
                 }
-
-                if (!flags.HasFlags(Flags.HasConsumption)) {
-                    yield return "This link has no consumption (Link ignored)";
-                }
-
-                if (flags.HasFlags(Flags.ChildNotMatched)) {
-                    yield return "Nested table link has unmatched production/consumption. These unmatched products are not captured by this link.";
-                }
-
-                if (!flags.HasFlags(Flags.HasProductionAndConsumption) && owner.owner is RecipeRow recipeRow && recipeRow.FindLink(goods, out _)) {
-                    yield return "Nested tables have their own set of links that DON'T connect to parent links. To connect this product to the outside, remove this link.";
-                }
-
-                if (flags.HasFlags(Flags.LinkRecursiveNotMatched)) {
-                    if (notMatchedFlow <= 0f) {
-                        yield return "YAFC was unable to satisfy this link (Negative feedback loop). This doesn't mean that this link is the problem, but it is part of the loop.";
-                    }
-                    else {
-                        yield return "YAFC was unable to satisfy this link (Overproduction). You can allow overproduction for this link to solve the error.";
-                    }
+                else {
+                    yield return "YAFC was unable to satisfy this link (Overproduction). You can allow overproduction for this link to solve the error.";
                 }
             }
         }
     }
+}
 
-    public record RecipeRowIngredient(Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants) {
-        public static implicit operator (Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants)(RecipeRowIngredient value) => (value.Goods, value.Amount, value.Link, value.Variants);
-        public static implicit operator RecipeRowIngredient((Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants) value) => new(value.Goods, value.Amount, value.Link, value.Variants);
-    }
+public record RecipeRowIngredient(Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants) {
+    public static implicit operator (Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants)(RecipeRowIngredient value) => (value.Goods, value.Amount, value.Link, value.Variants);
+    public static implicit operator RecipeRowIngredient((Goods? Goods, float Amount, ProductionLink? Link, Goods[]? Variants) value) => new(value.Goods, value.Amount, value.Link, value.Variants);
+}
 
-    public record RecipeRowProduct(Goods? Goods, float Amount, ProductionLink? Link) {
-        public static implicit operator (Goods? Goods, float Amount, ProductionLink? Link)(RecipeRowProduct value) => (value.Goods, value.Amount, value.Link);
-        public static implicit operator RecipeRowProduct((Goods? Goods, float Amount, ProductionLink? Link) value) => new(value.Goods, value.Amount, value.Link);
-    }
+public record RecipeRowProduct(Goods? Goods, float Amount, ProductionLink? Link) {
+    public static implicit operator (Goods? Goods, float Amount, ProductionLink? Link)(RecipeRowProduct value) => (value.Goods, value.Amount, value.Link);
+    public static implicit operator RecipeRowProduct((Goods? Goods, float Amount, ProductionLink? Link) value) => new(value.Goods, value.Amount, value.Link);
 }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -606,6 +606,12 @@ namespace Yafc.Model {
     public class ProductionLink(ProductionTable group, Goods goods) : ModelObject<ProductionTable>(group) {
         [Flags]
         public enum Flags {
+            // This enum uses powers of two to represent its state.
+            // 1 << 0 = 1. 1 << 1 = 2. 1 << 2 = 4. 1 << 3 = 8. An so on.
+            // That allows to check Flags state with bit operations. Like a | b.
+            // That is a legit and conventional way to do that.
+            // https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/enum#designing-flag-enums
+
             LinkNotMatched = 1 << 0,
             /// <summary>
             /// Indicates if there is a feedback loop that could not get balanced. 
@@ -615,8 +621,9 @@ namespace Yafc.Model {
             HasConsumption = 1 << 2,
             HasProduction = 1 << 3,
             /// <summary>
-            /// The production and consumption of the child link are not matched.
+            /// The links of a nested table have unmatched production/consumption. These unmatched products are not captured by this link.
             /// </summary>
+            /// <remarks> This info was taken from ProductionTableView#dropDownContent.</remarks>
             ChildNotMatched = 1 << 4,
             HasProductionAndConsumption = HasProduction | HasConsumption,
         }

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -5,321 +5,320 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json;
 
-namespace Yafc.Model {
-    public class Project : ModelObject {
-        public static Project current { get; set; } = null!; // null-forgiving: MainScreen.SetProject will set this to a non-null value
-        public static Version currentYafcVersion { get; set; } = new Version(0, 4, 0);
-        public uint projectVersion => undo.version;
-        public string? attachedFileName { get; private set; }
-        public bool justCreated { get; private set; } = true;
-        public ProjectSettings settings { get; }
-        public ProjectPreferences preferences { get; }
+namespace Yafc.Model;
+public class Project : ModelObject {
+    public static Project current { get; set; } = null!; // null-forgiving: MainScreen.SetProject will set this to a non-null value
+    public static Version currentYafcVersion { get; set; } = new Version(0, 4, 0);
+    public uint projectVersion => undo.version;
+    public string? attachedFileName { get; private set; }
+    public bool justCreated { get; private set; } = true;
+    public ProjectSettings settings { get; }
+    public ProjectPreferences preferences { get; }
 
-        public List<ProjectModuleTemplate> sharedModuleTemplates { get; } = [];
-        public string? yafcVersion { get; set; }
-        public List<ProjectPage> pages { get; } = [];
-        public List<Guid> displayPages { get; } = [];
-        private readonly Dictionary<Guid, ProjectPage> pagesByGuid = [];
-        public int hiddenPages { get; private set; }
-        public new UndoSystem undo => base.undo;
-        private uint lastSavedVersion;
-        public uint unsavedChangesCount => projectVersion - lastSavedVersion;
+    public List<ProjectModuleTemplate> sharedModuleTemplates { get; } = [];
+    public string? yafcVersion { get; set; }
+    public List<ProjectPage> pages { get; } = [];
+    public List<Guid> displayPages { get; } = [];
+    private readonly Dictionary<Guid, ProjectPage> pagesByGuid = [];
+    public int hiddenPages { get; private set; }
+    public new UndoSystem undo => base.undo;
+    private uint lastSavedVersion;
+    public uint unsavedChangesCount => projectVersion - lastSavedVersion;
 
-        public Project() : base(new UndoSystem()) {
-            settings = new ProjectSettings(this);
-            preferences = new ProjectPreferences(this);
+    public Project() : base(new UndoSystem()) {
+        settings = new ProjectSettings(this);
+        preferences = new ProjectPreferences(this);
+    }
+
+    public event Action? metaInfoChanged;
+
+    public override ModelObject? ownerObject {
+        get => null;
+        internal set => throw new NotSupportedException();
+    }
+
+    private void UpdatePageMapping() {
+        hiddenPages = 0;
+        pagesByGuid.Clear();
+        foreach (var page in pages) {
+            pagesByGuid[page.guid] = page;
+            page.visible = false;
         }
-
-        public event Action? metaInfoChanged;
-
-        public override ModelObject? ownerObject {
-            get => null;
-            internal set => throw new NotSupportedException();
-        }
-
-        private void UpdatePageMapping() {
-            hiddenPages = 0;
-            pagesByGuid.Clear();
-            foreach (var page in pages) {
-                pagesByGuid[page.guid] = page;
-                page.visible = false;
-            }
-            foreach (var page in displayPages) {
-                if (pagesByGuid.TryGetValue(page, out var dpage)) {
-                    dpage.visible = true;
-                }
-            }
-
-            foreach (var page in pages) {
-                if (!page.visible) {
-                    hiddenPages++;
-                }
+        foreach (var page in displayPages) {
+            if (pagesByGuid.TryGetValue(page, out var dpage)) {
+                dpage.visible = true;
             }
         }
 
-        protected internal override void ThisChanged(bool visualOnly) {
-            UpdatePageMapping();
-            base.ThisChanged(visualOnly);
-            foreach (var page in pages) {
-                page.SetToRecalculate();
-            }
-
-            metaInfoChanged?.Invoke();
-        }
-
-        public static Project ReadFromFile(string path, ErrorCollector collector) {
-            Project? proj;
-            if (!string.IsNullOrEmpty(path) && File.Exists(path)) {
-                proj = Read(File.ReadAllBytes(path), collector);
-            }
-            else {
-                proj = new Project();
-            }
-
-            proj.attachedFileName = path;
-            proj.lastSavedVersion = proj.projectVersion;
-            return proj;
-        }
-
-        public static Project Read(byte[] bytes, ErrorCollector collector) {
-            Project? proj;
-            Utf8JsonReader reader = new Utf8JsonReader(bytes);
-            _ = reader.Read();
-            DeserializationContext context = new DeserializationContext(collector);
-            proj = SerializationMap<Project>.DeserializeFromJson(null, ref reader, context);
-            if (!reader.IsFinalBlock) {
-                collector.Error("Json was not consumed to the end!", ErrorSeverity.MajorDataLoss);
-            }
-
-            if (proj == null) {
-                throw new SerializationException("Unable to load project file");
-            }
-
-            proj.justCreated = false;
-            Version version = new Version(proj.yafcVersion ?? "0.0");
-            if (version != currentYafcVersion) {
-                if (version > currentYafcVersion) {
-                    collector.Error("This file was created with future YAFC version. This may lose data.", ErrorSeverity.Important);
-                }
-
-                proj.yafcVersion = currentYafcVersion.ToString();
-            }
-            context.Notify();
-            return proj;
-        }
-
-        public void Save(string fileName) {
-            if (lastSavedVersion == projectVersion && fileName == attachedFileName) {
-                return;
-            }
-
-            using (FileStream fs = new FileStream(fileName, FileMode.Create, FileAccess.Write)) {
-                Save(fs);
-            }
-            attachedFileName = fileName;
-            lastSavedVersion = projectVersion;
-        }
-
-        public void Save(Stream stream) {
-            using Utf8JsonWriter writer = new Utf8JsonWriter(stream, JsonUtils.DefaultWriterOptions);
-            SerializationMap<Project>.SerializeToJson(this, writer);
-        }
-
-        public void RecalculateDisplayPages() {
-            foreach (var page in displayPages) {
-                FindPage(page)?.SetToRecalculate();
+        foreach (var page in pages) {
+            if (!page.visible) {
+                hiddenPages++;
             }
         }
+    }
 
-        public (float multiplier, string suffix) ResolveUnitOfMeasure(UnitOfMeasure unit) {
-            return unit switch {
-                UnitOfMeasure.Percent => (100f, "%"),
-                UnitOfMeasure.Second => (1f, "s"),
-                UnitOfMeasure.PerSecond => preferences.GetPerTimeUnit(),
-                UnitOfMeasure.ItemPerSecond => preferences.GetItemPerTimeUnit(),
-                UnitOfMeasure.FluidPerSecond => preferences.GetFluidPerTimeUnit(),
-                UnitOfMeasure.Megawatt => (1e6f, "W"),
-                UnitOfMeasure.Megajoule => (1e6f, "J"),
-                UnitOfMeasure.Celsius => (1f, "°"),
-                _ => (1f, ""),
-            };
+    protected internal override void ThisChanged(bool visualOnly) {
+        UpdatePageMapping();
+        base.ThisChanged(visualOnly);
+        foreach (var page in pages) {
+            page.SetToRecalculate();
         }
 
-        public ProjectPage? FindPage(Guid guid) {
-            return pagesByGuid.TryGetValue(guid, out var page) ? page : null;
+        metaInfoChanged?.Invoke();
+    }
+
+    public static Project ReadFromFile(string path, ErrorCollector collector) {
+        Project? proj;
+        if (!string.IsNullOrEmpty(path) && File.Exists(path)) {
+            proj = Read(File.ReadAllBytes(path), collector);
+        }
+        else {
+            proj = new Project();
         }
 
-        public void RemovePage(ProjectPage page) {
-            page.MarkAsDeleted();
+        proj.attachedFileName = path;
+        proj.lastSavedVersion = proj.projectVersion;
+        return proj;
+    }
+
+    public static Project Read(byte[] bytes, ErrorCollector collector) {
+        Project? proj;
+        Utf8JsonReader reader = new Utf8JsonReader(bytes);
+        _ = reader.Read();
+        DeserializationContext context = new DeserializationContext(collector);
+        proj = SerializationMap<Project>.DeserializeFromJson(null, ref reader, context);
+        if (!reader.IsFinalBlock) {
+            collector.Error("Json was not consumed to the end!", ErrorSeverity.MajorDataLoss);
+        }
+
+        if (proj == null) {
+            throw new SerializationException("Unable to load project file");
+        }
+
+        proj.justCreated = false;
+        Version version = new Version(proj.yafcVersion ?? "0.0");
+        if (version != currentYafcVersion) {
+            if (version > currentYafcVersion) {
+                collector.Error("This file was created with future YAFC version. This may lose data.", ErrorSeverity.Important);
+            }
+
+            proj.yafcVersion = currentYafcVersion.ToString();
+        }
+        context.Notify();
+        return proj;
+    }
+
+    public void Save(string fileName) {
+        if (lastSavedVersion == projectVersion && fileName == attachedFileName) {
+            return;
+        }
+
+        using (FileStream fs = new FileStream(fileName, FileMode.Create, FileAccess.Write)) {
+            Save(fs);
+        }
+        attachedFileName = fileName;
+        lastSavedVersion = projectVersion;
+    }
+
+    public void Save(Stream stream) {
+        using Utf8JsonWriter writer = new Utf8JsonWriter(stream, JsonUtils.DefaultWriterOptions);
+        SerializationMap<Project>.SerializeToJson(this, writer);
+    }
+
+    public void RecalculateDisplayPages() {
+        foreach (var page in displayPages) {
+            FindPage(page)?.SetToRecalculate();
+        }
+    }
+
+    public (float multiplier, string suffix) ResolveUnitOfMeasure(UnitOfMeasure unit) {
+        return unit switch {
+            UnitOfMeasure.Percent => (100f, "%"),
+            UnitOfMeasure.Second => (1f, "s"),
+            UnitOfMeasure.PerSecond => preferences.GetPerTimeUnit(),
+            UnitOfMeasure.ItemPerSecond => preferences.GetItemPerTimeUnit(),
+            UnitOfMeasure.FluidPerSecond => preferences.GetFluidPerTimeUnit(),
+            UnitOfMeasure.Megawatt => (1e6f, "W"),
+            UnitOfMeasure.Megajoule => (1e6f, "J"),
+            UnitOfMeasure.Celsius => (1f, "°"),
+            _ => (1f, ""),
+        };
+    }
+
+    public ProjectPage? FindPage(Guid guid) {
+        return pagesByGuid.TryGetValue(guid, out var page) ? page : null;
+    }
+
+    public void RemovePage(ProjectPage page) {
+        page.MarkAsDeleted();
+        _ = this.RecordUndo();
+        pages.Remove(page);
+        displayPages.Remove(page.guid);
+    }
+
+    /// <summary>
+    /// Get the page that is visually next (i.e. to the right of the current selected page on the tab bar)
+    /// from the specified one.
+    /// </summary>
+    /// <param name="currentPage">The page to get the next page from (probably the current page).
+    /// This is a nullable parameter because sometimes there isn't a current page at all; if it's
+    /// null, we'll return the first display page (if any).</param>
+    /// <param name="forward">Whether to move visually-forward (true), i.e. left to right, or
+    /// visually-backward (false), i.e. right-to-left.</param>
+    /// <returns>The page object that should be set to active.</returns>
+    public ProjectPage? VisibleNeighborOfPage(ProjectPage? currentPage, bool forward) {
+        if (currentPage == null) {
+            if (displayPages.Count == 0) {
+                return null;
+            }
+            return pagesByGuid[displayPages.First()];
+        }
+        var currentGuid = currentPage.guid;
+        var currentVisualIndex = displayPages.IndexOf(currentGuid);
+        return pagesByGuid[displayPages[forward ? NextVisualIndex() : PreviousVisualIndex()]];
+        int NextVisualIndex() {
+            var naiveNextVisualIndex = currentVisualIndex + 1;
+            return naiveNextVisualIndex >= displayPages.Count ? 0 : naiveNextVisualIndex;
+        }
+        int PreviousVisualIndex() {
+            var naivePreviousVisualIndex = currentVisualIndex - 1;
+            return naivePreviousVisualIndex < 0 ? displayPages.Count - 1 : naivePreviousVisualIndex;
+        }
+    }
+
+    /// <summary> Swaps the specified two pages in tab order. </summary>
+    public void ReorderPages(ProjectPage? page1, ProjectPage? page2) {
+        if (page1 is null || page2 is null) {
+            return;
+        }
+
+        _ = this.RecordUndo();
+        var index1 = displayPages.IndexOf(page1.guid);
+        var index2 = displayPages.IndexOf(page2.guid);
+        if (index1 == -1 || index2 == -1 || index1 == index2) {
+            return;
+        }
+        displayPages[index1] = page2.guid;
+        displayPages[index2] = page1.guid;
+    }
+}
+
+public class ProjectSettings(Project project) : ModelObject<Project>(project) {
+    public List<FactorioObject> milestones { get; } = [];
+    public SortedList<FactorioObject, ProjectPerItemFlags> itemFlags { get; } = new SortedList<FactorioObject, ProjectPerItemFlags>(DataUtils.DeterministicComparer);
+    public float miningProductivity { get; set; }
+    public float researchSpeedBonus { get; set; }
+    public float researchProductivity { get; set; }
+    public int reactorSizeX { get; set; } = 2;
+    public int reactorSizeY { get; set; } = 2;
+    public float PollutionCostModifier { get; set; } = 0;
+    public event Action<bool>? changed;
+    protected internal override void ThisChanged(bool visualOnly) {
+        changed?.Invoke(visualOnly);
+    }
+
+    public void SetFlag(FactorioObject obj, ProjectPerItemFlags flag, bool set) {
+        _ = itemFlags.TryGetValue(obj, out var flags);
+        var newFlags = set ? flags | flag : flags & ~flag;
+        if (newFlags != flags) {
             _ = this.RecordUndo();
-            pages.Remove(page);
-            displayPages.Remove(page.guid);
-        }
-
-        /// <summary>
-        /// Get the page that is visually next (i.e. to the right of the current selected page on the tab bar)
-        /// from the specified one.
-        /// </summary>
-        /// <param name="currentPage">The page to get the next page from (probably the current page).
-        /// This is a nullable parameter because sometimes there isn't a current page at all; if it's
-        /// null, we'll return the first display page (if any).</param>
-        /// <param name="forward">Whether to move visually-forward (true), i.e. left to right, or
-        /// visually-backward (false), i.e. right-to-left.</param>
-        /// <returns>The page object that should be set to active.</returns>
-        public ProjectPage? VisibleNeighborOfPage(ProjectPage? currentPage, bool forward) {
-            if (currentPage == null) {
-                if (displayPages.Count == 0) {
-                    return null;
-                }
-                return pagesByGuid[displayPages.First()];
-            }
-            var currentGuid = currentPage.guid;
-            var currentVisualIndex = displayPages.IndexOf(currentGuid);
-            return pagesByGuid[displayPages[forward ? NextVisualIndex() : PreviousVisualIndex()]];
-            int NextVisualIndex() {
-                var naiveNextVisualIndex = currentVisualIndex + 1;
-                return naiveNextVisualIndex >= displayPages.Count ? 0 : naiveNextVisualIndex;
-            }
-            int PreviousVisualIndex() {
-                var naivePreviousVisualIndex = currentVisualIndex - 1;
-                return naivePreviousVisualIndex < 0 ? displayPages.Count - 1 : naivePreviousVisualIndex;
-            }
-        }
-
-        /// <summary> Swaps the specified two pages in tab order. </summary>
-        public void ReorderPages(ProjectPage? page1, ProjectPage? page2) {
-            if (page1 is null || page2 is null) {
-                return;
-            }
-
-            _ = this.RecordUndo();
-            var index1 = displayPages.IndexOf(page1.guid);
-            var index2 = displayPages.IndexOf(page2.guid);
-            if (index1 == -1 || index2 == -1 || index1 == index2) {
-                return;
-            }
-            displayPages[index1] = page2.guid;
-            displayPages[index2] = page1.guid;
+            itemFlags[obj] = newFlags;
         }
     }
 
-    public class ProjectSettings(Project project) : ModelObject<Project>(project) {
-        public List<FactorioObject> milestones { get; } = [];
-        public SortedList<FactorioObject, ProjectPerItemFlags> itemFlags { get; } = new SortedList<FactorioObject, ProjectPerItemFlags>(DataUtils.DeterministicComparer);
-        public float miningProductivity { get; set; }
-        public float researchSpeedBonus { get; set; }
-        public float researchProductivity { get; set; }
-        public int reactorSizeX { get; set; } = 2;
-        public int reactorSizeY { get; set; } = 2;
-        public float PollutionCostModifier { get; set; } = 0;
-        public event Action<bool>? changed;
-        protected internal override void ThisChanged(bool visualOnly) {
-            changed?.Invoke(visualOnly);
+    public ProjectPerItemFlags Flags(FactorioObject obj) {
+        return itemFlags.TryGetValue(obj, out var val) ? val : 0;
+    }
+
+    public float GetReactorBonusMultiplier() {
+        return 4f - (2f / reactorSizeX) - (2f / reactorSizeY);
+    }
+}
+
+public class ProjectPreferences(Project owner) : ModelObject<Project>(owner) {
+    public int time { get; set; } = 1;
+    public float itemUnit { get; set; }
+    public float fluidUnit { get; set; }
+    public EntityBelt? defaultBelt { get; set; }
+    public EntityInserter? defaultInserter { get; set; }
+    public int inserterCapacity { get; set; } = 1;
+    public HashSet<FactorioObject> sourceResources { get; } = [];
+    public HashSet<FactorioObject> favorites { get; } = [];
+    /// <summary> Target technology for cost analysis - required item counts are estimated for researching this. If null, the is to research all finite technologies. </summary>
+    public Technology? targetTechnology { get; set; }
+    /// <summary>
+    /// The scale to use when drawing icons that have information stored in their background color, stored as a ratio from 0 to 1.
+    /// </summary>
+    public float iconScale { get; set; } = .9f;
+
+    protected internal override void AfterDeserialize() {
+        base.AfterDeserialize();
+        defaultBelt ??= Database.allBelts.OrderBy(x => x.beltItemsPerSecond).FirstOrDefault();
+        defaultInserter ??= Database.allInserters.OrderBy(x => x.energy.type).ThenBy(x => 1f / x.inserterSwingTime).FirstOrDefault();
+    }
+
+    public (float multiplier, string suffix) GetTimeUnit() {
+        return time switch {
+            1 or 0 => (1f, "s"),
+            60 => (1f / 60f, "m"),
+            3600 => (1f / 3600f, "h"),
+            _ => (1f / time, "t"),
+        };
+    }
+
+    public (float multiplier, string suffix) GetPerTimeUnit() {
+        return time switch {
+            1 or 0 => (1f, "/s"),
+            60 => (60f, "/m"),
+            3600 => (3600f, "/h"),
+            _ => (time, "/t"),
+        };
+    }
+
+    public (float multiplier, string suffix) GetItemPerTimeUnit() {
+        if (itemUnit == 0f) {
+            return GetPerTimeUnit();
         }
 
-        public void SetFlag(FactorioObject obj, ProjectPerItemFlags flag, bool set) {
-            _ = itemFlags.TryGetValue(obj, out var flags);
-            var newFlags = set ? flags | flag : flags & ~flag;
-            if (newFlags != flags) {
-                _ = this.RecordUndo();
-                itemFlags[obj] = newFlags;
-            }
+        return (1f / itemUnit, "b");
+    }
+
+    public (float multiplier, string suffix) GetFluidPerTimeUnit() {
+        if (fluidUnit == 0f) {
+            return GetPerTimeUnit();
         }
 
-        public ProjectPerItemFlags Flags(FactorioObject obj) {
-            return itemFlags.TryGetValue(obj, out var val) ? val : 0;
-        }
+        return (1f / fluidUnit, "p");
+    }
 
-        public float GetReactorBonusMultiplier() {
-            return 4f - (2f / reactorSizeX) - (2f / reactorSizeY);
+    public void SetSourceResource(Goods goods, bool value) {
+        _ = this.RecordUndo();
+        if (value) {
+            _ = sourceResources.Add(goods);
+        }
+        else {
+            _ = sourceResources.Remove(goods);
         }
     }
 
-    public class ProjectPreferences(Project owner) : ModelObject<Project>(owner) {
-        public int time { get; set; } = 1;
-        public float itemUnit { get; set; }
-        public float fluidUnit { get; set; }
-        public EntityBelt? defaultBelt { get; set; }
-        public EntityInserter? defaultInserter { get; set; }
-        public int inserterCapacity { get; set; } = 1;
-        public HashSet<FactorioObject> sourceResources { get; } = [];
-        public HashSet<FactorioObject> favorites { get; } = [];
-        /// <summary> Target technology for cost analysis - required item counts are estimated for researching this. If null, the is to research all finite technologies. </summary>
-        public Technology? targetTechnology { get; set; }
-        /// <summary>
-        /// The scale to use when drawing icons that have information stored in their background color, stored as a ratio from 0 to 1.
-        /// </summary>
-        public float iconScale { get; set; } = .9f;
-
-        protected internal override void AfterDeserialize() {
-            base.AfterDeserialize();
-            defaultBelt ??= Database.allBelts.OrderBy(x => x.beltItemsPerSecond).FirstOrDefault();
-            defaultInserter ??= Database.allInserters.OrderBy(x => x.energy.type).ThenBy(x => 1f / x.inserterSwingTime).FirstOrDefault();
-        }
-
-        public (float multiplier, string suffix) GetTimeUnit() {
-            return time switch {
-                1 or 0 => (1f, "s"),
-                60 => (1f / 60f, "m"),
-                3600 => (1f / 3600f, "h"),
-                _ => (1f / time, "t"),
-            };
-        }
-
-        public (float multiplier, string suffix) GetPerTimeUnit() {
-            return time switch {
-                1 or 0 => (1f, "/s"),
-                60 => (60f, "/m"),
-                3600 => (3600f, "/h"),
-                _ => (time, "/t"),
-            };
-        }
-
-        public (float multiplier, string suffix) GetItemPerTimeUnit() {
-            if (itemUnit == 0f) {
-                return GetPerTimeUnit();
-            }
-
-            return (1f / itemUnit, "b");
-        }
-
-        public (float multiplier, string suffix) GetFluidPerTimeUnit() {
-            if (fluidUnit == 0f) {
-                return GetPerTimeUnit();
-            }
-
-            return (1f / fluidUnit, "p");
-        }
-
-        public void SetSourceResource(Goods goods, bool value) {
-            _ = this.RecordUndo();
-            if (value) {
-                _ = sourceResources.Add(goods);
-            }
-            else {
-                _ = sourceResources.Remove(goods);
-            }
-        }
-
-        protected internal override void ThisChanged(bool visualOnly) {
-            // Don't propagate preferences changes to project
-        }
-
-        public void ToggleFavorite(FactorioObject obj) {
-            _ = this.RecordUndo(true);
-            if (favorites.Contains(obj)) {
-                _ = favorites.Remove(obj);
-            }
-            else {
-                _ = favorites.Add(obj);
-            }
-        }
+    protected internal override void ThisChanged(bool visualOnly) {
+        // Don't propagate preferences changes to project
     }
 
-    [Flags]
-    public enum ProjectPerItemFlags {
-        MilestoneUnlocked = 1 << 0,
-        MarkedAccessible = 1 << 1,
-        MarkedInaccessible = 1 << 2,
+    public void ToggleFavorite(FactorioObject obj) {
+        _ = this.RecordUndo(true);
+        if (favorites.Contains(obj)) {
+            _ = favorites.Remove(obj);
+        }
+        else {
+            _ = favorites.Add(obj);
+        }
     }
+}
+
+[Flags]
+public enum ProjectPerItemFlags {
+    MilestoneUnlocked = 1 << 0,
+    MarkedAccessible = 1 << 1,
+    MarkedInaccessible = 1 << 2,
 }

--- a/Yafc.Model/Model/ProjectModuleTemplate.cs
+++ b/Yafc.Model/Model/ProjectModuleTemplate.cs
@@ -1,15 +1,14 @@
 ﻿using System.Collections.Generic;
 
-namespace Yafc.Model {
-    public class ProjectModuleTemplate : ModelObject<Project> {
-        public ProjectModuleTemplate(Project owner, string name) : base(owner) {
-            template = new ModuleTemplateBuilder().Build(this);
-            this.name = name;
-        }
-
-        public ModuleTemplate template { get; set; }
-        public FactorioObject? icon { get; set; }
-        public string name { get; set; }
-        public List<Entity> filterEntities { get; } = [];
+namespace Yafc.Model;
+public class ProjectModuleTemplate : ModelObject<Project> {
+    public ProjectModuleTemplate(Project owner, string name) : base(owner) {
+        template = new ModuleTemplateBuilder().Build(this);
+        this.name = name;
     }
+
+    public ModuleTemplate template { get; set; }
+    public FactorioObject? icon { get; set; }
+    public string name { get; set; }
+    public List<Entity> filterEntities { get; } = [];
 }

--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -2,120 +2,119 @@
 using System.Threading.Tasks;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public class ProjectPage : ModelObject<Project> {
-        public FactorioObject? icon { get; set; }
-        public string name { get; set; } = "New page";
-        public Guid guid { get; private set; }
-        public Type contentType { get; }
-        public ProjectPageContents content { get; }
-        public bool active { get; private set; }
-        public bool visible { get; internal set; }
-        [SkipSerialization] public string? modelError { get; set; }
-        public bool deleted { get; private set; }
-        [SkipSerialization]
-        public bool canDelete => contentType != typeof(Summary);
+namespace Yafc.Model;
+public class ProjectPage : ModelObject<Project> {
+    public FactorioObject? icon { get; set; }
+    public string name { get; set; } = "New page";
+    public Guid guid { get; private set; }
+    public Type contentType { get; }
+    public ProjectPageContents content { get; }
+    public bool active { get; private set; }
+    public bool visible { get; internal set; }
+    [SkipSerialization] public string? modelError { get; set; }
+    public bool deleted { get; private set; }
+    [SkipSerialization]
+    public bool canDelete => contentType != typeof(Summary);
 
-        private uint lastSolvedVersion;
-        private uint currentSolvingVersion;
-        private uint actualVersion;
-        public event Action<bool>? contentChanged;
+    private uint lastSolvedVersion;
+    private uint currentSolvingVersion;
+    private uint actualVersion;
+    public event Action<bool>? contentChanged;
 
-        public ProjectPage(Project project, Type contentType, Guid guid = default) : base(project) {
-            this.guid = guid == default ? Guid.NewGuid() : guid;
-            actualVersion = project.projectVersion;
-            this.contentType = contentType;
-            content = Activator.CreateInstance(contentType, this) as ProjectPageContents ?? throw new ArgumentException($"{nameof(contentType)} must derive from {nameof(ProjectPageContents)}", nameof(contentType));
-        }
+    public ProjectPage(Project project, Type contentType, Guid guid = default) : base(project) {
+        this.guid = guid == default ? Guid.NewGuid() : guid;
+        actualVersion = project.projectVersion;
+        this.contentType = contentType;
+        content = Activator.CreateInstance(contentType, this) as ProjectPageContents ?? throw new ArgumentException($"{nameof(contentType)} must derive from {nameof(ProjectPageContents)}", nameof(contentType));
+    }
 
-        protected internal override void AfterDeserialize() {
-            base.AfterDeserialize();
-            deleted = false;
-        }
+    protected internal override void AfterDeserialize() {
+        base.AfterDeserialize();
+        deleted = false;
+    }
 
-        internal void MarkAsDeleted() {
-            deleted = true;
-        }
+    internal void MarkAsDeleted() {
+        deleted = true;
+    }
 
-        public void GenerateNewGuid() {
-            guid = Guid.NewGuid();
-        }
+    public void GenerateNewGuid() {
+        guid = Guid.NewGuid();
+    }
 
-        public void SetActive(bool active) {
-            this.active = active;
-            if (active) {
-                CheckSolve();
-            }
-        }
-
-        public void SetToRecalculate() {
-            lastSolvedVersion = 0;
-            if (currentSolvingVersion > 0) {
-                currentSolvingVersion = 1;
-            }
-            else {
-                CheckSolve();
-            }
-        }
-
-        public void ContentChanged(bool visualOnly) {
-            if (!visualOnly) {
-                actualVersion = hierarchyVersion;
-                CheckSolve();
-            }
-            contentChanged?.Invoke(visualOnly);
-        }
-
-        private Task CheckSolve() {
-            if (active && IsSolutionStale()) {
-                return RunSolveJob();
-            }
-            return Task.CompletedTask;
-        }
-
-        public bool IsSolutionStale() {
-            return content != null && actualVersion > lastSolvedVersion && currentSolvingVersion == 0;
-        }
-
-        protected internal override void ThisChanged(bool visualOnly) {
-            // Don't propagate page changes to project
-        }
-
-        public async Task<string?> ExternalSolve() {
-            if (!IsSolutionStale()) {
-                return modelError;
-            }
-
-            currentSolvingVersion = actualVersion;
-            try {
-                string? error = await content.Solve(this);
-                await Ui.EnterMainThread();
-                return error;
-            }
-            finally {
-                await Ui.EnterMainThread();
-                lastSolvedVersion = currentSolvingVersion;
-                currentSolvingVersion = 0;
-            }
-        }
-
-        public async Task RunSolveJob() {
-            modelError = await ExternalSolve();
-            contentChanged?.Invoke(false);
-            await CheckSolve();
+    public void SetActive(bool active) {
+        this.active = active;
+        if (active) {
+            CheckSolve();
         }
     }
 
-    public abstract class ProjectPageContents(ModelObject page) : ModelObject<ModelObject>(page) {
-        public virtual void InitNew() { }
-        public abstract Task<string?> Solve(ProjectPage page);
-
-        protected internal override void ThisChanged(bool visualOnly) {
-            if (owner is ProjectPage page) {
-                page.ContentChanged(visualOnly);
-            }
-
-            base.ThisChanged(visualOnly);
+    public void SetToRecalculate() {
+        lastSolvedVersion = 0;
+        if (currentSolvingVersion > 0) {
+            currentSolvingVersion = 1;
         }
+        else {
+            CheckSolve();
+        }
+    }
+
+    public void ContentChanged(bool visualOnly) {
+        if (!visualOnly) {
+            actualVersion = hierarchyVersion;
+            CheckSolve();
+        }
+        contentChanged?.Invoke(visualOnly);
+    }
+
+    private Task CheckSolve() {
+        if (active && IsSolutionStale()) {
+            return RunSolveJob();
+        }
+        return Task.CompletedTask;
+    }
+
+    public bool IsSolutionStale() {
+        return content != null && actualVersion > lastSolvedVersion && currentSolvingVersion == 0;
+    }
+
+    protected internal override void ThisChanged(bool visualOnly) {
+        // Don't propagate page changes to project
+    }
+
+    public async Task<string?> ExternalSolve() {
+        if (!IsSolutionStale()) {
+            return modelError;
+        }
+
+        currentSolvingVersion = actualVersion;
+        try {
+            string? error = await content.Solve(this);
+            await Ui.EnterMainThread();
+            return error;
+        }
+        finally {
+            await Ui.EnterMainThread();
+            lastSolvedVersion = currentSolvingVersion;
+            currentSolvingVersion = 0;
+        }
+    }
+
+    public async Task RunSolveJob() {
+        modelError = await ExternalSolve();
+        contentChanged?.Invoke(false);
+        await CheckSolve();
+    }
+}
+
+public abstract class ProjectPageContents(ModelObject page) : ModelObject<ModelObject>(page) {
+    public virtual void InitNew() { }
+    public abstract Task<string?> Solve(ProjectPage page);
+
+    protected internal override void ThisChanged(bool visualOnly) {
+        if (owner is ProjectPage page) {
+            page.ContentChanged(visualOnly);
+        }
+
+        base.ThisChanged(visualOnly);
     }
 }

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -1,188 +1,187 @@
 ﻿using System;
 using System.Linq;
 
-namespace Yafc.Model {
-    [Flags]
-    public enum WarningFlags {
-        // Non-errors
-        AssumesNauvisSolarRatio = 1 << 0,
-        ReactorsNeighborsFromPrefs = 1 << 1,
-        RecipeTickLimit = 1 << 2,
-        FuelUsageInputLimited = 1 << 3,
+namespace Yafc.Model;
+[Flags]
+public enum WarningFlags {
+    // Non-errors
+    AssumesNauvisSolarRatio = 1 << 0,
+    ReactorsNeighborsFromPrefs = 1 << 1,
+    RecipeTickLimit = 1 << 2,
+    FuelUsageInputLimited = 1 << 3,
 
-        // Static errors
-        EntityNotSpecified = 1 << 8,
-        FuelNotSpecified = 1 << 9,
-        FuelTemperatureExceedsMaximum = 1 << 10,
-        FuelDoesNotProvideEnergy = 1 << 11,
-        FuelWithTemperatureNotLinked = 1 << 12,
+    // Static errors
+    EntityNotSpecified = 1 << 8,
+    FuelNotSpecified = 1 << 9,
+    FuelTemperatureExceedsMaximum = 1 << 10,
+    FuelDoesNotProvideEnergy = 1 << 11,
+    FuelWithTemperatureNotLinked = 1 << 12,
 
-        // Solution errors
-        DeadlockCandidate = 1 << 16,
-        OverproductionRequired = 1 << 17,
-        ExceedsBuiltCount = 1 << 18,
+    // Solution errors
+    DeadlockCandidate = 1 << 16,
+    OverproductionRequired = 1 << 17,
+    ExceedsBuiltCount = 1 << 18,
 
-        // Not implemented warnings
-        TemperatureForIngredientNotMatch = 1 << 24,
-    }
+    // Not implemented warnings
+    TemperatureForIngredientNotMatch = 1 << 24,
+}
 
-    public struct UsedModule {
-        public (Module module, int count, bool beacon)[]? modules;
-        public Entity? beacon;
-        public int beaconCount;
-    }
+public struct UsedModule {
+    public (Module module, int count, bool beacon)[]? modules;
+    public Entity? beacon;
+    public int beaconCount;
+}
 
-    internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBuilding, float productivity, WarningFlags warningFlags, ModuleEffects activeEffects, UsedModule modules) {
-        public const float MIN_RECIPE_TIME = 1f / 60;
-        public float recipeTime { get; } = recipeTime;
-        public float fuelUsagePerSecondPerBuilding { get; } = fuelUsagePerSecondPerBuilding;
-        public float productivity { get; } = productivity;
-        public WarningFlags warningFlags { get; internal set; } = warningFlags;
-        public ModuleEffects activeEffects { get; } = activeEffects;
-        public UsedModule modules { get; } = modules;
+internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBuilding, float productivity, WarningFlags warningFlags, ModuleEffects activeEffects, UsedModule modules) {
+    public const float MIN_RECIPE_TIME = 1f / 60;
+    public float recipeTime { get; } = recipeTime;
+    public float fuelUsagePerSecondPerBuilding { get; } = fuelUsagePerSecondPerBuilding;
+    public float productivity { get; } = productivity;
+    public WarningFlags warningFlags { get; internal set; } = warningFlags;
+    public ModuleEffects activeEffects { get; } = activeEffects;
+    public UsedModule modules { get; } = modules;
 
-        public static RecipeParameters Empty = new(0, 0, 0, 0, default, default);
+    public static RecipeParameters Empty = new(0, 0, 0, 0, default, default);
 
-        public float fuelUsagePerSecondPerRecipe => recipeTime * fuelUsagePerSecondPerBuilding;
+    public float fuelUsagePerSecondPerRecipe => recipeTime * fuelUsagePerSecondPerBuilding;
 
-        public static RecipeParameters CalculateParameters(RecipeRow row) {
-            WarningFlags warningFlags = 0;
-            EntityCrafter? entity = row.entity;
-            RecipeOrTechnology recipe = row.recipe;
-            Goods? fuel = row.fuel;
-            float recipeTime, fuelUsagePerSecondPerBuilding = 0, productivity;
-            ModuleEffects activeEffects = default;
-            UsedModule modules = default;
+    public static RecipeParameters CalculateParameters(RecipeRow row) {
+        WarningFlags warningFlags = 0;
+        EntityCrafter? entity = row.entity;
+        RecipeOrTechnology recipe = row.recipe;
+        Goods? fuel = row.fuel;
+        float recipeTime, fuelUsagePerSecondPerBuilding = 0, productivity;
+        ModuleEffects activeEffects = default;
+        UsedModule modules = default;
 
-            if (entity == null) {
-                warningFlags |= WarningFlags.EntityNotSpecified;
-                recipeTime = recipe.time;
-                productivity = 0f;
-            }
-            else {
-                recipeTime = recipe.time / entity.craftingSpeed;
-                productivity = entity.productivity;
-                var energy = entity.energy;
-                float energyUsage = entity.power;
-                float energyPerUnitOfFuel = 0f;
+        if (entity == null) {
+            warningFlags |= WarningFlags.EntityNotSpecified;
+            recipeTime = recipe.time;
+            productivity = 0f;
+        }
+        else {
+            recipeTime = recipe.time / entity.craftingSpeed;
+            productivity = entity.productivity;
+            var energy = entity.energy;
+            float energyUsage = entity.power;
+            float energyPerUnitOfFuel = 0f;
 
-                // Special case for fuel
-                if (energy != null && fuel != null) {
-                    var fluid = fuel.fluid;
-                    energyPerUnitOfFuel = fuel.fuelValue;
+            // Special case for fuel
+            if (energy != null && fuel != null) {
+                var fluid = fuel.fluid;
+                energyPerUnitOfFuel = fuel.fuelValue;
 
-                    if (energy.type == EntityEnergyType.FluidHeat) {
-                        if (fluid == null) {
-                            warningFlags |= WarningFlags.FuelWithTemperatureNotLinked;
-                        }
-                        else {
-                            int temperature = fluid.temperature;
-                            if (temperature > energy.workingTemperature.max) {
-                                temperature = energy.workingTemperature.max;
-                                warningFlags |= WarningFlags.FuelTemperatureExceedsMaximum;
-                            }
-
-                            float heatCap = fluid.heatCapacity;
-                            energyPerUnitOfFuel = (temperature - energy.workingTemperature.min) * heatCap;
-                        }
-                    }
-
-                    if (fluid != null && !energy.acceptedTemperature.Contains(fluid.temperature)) {
-                        warningFlags |= WarningFlags.FuelDoesNotProvideEnergy;
-                    }
-
-                    if (energyPerUnitOfFuel > 0f) {
-                        fuelUsagePerSecondPerBuilding = energyUsage <= 0f ? 0f : energyUsage / (energyPerUnitOfFuel * energy.effectivity);
+                if (energy.type == EntityEnergyType.FluidHeat) {
+                    if (fluid == null) {
+                        warningFlags |= WarningFlags.FuelWithTemperatureNotLinked;
                     }
                     else {
-                        fuelUsagePerSecondPerBuilding = 0;
-                        warningFlags |= WarningFlags.FuelDoesNotProvideEnergy;
+                        int temperature = fluid.temperature;
+                        if (temperature > energy.workingTemperature.max) {
+                            temperature = energy.workingTemperature.max;
+                            warningFlags |= WarningFlags.FuelTemperatureExceedsMaximum;
+                        }
+
+                        float heatCap = fluid.heatCapacity;
+                        energyPerUnitOfFuel = (temperature - energy.workingTemperature.min) * heatCap;
                     }
+                }
+
+                if (fluid != null && !energy.acceptedTemperature.Contains(fluid.temperature)) {
+                    warningFlags |= WarningFlags.FuelDoesNotProvideEnergy;
+                }
+
+                if (energyPerUnitOfFuel > 0f) {
+                    fuelUsagePerSecondPerBuilding = energyUsage <= 0f ? 0f : energyUsage / (energyPerUnitOfFuel * energy.effectivity);
                 }
                 else {
-                    fuelUsagePerSecondPerBuilding = energyUsage;
-                    warningFlags |= WarningFlags.FuelNotSpecified;
-                    energy ??= new EntityEnergy { type = EntityEnergyType.Void };
+                    fuelUsagePerSecondPerBuilding = 0;
+                    warningFlags |= WarningFlags.FuelDoesNotProvideEnergy;
                 }
+            }
+            else {
+                fuelUsagePerSecondPerBuilding = energyUsage;
+                warningFlags |= WarningFlags.FuelNotSpecified;
+                energy ??= new EntityEnergy { type = EntityEnergyType.Void };
+            }
 
-                // Special case for generators
-                if (recipe.flags.HasFlags(RecipeFlags.ScaleProductionWithPower) && energyPerUnitOfFuel > 0 && entity.energy.type != EntityEnergyType.Void) {
-                    if (energyUsage == 0) {
-                        fuelUsagePerSecondPerBuilding = energy.fuelConsumptionLimit;
-                        recipeTime = 1f / (energy.fuelConsumptionLimit * energyPerUnitOfFuel * energy.effectivity);
-                    }
-                    else {
-                        recipeTime = 1f / energyUsage;
-                    }
-                }
-
-                // Special case for boilers
-                if (recipe.flags.HasFlags(RecipeFlags.UsesFluidTemperature)) {
-                    var fluid = recipe.ingredients[0].goods.fluid;
-                    if (fluid != null) {
-                        float inputTemperature = fluid.temperature;
-                        foreach (Fluid variant in row.variants.OfType<Fluid>()) {
-                            if (variant.originalName == fluid.originalName) {
-                                inputTemperature = variant.temperature;
-                            }
-                        }
-
-                        int outputTemp = recipe.products[0].goods.fluid!.temperature; // null-forgiving: UsesFluidTemperature tells us this is a special "Fluid boiling to ??°" recipe, with one output fluid.
-                        float deltaTemp = outputTemp - inputTemperature;
-                        float energyPerUnitOfFluid = deltaTemp * fluid.heatCapacity;
-                        if (deltaTemp > 0 && fuel != null) {
-                            recipeTime = 60 * energyPerUnitOfFluid / (fuelUsagePerSecondPerBuilding * fuel.fuelValue * energy.effectivity);
-                        }
-                    }
-                }
-
-                bool isMining = recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity);
-                activeEffects = new ModuleEffects();
-                if (isMining) {
-                    productivity += Project.current.settings.miningProductivity;
-                }
-                else if (recipe is Technology) {
-                    productivity += Project.current.settings.researchProductivity;
-                }
-
-                if (entity is EntityReactor reactor && reactor.reactorNeighborBonus > 0f) {
-                    productivity += reactor.reactorNeighborBonus * Project.current.settings.GetReactorBonusMultiplier();
-                    warningFlags |= WarningFlags.ReactorsNeighborsFromPrefs;
-                }
-
-                if (entity.factorioType == "solar-panel") {
-                    warningFlags |= WarningFlags.AssumesNauvisSolarRatio;
-                }
-
-                modules = default;
-                if (recipe.modules.Length > 0 && entity.allowedEffects != AllowedEffects.None) {
-                    row.GetModulesInfo((recipeTime, fuelUsagePerSecondPerBuilding), entity, ref activeEffects, ref modules);
-                    productivity += activeEffects.productivity;
-                    recipeTime /= activeEffects.speedMod;
-                    fuelUsagePerSecondPerBuilding *= activeEffects.energyUsageMod;
-                }
-
-                if (energy.drain > 0f) {
-                    fuelUsagePerSecondPerBuilding += energy.drain / energyPerUnitOfFuel;
-                }
-
-                if (fuelUsagePerSecondPerBuilding > energy.fuelConsumptionLimit) {
-                    recipeTime *= fuelUsagePerSecondPerBuilding / energy.fuelConsumptionLimit;
+            // Special case for generators
+            if (recipe.flags.HasFlags(RecipeFlags.ScaleProductionWithPower) && energyPerUnitOfFuel > 0 && entity.energy.type != EntityEnergyType.Void) {
+                if (energyUsage == 0) {
                     fuelUsagePerSecondPerBuilding = energy.fuelConsumptionLimit;
-                    warningFlags |= WarningFlags.FuelUsageInputLimited;
+                    recipeTime = 1f / (energy.fuelConsumptionLimit * energyPerUnitOfFuel * energy.effectivity);
+                }
+                else {
+                    recipeTime = 1f / energyUsage;
                 }
             }
 
-            if (recipeTime < MIN_RECIPE_TIME && recipe.flags.HasFlags(RecipeFlags.LimitedByTickRate)) {
-                if (productivity > 0f) {
-                    productivity *= (MIN_RECIPE_TIME / recipeTime); // Recipe time is affected by the minimum time while productivity bonus aren't
-                }
+            // Special case for boilers
+            if (recipe.flags.HasFlags(RecipeFlags.UsesFluidTemperature)) {
+                var fluid = recipe.ingredients[0].goods.fluid;
+                if (fluid != null) {
+                    float inputTemperature = fluid.temperature;
+                    foreach (Fluid variant in row.variants.OfType<Fluid>()) {
+                        if (variant.originalName == fluid.originalName) {
+                            inputTemperature = variant.temperature;
+                        }
+                    }
 
-                recipeTime = MIN_RECIPE_TIME;
-                warningFlags |= WarningFlags.RecipeTickLimit;
+                    int outputTemp = recipe.products[0].goods.fluid!.temperature; // null-forgiving: UsesFluidTemperature tells us this is a special "Fluid boiling to ??°" recipe, with one output fluid.
+                    float deltaTemp = outputTemp - inputTemperature;
+                    float energyPerUnitOfFluid = deltaTemp * fluid.heatCapacity;
+                    if (deltaTemp > 0 && fuel != null) {
+                        recipeTime = 60 * energyPerUnitOfFluid / (fuelUsagePerSecondPerBuilding * fuel.fuelValue * energy.effectivity);
+                    }
+                }
             }
 
-            return new RecipeParameters(recipeTime, fuelUsagePerSecondPerBuilding, productivity, warningFlags, activeEffects, modules);
+            bool isMining = recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity);
+            activeEffects = new ModuleEffects();
+            if (isMining) {
+                productivity += Project.current.settings.miningProductivity;
+            }
+            else if (recipe is Technology) {
+                productivity += Project.current.settings.researchProductivity;
+            }
+
+            if (entity is EntityReactor reactor && reactor.reactorNeighborBonus > 0f) {
+                productivity += reactor.reactorNeighborBonus * Project.current.settings.GetReactorBonusMultiplier();
+                warningFlags |= WarningFlags.ReactorsNeighborsFromPrefs;
+            }
+
+            if (entity.factorioType == "solar-panel") {
+                warningFlags |= WarningFlags.AssumesNauvisSolarRatio;
+            }
+
+            modules = default;
+            if (recipe.modules.Length > 0 && entity.allowedEffects != AllowedEffects.None) {
+                row.GetModulesInfo((recipeTime, fuelUsagePerSecondPerBuilding), entity, ref activeEffects, ref modules);
+                productivity += activeEffects.productivity;
+                recipeTime /= activeEffects.speedMod;
+                fuelUsagePerSecondPerBuilding *= activeEffects.energyUsageMod;
+            }
+
+            if (energy.drain > 0f) {
+                fuelUsagePerSecondPerBuilding += energy.drain / energyPerUnitOfFuel;
+            }
+
+            if (fuelUsagePerSecondPerBuilding > energy.fuelConsumptionLimit) {
+                recipeTime *= fuelUsagePerSecondPerBuilding / energy.fuelConsumptionLimit;
+                fuelUsagePerSecondPerBuilding = energy.fuelConsumptionLimit;
+                warningFlags |= WarningFlags.FuelUsageInputLimited;
+            }
         }
+
+        if (recipeTime < MIN_RECIPE_TIME && recipe.flags.HasFlags(RecipeFlags.LimitedByTickRate)) {
+            if (productivity > 0f) {
+                productivity *= (MIN_RECIPE_TIME / recipeTime); // Recipe time is affected by the minimum time while productivity bonus aren't
+            }
+
+            recipeTime = MIN_RECIPE_TIME;
+            warningFlags |= WarningFlags.RecipeTickLimit;
+        }
+
+        return new RecipeParameters(recipeTime, fuelUsagePerSecondPerBuilding, productivity, warningFlags, activeEffects, modules);
     }
 }

--- a/Yafc.Model/Model/Summary.cs
+++ b/Yafc.Model/Model/Summary.cs
@@ -1,14 +1,13 @@
 ﻿using System.Threading.Tasks;
 
-namespace Yafc.Model {
-    public class Summary : ProjectPageContents {
+namespace Yafc.Model;
+public class Summary : ProjectPageContents {
 
-        public bool showOnlyIssues { get; set; }
+    public bool showOnlyIssues { get; set; }
 
-        public Summary(ModelObject page) : base(page) { }
+    public Summary(ModelObject page) : base(page) { }
 
-        public override Task<string?> Solve(ProjectPage page) {
-            return Task.FromResult<string?>(null);
-        }
+    public override Task<string?> Solve(ProjectPage page) {
+        return Task.FromResult<string?>(null);
     }
 }

--- a/Yafc.Model/Serialization/ErrorCollector.cs
+++ b/Yafc.Model/Serialization/ErrorCollector.cs
@@ -5,59 +5,58 @@ using System.Text.Json;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public enum ErrorSeverity {
-        None,
-        AnalysisWarning,
-        MinorDataLoss,
-        MajorDataLoss,
-        Important,
-        Critical
+namespace Yafc.Model;
+public enum ErrorSeverity {
+    None,
+    AnalysisWarning,
+    MinorDataLoss,
+    MajorDataLoss,
+    Important,
+    Critical
+}
+
+public class ErrorCollector {
+    private static readonly ILogger logger = Logging.GetLogger<ErrorCollector>();
+    private readonly Dictionary<(string message, ErrorSeverity severity), int> allErrors = [];
+    public ErrorSeverity severity { get; private set; }
+    public void Error(string message, ErrorSeverity severity) {
+        var key = (message, severity);
+        if (severity > this.severity) {
+            this.severity = severity;
+        }
+
+        _ = allErrors.TryGetValue(key, out int prevC);
+        allErrors[key] = prevC + 1;
+        logger.Information(message);
     }
 
-    public class ErrorCollector {
-        private static readonly ILogger logger = Logging.GetLogger<ErrorCollector>();
-        private readonly Dictionary<(string message, ErrorSeverity severity), int> allErrors = [];
-        public ErrorSeverity severity { get; private set; }
-        public void Error(string message, ErrorSeverity severity) {
-            var key = (message, severity);
-            if (severity > this.severity) {
-                this.severity = severity;
-            }
+    public (string error, ErrorSeverity severity)[] GetArrErrors() {
+        return allErrors.OrderByDescending(x => x.Key.severity).ThenByDescending(x => x.Value).Select(x => (x.Value == 1 ? x.Key.message : x.Key.message + " (x" + x.Value + ")", x.Key.severity)).ToArray();
+    }
 
-            _ = allErrors.TryGetValue(key, out int prevC);
-            allErrors[key] = prevC + 1;
-            logger.Information(message);
+    public void Exception(Exception exception, string message, ErrorSeverity errorSeverity) {
+        while (exception.InnerException != null) {
+            exception = exception.InnerException;
         }
 
-        public (string error, ErrorSeverity severity)[] GetArrErrors() {
-            return allErrors.OrderByDescending(x => x.Key.severity).ThenByDescending(x => x.Value).Select(x => (x.Value == 1 ? x.Key.message : x.Key.message + " (x" + x.Value + ")", x.Key.severity)).ToArray();
+        string s = message + ": ";
+        if (exception is JsonException) {
+            s += "unexpected or invalid json";
+        }
+        else if (exception is ArgumentNullException argnull) {
+            s += argnull.Message;
+        }
+        else if (exception is NotSupportedException notSupportedException) {
+            s += notSupportedException.Message;
+        }
+        else if (exception is InvalidOperationException unexpectedNull) {
+            s += unexpectedNull.Message;
+        }
+        else {
+            s += exception.GetType().Name;
         }
 
-        public void Exception(Exception exception, string message, ErrorSeverity errorSeverity) {
-            while (exception.InnerException != null) {
-                exception = exception.InnerException;
-            }
-
-            string s = message + ": ";
-            if (exception is JsonException) {
-                s += "unexpected or invalid json";
-            }
-            else if (exception is ArgumentNullException argnull) {
-                s += argnull.Message;
-            }
-            else if (exception is NotSupportedException notSupportedException) {
-                s += notSupportedException.Message;
-            }
-            else if (exception is InvalidOperationException unexpectedNull) {
-                s += unexpectedNull.Message;
-            }
-            else {
-                s += exception.GetType().Name;
-            }
-
-            Error(s, errorSeverity);
-            logger.Error(exception, "Exception encountered");
-        }
+        Error(s, errorSeverity);
+        logger.Error(exception, "Exception encountered");
     }
 }

--- a/Yafc.Model/Serialization/JsonUtils.cs
+++ b/Yafc.Model/Serialization/JsonUtils.cs
@@ -3,71 +3,70 @@ using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
-namespace Yafc.Model {
-    public static class JsonUtils {
-        public static readonly JsonSerializerOptions DefaultOptions = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true, IgnoreReadOnlyProperties = true };
-        public static readonly JsonWriterOptions DefaultWriterOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Indented = true };
-        internal static bool ReadStartArray(this ref Utf8JsonReader reader) {
-            var token = reader.TokenType;
-            if (token == JsonTokenType.Null) {
-                return false;
-            }
-
-            if (token == JsonTokenType.StartArray) {
-                _ = reader.Read();
-                return true;
-            }
-            throw new JsonException("Expected array or null");
+namespace Yafc.Model;
+public static class JsonUtils {
+    public static readonly JsonSerializerOptions DefaultOptions = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, WriteIndented = true, IgnoreReadOnlyProperties = true };
+    public static readonly JsonWriterOptions DefaultWriterOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, Indented = true };
+    internal static bool ReadStartArray(this ref Utf8JsonReader reader) {
+        var token = reader.TokenType;
+        if (token == JsonTokenType.Null) {
+            return false;
         }
 
-        internal static bool ReadStartObject(this ref Utf8JsonReader reader) {
-            var token = reader.TokenType;
-            if (token == JsonTokenType.Null) {
-                return false;
-            }
-
-            if (token == JsonTokenType.StartObject) {
-                _ = reader.Read();
-                return true;
-            }
-            throw new JsonException("Expected object or null");
-        }
-
-        public static T? Copy<T>(T obj, ModelObject newOwner, ErrorCollector? collector) where T : ModelObject {
-            using var ms = SaveToJson(obj);
-            return LoadFromJson<T>(new ReadOnlySpan<byte>(ms.GetBuffer(), 0, (int)ms.Length), newOwner, collector);
-        }
-
-        public static MemoryStream SaveToJson<T>(T obj) where T : ModelObject {
-            MemoryStream ms = new MemoryStream();
-            using (Utf8JsonWriter writer = new Utf8JsonWriter(ms)) {
-                SerializationMap<T>.SerializeToJson(obj, writer);
-            }
-
-            ms.Position = 0;
-            return ms;
-        }
-
-        public static T? LoadFromJson<T>(MemoryStream stream, ModelObject owner, T? def = null) where T : ModelObject {
-            ErrorCollector collector = new ErrorCollector();
-            var result = LoadFromJson<T>(new ReadOnlySpan<byte>(stream.GetBuffer(), 0, (int)stream.Length), owner, collector, false);
-            if (collector.severity != ErrorSeverity.None) {
-                return def;
-            }
-
-            return result;
-        }
-
-        public static T? LoadFromJson<T>(ReadOnlySpan<byte> buffer, ModelObject owner, ErrorCollector? collector, bool notify = true) where T : ModelObject {
-            Utf8JsonReader reader = new Utf8JsonReader(buffer);
+        if (token == JsonTokenType.StartArray) {
             _ = reader.Read();
-            DeserializationContext context = new DeserializationContext(collector);
-            var result = SerializationMap<T>.DeserializeFromJson(owner, ref reader, context);
-            if (notify) {
-                context.Notify();
-            }
-
-            return result;
+            return true;
         }
+        throw new JsonException("Expected array or null");
+    }
+
+    internal static bool ReadStartObject(this ref Utf8JsonReader reader) {
+        var token = reader.TokenType;
+        if (token == JsonTokenType.Null) {
+            return false;
+        }
+
+        if (token == JsonTokenType.StartObject) {
+            _ = reader.Read();
+            return true;
+        }
+        throw new JsonException("Expected object or null");
+    }
+
+    public static T? Copy<T>(T obj, ModelObject newOwner, ErrorCollector? collector) where T : ModelObject {
+        using var ms = SaveToJson(obj);
+        return LoadFromJson<T>(new ReadOnlySpan<byte>(ms.GetBuffer(), 0, (int)ms.Length), newOwner, collector);
+    }
+
+    public static MemoryStream SaveToJson<T>(T obj) where T : ModelObject {
+        MemoryStream ms = new MemoryStream();
+        using (Utf8JsonWriter writer = new Utf8JsonWriter(ms)) {
+            SerializationMap<T>.SerializeToJson(obj, writer);
+        }
+
+        ms.Position = 0;
+        return ms;
+    }
+
+    public static T? LoadFromJson<T>(MemoryStream stream, ModelObject owner, T? def = null) where T : ModelObject {
+        ErrorCollector collector = new ErrorCollector();
+        var result = LoadFromJson<T>(new ReadOnlySpan<byte>(stream.GetBuffer(), 0, (int)stream.Length), owner, collector, false);
+        if (collector.severity != ErrorSeverity.None) {
+            return def;
+        }
+
+        return result;
+    }
+
+    public static T? LoadFromJson<T>(ReadOnlySpan<byte> buffer, ModelObject owner, ErrorCollector? collector, bool notify = true) where T : ModelObject {
+        Utf8JsonReader reader = new Utf8JsonReader(buffer);
+        _ = reader.Read();
+        DeserializationContext context = new DeserializationContext(collector);
+        var result = SerializationMap<T>.DeserializeFromJson(owner, ref reader, context);
+        if (notify) {
+            context.Notify();
+        }
+
+        return result;
     }
 }

--- a/Yafc.Model/Serialization/ModelObject.cs
+++ b/Yafc.Model/Serialization/ModelObject.cs
@@ -1,87 +1,86 @@
 ﻿using System;
 
-namespace Yafc.Model {
-    /*
-     * Base class for objects that can be serialized to JSON and that support undo
-     * supports ONLY properties of following types:
-     * - Serializable (must be read-only)
-     * - List<T> (must be read-only) where T is a supported type
-     * - FactorioObject (must be read-write)
-     * - bool, int, ulong (must be read-write)
-     * - enums with backing int (must be read-write)
-     * - string (must be read-write)
-     *
-     * Also supports non-default constructors that write to read-only properties and/or have "owner" as its first parameter
-     */
+namespace Yafc.Model;
+/*
+ * Base class for objects that can be serialized to JSON and that support undo
+ * supports ONLY properties of following types:
+ * - Serializable (must be read-only)
+ * - List<T> (must be read-only) where T is a supported type
+ * - FactorioObject (must be read-write)
+ * - bool, int, ulong (must be read-write)
+ * - enums with backing int (must be read-write)
+ * - string (must be read-write)
+ *
+ * Also supports non-default constructors that write to read-only properties and/or have "owner" as its first parameter
+ */
 
-    public abstract class ModelObject {
-        internal readonly UndoSystem undo;
+public abstract class ModelObject {
+    internal readonly UndoSystem undo;
 
-        internal ModelObject(UndoSystem undo) {
-            this.undo = undo;
-            _objectVersion = _hierarchyVersion = undo?.version ?? 0;
-        }
-
-        [SkipSerialization] public abstract ModelObject? ownerObject { get; internal set; }
-        public ModelObject GetRoot() {
-            return ownerObject?.GetRoot() ?? this;
-        }
-
-        private uint _objectVersion;
-        private uint _hierarchyVersion;
-        public uint objectVersion {
-            get => _objectVersion;
-            internal set {
-                _objectVersion = value;
-                hierarchyVersion = value;
-            }
-        }
-
-        public uint hierarchyVersion {
-            get => _hierarchyVersion;
-            private set {
-                if (_hierarchyVersion == value) {
-                    return;
-                }
-
-                _hierarchyVersion = value;
-                var owner = ownerObject;
-                if (owner != null) {
-                    owner.hierarchyVersion = value;
-                }
-            }
-        }
-
-        protected internal virtual void AfterDeserialize() { }
-        protected internal virtual void ThisChanged(bool visualOnly) {
-            ownerObject?.ThisChanged(visualOnly);
-        }
-
-        internal SerializationMap GetUndoBuilder() {
-            return SerializationMap.GetSerializationMap(GetType());
-        }
-
-        internal void CreateUndoSnapshot(bool visualOnly = false) {
-            undo?.CreateUndoSnapshot(this, visualOnly);
-        }
-
-        private protected virtual void WriteExtraUndoInformation(UndoSnapshotBuilder builder) { }
-        private protected virtual void ReadExtraUndoInformation(UndoSnapshotReader reader) { }
-        public bool justChanged => undo.HasChangesPending(this);
+    internal ModelObject(UndoSystem undo) {
+        this.undo = undo;
+        _objectVersion = _hierarchyVersion = undo?.version ?? 0;
     }
-    public abstract class ModelObject<TOwner>(TOwner owner) : ModelObject(owner.undo) where TOwner : ModelObject {
-        private TOwner _owner = owner ?? throw new ArgumentNullException(nameof(owner));
 
-        [SkipSerialization]
-        public TOwner owner {
-            get => _owner;
-            protected set => _owner = value ?? throw new ArgumentNullException(nameof(value));
-        }
+    [SkipSerialization] public abstract ModelObject? ownerObject { get; internal set; }
+    public ModelObject GetRoot() {
+        return ownerObject?.GetRoot() ?? this;
+    }
 
-        public override ModelObject? ownerObject {
-            get => owner;
-            internal set => owner = value is null ? throw new ArgumentNullException(nameof(value))
-                    : value as TOwner ?? throw new ArgumentException($"value must be of type {typeof(TOwner)}", nameof(value));
+    private uint _objectVersion;
+    private uint _hierarchyVersion;
+    public uint objectVersion {
+        get => _objectVersion;
+        internal set {
+            _objectVersion = value;
+            hierarchyVersion = value;
         }
+    }
+
+    public uint hierarchyVersion {
+        get => _hierarchyVersion;
+        private set {
+            if (_hierarchyVersion == value) {
+                return;
+            }
+
+            _hierarchyVersion = value;
+            var owner = ownerObject;
+            if (owner != null) {
+                owner.hierarchyVersion = value;
+            }
+        }
+    }
+
+    protected internal virtual void AfterDeserialize() { }
+    protected internal virtual void ThisChanged(bool visualOnly) {
+        ownerObject?.ThisChanged(visualOnly);
+    }
+
+    internal SerializationMap GetUndoBuilder() {
+        return SerializationMap.GetSerializationMap(GetType());
+    }
+
+    internal void CreateUndoSnapshot(bool visualOnly = false) {
+        undo?.CreateUndoSnapshot(this, visualOnly);
+    }
+
+    private protected virtual void WriteExtraUndoInformation(UndoSnapshotBuilder builder) { }
+    private protected virtual void ReadExtraUndoInformation(UndoSnapshotReader reader) { }
+    public bool justChanged => undo.HasChangesPending(this);
+}
+public abstract class ModelObject<TOwner>(TOwner owner) : ModelObject(owner.undo) where TOwner : ModelObject {
+    private TOwner _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+
+    [SkipSerialization]
+    public TOwner owner {
+        get => _owner;
+        protected set => _owner = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public override ModelObject? ownerObject {
+        get => owner;
+        internal set => owner = value is null ? throw new ArgumentNullException(nameof(value))
+                : value as TOwner ?? throw new ArgumentException($"value must be of type {typeof(TOwner)}", nameof(value));
     }
 }

--- a/Yafc.Model/Serialization/PropertySerializers.cs
+++ b/Yafc.Model/Serialization/PropertySerializers.cs
@@ -6,345 +6,344 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Yafc.Model {
-    internal enum PropertyType {
-        Normal,
-        Immutable,
-        Obsolete,
-        NoUndo,
-    }
+namespace Yafc.Model;
+internal enum PropertyType {
+    Normal,
+    Immutable,
+    Obsolete,
+    NoUndo,
+}
 
-    internal abstract class PropertySerializer<TOwner> where TOwner : class {
-        public readonly PropertyInfo property;
-        public readonly JsonEncodedText propertyName;
-        internal readonly PropertyType type;
+internal abstract class PropertySerializer<TOwner> where TOwner : class {
+    public readonly PropertyInfo property;
+    public readonly JsonEncodedText propertyName;
+    internal readonly PropertyType type;
 
-        protected PropertySerializer(PropertyInfo property, PropertyType type, bool usingSetter) {
-            this.property = property;
-            this.type = type;
-            if (property.GetCustomAttribute<ObsoleteAttribute>() != null) {
-                this.type = PropertyType.Obsolete;
-            }
-            else if (property.GetCustomAttribute<NoUndoAttribute>() != null) {
-                this.type = PropertyType.NoUndo;
-            }
-            else if (usingSetter && type == PropertyType.Normal && (!property.CanWrite || property.GetSetMethod() == null)) {
-                this.type = PropertyType.Immutable;
-            }
-
-            var parameters = property.GetCustomAttribute<JsonPropertyNameAttribute>();
-            string name = parameters?.Name ?? property.Name;
-            propertyName = JsonEncodedText.Encode(name, JsonUtils.DefaultOptions.Encoder);
+    protected PropertySerializer(PropertyInfo property, PropertyType type, bool usingSetter) {
+        this.property = property;
+        this.type = type;
+        if (property.GetCustomAttribute<ObsoleteAttribute>() != null) {
+            this.type = PropertyType.Obsolete;
+        }
+        else if (property.GetCustomAttribute<NoUndoAttribute>() != null) {
+            this.type = PropertyType.NoUndo;
+        }
+        else if (usingSetter && type == PropertyType.Normal && (!property.CanWrite || property.GetSetMethod() == null)) {
+            this.type = PropertyType.Immutable;
         }
 
-        public override string ToString() => typeof(TOwner).Name + "." + property.Name;
-
-        public abstract void SerializeToJson(TOwner owner, Utf8JsonWriter writer);
-        public abstract void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context);
-        public abstract void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder);
-        public abstract void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader);
-        public virtual object? DeserializeFromJson(ref Utf8JsonReader reader, DeserializationContext context) =>
-            throw new NotSupportedException();
-
-        public virtual bool CanBeNull => false;
+        var parameters = property.GetCustomAttribute<JsonPropertyNameAttribute>();
+        string name = parameters?.Name ?? property.Name;
+        propertyName = JsonEncodedText.Encode(name, JsonUtils.DefaultOptions.Encoder);
     }
 
-    internal abstract class PropertySerializer<TOwner, TPropertyType>(PropertyInfo property, PropertyType type, bool usingSetter) :
-        PropertySerializer<TOwner>(property, type, usingSetter) where TOwner : class {
+    public override string ToString() => typeof(TOwner).Name + "." + property.Name;
 
-        // null-forgiving: Can these be null? Yep. Do we ever check for that? Nope. Do I want to figure out how to handle that? Also nope.
-        protected readonly Action<TOwner, TPropertyType?> _setter = property.GetSetMethod()?.CreateDelegate<Action<TOwner, TPropertyType?>>()!;
-        protected readonly Func<TOwner, TPropertyType> _getter = property.GetGetMethod()?.CreateDelegate<Func<TOwner, TPropertyType>>()!;
+    public abstract void SerializeToJson(TOwner owner, Utf8JsonWriter writer);
+    public abstract void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context);
+    public abstract void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder);
+    public abstract void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader);
+    public virtual object? DeserializeFromJson(ref Utf8JsonReader reader, DeserializationContext context) =>
+        throw new NotSupportedException();
 
-        protected TPropertyType getter(TOwner owner) {
-            ArgumentNullException.ThrowIfNull(owner, nameof(owner));
+    public virtual bool CanBeNull => false;
+}
 
-            return _getter(owner) ?? throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not return null.");
-        }
+internal abstract class PropertySerializer<TOwner, TPropertyType>(PropertyInfo property, PropertyType type, bool usingSetter) :
+    PropertySerializer<TOwner>(property, type, usingSetter) where TOwner : class {
+
+    // null-forgiving: Can these be null? Yep. Do we ever check for that? Nope. Do I want to figure out how to handle that? Also nope.
+    protected readonly Action<TOwner, TPropertyType?> _setter = property.GetSetMethod()?.CreateDelegate<Action<TOwner, TPropertyType?>>()!;
+    protected readonly Func<TOwner, TPropertyType> _getter = property.GetGetMethod()?.CreateDelegate<Func<TOwner, TPropertyType>>()!;
+
+    protected TPropertyType getter(TOwner owner) {
+        ArgumentNullException.ThrowIfNull(owner, nameof(owner));
+
+        return _getter(owner) ?? throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not return null.");
     }
+}
 
-    internal sealed class ValuePropertySerializer<TOwner, TPropertyType>(PropertyInfo property) :
-        PropertySerializer<TOwner, TPropertyType>(property, PropertyType.Normal, true) where TOwner : class {
+internal sealed class ValuePropertySerializer<TOwner, TPropertyType>(PropertyInfo property) :
+    PropertySerializer<TOwner, TPropertyType>(property, PropertyType.Normal, true) where TOwner : class {
 
-        private static readonly ValueSerializer<TPropertyType> ValueSerializer = ValueSerializer<TPropertyType>.Default;
+    private static readonly ValueSerializer<TPropertyType> ValueSerializer = ValueSerializer<TPropertyType>.Default;
 
-        private void setter(TOwner owner, TPropertyType? value)
-            // TODO (yafc-ce/issues/256): unwrap this one-liner
-            => _setter(owner ?? throw new ArgumentNullException(nameof(owner)),
-                value ?? (CanBeNull ? default :
-                throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not be set to null.")));
+    private void setter(TOwner owner, TPropertyType? value)
+        // TODO (yafc-ce/issues/256): unwrap this one-liner
+        => _setter(owner ?? throw new ArgumentNullException(nameof(owner)),
+            value ?? (CanBeNull ? default :
+            throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not be set to null.")));
 
-        private new TPropertyType? getter(TOwner owner) {
-            ArgumentNullException.ThrowIfNull(owner, nameof(owner));
+    private new TPropertyType? getter(TOwner owner) {
+        ArgumentNullException.ThrowIfNull(owner, nameof(owner));
 
-            var result = _getter(owner);
-            if (result == null) {
-                if (CanBeNull) {
-                    return default;
-                }
-                else {
-                    throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not return null.");
-                }
-            }
-
-            return result;
-        }
-
-
-        public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) =>
-            ValueSerializer.WriteToJson(writer, getter(owner));
-
-        public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) =>
-            setter(owner, ValueSerializer.ReadFromJson(ref reader, context, owner));
-
-        public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) =>
-            ValueSerializer.WriteToUndoSnapshot(builder, getter(owner));
-
-        public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) =>
-            setter(owner, ValueSerializer.ReadFromUndoSnapshot(reader, owner));
-
-        public override object? DeserializeFromJson(ref Utf8JsonReader reader, DeserializationContext context) =>
-            ValueSerializer.ReadFromJson(ref reader, context, null);
-
-        public override bool CanBeNull => ValueSerializer.CanBeNull;
-    }
-
-    // Serializes read-only sub-value with support of polymorphism
-    internal class ReadOnlyReferenceSerializer<TOwner, TPropertyType> :
-        PropertySerializer<TOwner, TPropertyType> where TOwner : ModelObject where TPropertyType : ModelObject {
-
-        public ReadOnlyReferenceSerializer(PropertyInfo property) : base(property, PropertyType.Immutable, false) { }
-        public ReadOnlyReferenceSerializer(PropertyInfo property, PropertyType type, bool usingSetter) :
-            base(property, type, usingSetter) { }
-
-        private new TPropertyType? getter(TOwner owner) => _getter(owner ?? throw new ArgumentNullException(nameof(owner)));
-
-        public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
-            var instance = getter(owner);
-            if (instance == null) {
-                writer.WriteNullValue();
-            }
-            else if (instance.GetType() == typeof(TPropertyType)) {
-                SerializationMap<TPropertyType>.SerializeToJson(instance, writer);
+        var result = _getter(owner);
+        if (result == null) {
+            if (CanBeNull) {
+                return default;
             }
             else {
-                SerializationMap.GetSerializationMap(instance.GetType()).SerializeToJson(instance, writer);
+                throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not return null.");
             }
         }
 
-        public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
-            if (reader.TokenType == JsonTokenType.Null) {
-                return;
-            }
-
-            var instance = getter(owner);
-            if (instance == null) {
-                context.Error("Project contained an unexpected object", ErrorSeverity.MinorDataLoss);
-                reader.Skip();
-            }
-            else if (instance.GetType() == typeof(TPropertyType)) {
-                SerializationMap<TPropertyType>.PopulateFromJson(instance, ref reader, context);
-            }
-            else {
-                SerializationMap.GetSerializationMap(instance.GetType()).PopulateFromJson(instance, ref reader, context);
-            }
-        }
-
-        public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) { }
-
-        public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) { }
+        return result;
     }
 
-    internal class ReadWriteReferenceSerializer<TOwner, TPropertyType>(PropertyInfo property) :
-        ReadOnlyReferenceSerializer<TOwner, TPropertyType>(property, PropertyType.Normal, true)
-        where TOwner : ModelObject where TPropertyType : ModelObject {
 
-        private void setter(TOwner owner, TPropertyType? value)
-            => _setter(owner ?? throw new ArgumentNullException(nameof(owner)), value);
-        private new TPropertyType? getter(TOwner owner)
-            => _getter(owner ?? throw new ArgumentNullException(nameof(owner)));
+    public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) =>
+        ValueSerializer.WriteToJson(writer, getter(owner));
 
-        public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
-            if (reader.TokenType == JsonTokenType.Null) {
-                return;
-            }
+    public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) =>
+        setter(owner, ValueSerializer.ReadFromJson(ref reader, context, owner));
 
-            var instance = getter(owner);
-            if (instance == null) {
-                setter(owner, SerializationMap<TPropertyType>.DeserializeFromJson(owner, ref reader, context));
-                return;
-            }
+    public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) =>
+        ValueSerializer.WriteToUndoSnapshot(builder, getter(owner));
 
-            base.DeserializeFromJson(owner, ref reader, context);
+    public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) =>
+        setter(owner, ValueSerializer.ReadFromUndoSnapshot(reader, owner));
+
+    public override object? DeserializeFromJson(ref Utf8JsonReader reader, DeserializationContext context) =>
+        ValueSerializer.ReadFromJson(ref reader, context, null);
+
+    public override bool CanBeNull => ValueSerializer.CanBeNull;
+}
+
+// Serializes read-only sub-value with support of polymorphism
+internal class ReadOnlyReferenceSerializer<TOwner, TPropertyType> :
+    PropertySerializer<TOwner, TPropertyType> where TOwner : ModelObject where TPropertyType : ModelObject {
+
+    public ReadOnlyReferenceSerializer(PropertyInfo property) : base(property, PropertyType.Immutable, false) { }
+    public ReadOnlyReferenceSerializer(PropertyInfo property, PropertyType type, bool usingSetter) :
+        base(property, type, usingSetter) { }
+
+    private new TPropertyType? getter(TOwner owner) => _getter(owner ?? throw new ArgumentNullException(nameof(owner)));
+
+    public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
+        var instance = getter(owner);
+        if (instance == null) {
+            writer.WriteNullValue();
         }
-
-        public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) =>
-            builder.WriteManagedReference(getter(owner) ?? throw new InvalidOperationException($"Cannot serialize a null value for {property.DeclaringType}.{propertyName} to the undo snapshot."));
-
-        public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) =>
-            setter(owner, reader.ReadOwnedReference<TPropertyType>(owner));
+        else if (instance.GetType() == typeof(TPropertyType)) {
+            SerializationMap<TPropertyType>.SerializeToJson(instance, writer);
+        }
+        else {
+            SerializationMap.GetSerializationMap(instance.GetType()).SerializeToJson(instance, writer);
+        }
     }
 
-    internal sealed class CollectionSerializer<TOwner, TCollection, TElement>(PropertyInfo property) :
-        PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
-        where TCollection : ICollection<TElement?> where TOwner : class {
-
-        private static readonly ValueSerializer<TElement> ValueSerializer = ValueSerializer<TElement>.Default;
-
-        public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
-            TCollection list = getter(owner);
-            writer.WriteStartArray();
-            foreach (var elem in list) {
-                ValueSerializer.WriteToJson(writer, elem);
-            }
-
-            writer.WriteEndArray();
+    public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
+        if (reader.TokenType == JsonTokenType.Null) {
+            return;
         }
 
-        public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
-            TCollection list = getter(owner);
-            list.Clear();
-            if (reader.ReadStartArray()) {
-                while (reader.TokenType != JsonTokenType.EndArray) {
-                    var item = ValueSerializer.ReadFromJson(ref reader, context, owner);
-                    if (item != null) {
-                        list.Add(item);
-                    }
+        var instance = getter(owner);
+        if (instance == null) {
+            context.Error("Project contained an unexpected object", ErrorSeverity.MinorDataLoss);
+            reader.Skip();
+        }
+        else if (instance.GetType() == typeof(TPropertyType)) {
+            SerializationMap<TPropertyType>.PopulateFromJson(instance, ref reader, context);
+        }
+        else {
+            SerializationMap.GetSerializationMap(instance.GetType()).PopulateFromJson(instance, ref reader, context);
+        }
+    }
 
-                    _ = reader.Read();
+    public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) { }
+
+    public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) { }
+}
+
+internal class ReadWriteReferenceSerializer<TOwner, TPropertyType>(PropertyInfo property) :
+    ReadOnlyReferenceSerializer<TOwner, TPropertyType>(property, PropertyType.Normal, true)
+    where TOwner : ModelObject where TPropertyType : ModelObject {
+
+    private void setter(TOwner owner, TPropertyType? value)
+        => _setter(owner ?? throw new ArgumentNullException(nameof(owner)), value);
+    private new TPropertyType? getter(TOwner owner)
+        => _getter(owner ?? throw new ArgumentNullException(nameof(owner)));
+
+    public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
+        if (reader.TokenType == JsonTokenType.Null) {
+            return;
+        }
+
+        var instance = getter(owner);
+        if (instance == null) {
+            setter(owner, SerializationMap<TPropertyType>.DeserializeFromJson(owner, ref reader, context));
+            return;
+        }
+
+        base.DeserializeFromJson(owner, ref reader, context);
+    }
+
+    public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) =>
+        builder.WriteManagedReference(getter(owner) ?? throw new InvalidOperationException($"Cannot serialize a null value for {property.DeclaringType}.{propertyName} to the undo snapshot."));
+
+    public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) =>
+        setter(owner, reader.ReadOwnedReference<TPropertyType>(owner));
+}
+
+internal sealed class CollectionSerializer<TOwner, TCollection, TElement>(PropertyInfo property) :
+    PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
+    where TCollection : ICollection<TElement?> where TOwner : class {
+
+    private static readonly ValueSerializer<TElement> ValueSerializer = ValueSerializer<TElement>.Default;
+
+    public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
+        TCollection list = getter(owner);
+        writer.WriteStartArray();
+        foreach (var elem in list) {
+            ValueSerializer.WriteToJson(writer, elem);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
+        TCollection list = getter(owner);
+        list.Clear();
+        if (reader.ReadStartArray()) {
+            while (reader.TokenType != JsonTokenType.EndArray) {
+                var item = ValueSerializer.ReadFromJson(ref reader, context, owner);
+                if (item != null) {
+                    list.Add(item);
+                }
+
+                _ = reader.Read();
+            }
+        }
+    }
+
+    public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) {
+        TCollection list = getter(owner);
+        builder.writer.Write(list.Count);
+        foreach (var elem in list) {
+            ValueSerializer.WriteToUndoSnapshot(builder, elem);
+        }
+    }
+
+    public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) {
+        TCollection list = getter(owner);
+        list.Clear();
+        int count = reader.reader.ReadInt32();
+        for (int i = 0; i < count; i++) {
+            list.Add(ValueSerializer.ReadFromUndoSnapshot(reader, owner));
+        }
+    }
+}
+
+internal sealed class ReadOnlyCollectionSerializer<TOwner, TCollection, TElement>(PropertyInfo property) :
+    PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
+    // This is ReadOnlyCollection, not IReadOnlyCollection, because we rely on knowing about the mutable backing storage of ReadOnlyCollection.
+    where TCollection : ReadOnlyCollection<TElement?> where TOwner : class {
+
+    private static readonly ValueSerializer<TElement> ValueSerializer = ValueSerializer<TElement>.Default;
+
+    public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
+        TCollection list = getter(owner);
+        writer.WriteStartArray();
+        foreach (TElement? elem in list) {
+            ValueSerializer.WriteToJson(writer, elem);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
+        TCollection readonlyList = getter(owner);
+        IList<TElement?> list = (IList<TElement?>)readonlyList.GetType()
+            .GetField("list", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(readonlyList)!;
+        list.Clear();
+        if (reader.ReadStartArray()) {
+            while (reader.TokenType != JsonTokenType.EndArray) {
+                TElement? item = ValueSerializer.ReadFromJson(ref reader, context, owner);
+                if (item != null) {
+                    list.Add(item);
+                }
+
+                _ = reader.Read();
+            }
+        }
+    }
+
+    public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) {
+        TCollection list = getter(owner);
+        builder.writer.Write(list.Count);
+        foreach (TElement? elem in list) {
+            ValueSerializer.WriteToUndoSnapshot(builder, elem);
+        }
+    }
+
+    public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) {
+        TCollection readonlyList = getter(owner);
+        IList<TElement?> list = (IList<TElement?>)readonlyList.GetType()
+            .GetField("list", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(readonlyList)!;
+        list.Clear();
+        int count = reader.reader.ReadInt32();
+        for (int i = 0; i < count; i++) {
+            list.Add(ValueSerializer.ReadFromUndoSnapshot(reader, owner));
+        }
+    }
+}
+
+internal class DictionarySerializer<TOwner, TCollection, TKey, TValue>(PropertyInfo property) :
+    PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
+    where TCollection : IDictionary<TKey, TValue?> where TOwner : class {
+
+    private static readonly ValueSerializer<TKey> KeySerializer = ValueSerializer<TKey>.Default;
+    private static readonly ValueSerializer<TValue> ValueSerializer = ValueSerializer<TValue>.Default;
+
+    public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
+        TCollection? dictionary = getter(owner);
+        writer.WriteStartObject();
+        foreach (var (key, value) in dictionary.Select(x => (Key: KeySerializer.GetJsonProperty(x.Key), x.Value))
+            .OrderBy(x => x.Key, StringComparer.Ordinal)) {
+
+            writer.WritePropertyName(key);
+            ValueSerializer.WriteToJson(writer, value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
+        TCollection? dictionary = getter(owner);
+        dictionary.Clear();
+        if (reader.ReadStartObject()) {
+            while (reader.TokenType != JsonTokenType.EndObject) {
+                var key = KeySerializer.ReadFromJsonProperty(ref reader, context, owner);
+                _ = reader.Read();
+                var value = ValueSerializer.ReadFromJson(ref reader, context, owner);
+                _ = reader.Read();
+                if (key != null && value != null) {
+                    dictionary.Add(key, value);
                 }
             }
         }
+    }
 
-        public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) {
-            TCollection list = getter(owner);
-            builder.writer.Write(list.Count);
-            foreach (var elem in list) {
-                ValueSerializer.WriteToUndoSnapshot(builder, elem);
-            }
-        }
-
-        public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) {
-            TCollection list = getter(owner);
-            list.Clear();
-            int count = reader.reader.ReadInt32();
-            for (int i = 0; i < count; i++) {
-                list.Add(ValueSerializer.ReadFromUndoSnapshot(reader, owner));
-            }
+    public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) {
+        TCollection? dictionary = getter(owner);
+        builder.writer.Write(dictionary.Count);
+        foreach (var elem in dictionary) {
+            KeySerializer.WriteToUndoSnapshot(builder, elem.Key);
+            ValueSerializer.WriteToUndoSnapshot(builder, elem.Value);
         }
     }
 
-    internal sealed class ReadOnlyCollectionSerializer<TOwner, TCollection, TElement>(PropertyInfo property) :
-        PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
-        // This is ReadOnlyCollection, not IReadOnlyCollection, because we rely on knowing about the mutable backing storage of ReadOnlyCollection.
-        where TCollection : ReadOnlyCollection<TElement?> where TOwner : class {
-
-        private static readonly ValueSerializer<TElement> ValueSerializer = ValueSerializer<TElement>.Default;
-
-        public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
-            TCollection list = getter(owner);
-            writer.WriteStartArray();
-            foreach (TElement? elem in list) {
-                ValueSerializer.WriteToJson(writer, elem);
-            }
-
-            writer.WriteEndArray();
-        }
-
-        public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
-            TCollection readonlyList = getter(owner);
-            IList<TElement?> list = (IList<TElement?>)readonlyList.GetType()
-                .GetField("list", BindingFlags.NonPublic | BindingFlags.Instance)!
-                .GetValue(readonlyList)!;
-            list.Clear();
-            if (reader.ReadStartArray()) {
-                while (reader.TokenType != JsonTokenType.EndArray) {
-                    TElement? item = ValueSerializer.ReadFromJson(ref reader, context, owner);
-                    if (item != null) {
-                        list.Add(item);
-                    }
-
-                    _ = reader.Read();
-                }
-            }
-        }
-
-        public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) {
-            TCollection list = getter(owner);
-            builder.writer.Write(list.Count);
-            foreach (TElement? elem in list) {
-                ValueSerializer.WriteToUndoSnapshot(builder, elem);
-            }
-        }
-
-        public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) {
-            TCollection readonlyList = getter(owner);
-            IList<TElement?> list = (IList<TElement?>)readonlyList.GetType()
-                .GetField("list", BindingFlags.NonPublic | BindingFlags.Instance)!
-                .GetValue(readonlyList)!;
-            list.Clear();
-            int count = reader.reader.ReadInt32();
-            for (int i = 0; i < count; i++) {
-                list.Add(ValueSerializer.ReadFromUndoSnapshot(reader, owner));
-            }
-        }
-    }
-
-    internal class DictionarySerializer<TOwner, TCollection, TKey, TValue>(PropertyInfo property) :
-        PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
-        where TCollection : IDictionary<TKey, TValue?> where TOwner : class {
-
-        private static readonly ValueSerializer<TKey> KeySerializer = ValueSerializer<TKey>.Default;
-        private static readonly ValueSerializer<TValue> ValueSerializer = ValueSerializer<TValue>.Default;
-
-        public override void SerializeToJson(TOwner owner, Utf8JsonWriter writer) {
-            TCollection? dictionary = getter(owner);
-            writer.WriteStartObject();
-            foreach (var (key, value) in dictionary.Select(x => (Key: KeySerializer.GetJsonProperty(x.Key), x.Value))
-                .OrderBy(x => x.Key, StringComparer.Ordinal)) {
-
-                writer.WritePropertyName(key);
-                ValueSerializer.WriteToJson(writer, value);
-            }
-
-            writer.WriteEndObject();
-        }
-
-        public override void DeserializeFromJson(TOwner owner, ref Utf8JsonReader reader, DeserializationContext context) {
-            TCollection? dictionary = getter(owner);
-            dictionary.Clear();
-            if (reader.ReadStartObject()) {
-                while (reader.TokenType != JsonTokenType.EndObject) {
-                    var key = KeySerializer.ReadFromJsonProperty(ref reader, context, owner);
-                    _ = reader.Read();
-                    var value = ValueSerializer.ReadFromJson(ref reader, context, owner);
-                    _ = reader.Read();
-                    if (key != null && value != null) {
-                        dictionary.Add(key, value);
-                    }
-                }
-            }
-        }
-
-        public override void SerializeToUndoBuilder(TOwner owner, UndoSnapshotBuilder builder) {
-            TCollection? dictionary = getter(owner);
-            builder.writer.Write(dictionary.Count);
-            foreach (var elem in dictionary) {
-                KeySerializer.WriteToUndoSnapshot(builder, elem.Key);
-                ValueSerializer.WriteToUndoSnapshot(builder, elem.Value);
-            }
-        }
-
-        public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) {
-            TCollection? dictionary = getter(owner);
-            dictionary.Clear();
-            int count = reader.reader.ReadInt32();
-            for (int i = 0; i < count; i++) {
-                TKey key = KeySerializer.ReadFromUndoSnapshot(reader, owner) ??
-                    throw new InvalidOperationException($"Serialized a null key for {property}. Cannot deserialize undo entry.");
-                dictionary.Add(key, DictionarySerializer<TOwner, TCollection, TKey, TValue>.ValueSerializer
-                    .ReadFromUndoSnapshot(reader, owner));
-            }
+    public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) {
+        TCollection? dictionary = getter(owner);
+        dictionary.Clear();
+        int count = reader.reader.ReadInt32();
+        for (int i = 0; i < count; i++) {
+            TKey key = KeySerializer.ReadFromUndoSnapshot(reader, owner) ??
+                throw new InvalidOperationException($"Serialized a null key for {property}. Cannot deserialize undo entry.");
+            dictionary.Add(key, DictionarySerializer<TOwner, TCollection, TKey, TValue>.ValueSerializer
+                .ReadFromUndoSnapshot(reader, owner));
         }
     }
 }

--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -7,382 +7,381 @@ using System.Text.Json;
 using Serilog;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    [AttributeUsage(AttributeTargets.Property)]
-    public class SkipSerializationAttribute : Attribute { }
+namespace Yafc.Model;
+[AttributeUsage(AttributeTargets.Property)]
+public class SkipSerializationAttribute : Attribute { }
 
-    [AttributeUsage(AttributeTargets.Property)]
-    public class NoUndoAttribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property)]
+public class NoUndoAttribute : Attribute { }
 
-    [AttributeUsage(AttributeTargets.Class)]
-    public sealed class DeserializeWithNonPublicConstructorAttribute : Attribute { }
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class DeserializeWithNonPublicConstructorAttribute : Attribute { }
 
-    internal abstract class SerializationMap {
-        private static readonly ILogger logger = Logging.GetLogger<SerializationMap>();
-        public UndoSnapshot MakeUndoSnapshot(ModelObject target) {
-            UndoSnapshotBuilder snapshotBuilder = new(target);
-            BuildUndo(target, snapshotBuilder);
-            return snapshotBuilder.Build();
-        }
-        public void RevertToUndoSnapshot(ModelObject target, UndoSnapshot snapshot) {
-            UndoSnapshotReader snapshotReader = new(snapshot);
-            ReadUndo(target, snapshotReader);
-        }
-        public abstract void BuildUndo(object target, UndoSnapshotBuilder builder);
-        public abstract void ReadUndo(object target, UndoSnapshotReader reader);
+internal abstract class SerializationMap {
+    private static readonly ILogger logger = Logging.GetLogger<SerializationMap>();
+    public UndoSnapshot MakeUndoSnapshot(ModelObject target) {
+        UndoSnapshotBuilder snapshotBuilder = new(target);
+        BuildUndo(target, snapshotBuilder);
+        return snapshotBuilder.Build();
+    }
+    public void RevertToUndoSnapshot(ModelObject target, UndoSnapshot snapshot) {
+        UndoSnapshotReader snapshotReader = new(snapshot);
+        ReadUndo(target, snapshotReader);
+    }
+    public abstract void BuildUndo(object target, UndoSnapshotBuilder builder);
+    public abstract void ReadUndo(object target, UndoSnapshotReader reader);
 
 
-        private static readonly Dictionary<Type, SerializationMap> undoBuilders = [];
-        protected static int deserializingCount;
-        public static bool IsDeserializing => deserializingCount > 0;
+    private static readonly Dictionary<Type, SerializationMap> undoBuilders = [];
+    protected static int deserializingCount;
+    public static bool IsDeserializing => deserializingCount > 0;
 
-        public static SerializationMap GetSerializationMap(Type type) {
-            if (undoBuilders.TryGetValue(type, out var builder)) {
-                return builder;
-            }
-
-            return undoBuilders[type] = (SerializationMap)Activator.CreateInstance(typeof(SerializationMap<>.SpecificSerializationMap).MakeGenericType(type))!;
+    public static SerializationMap GetSerializationMap(Type type) {
+        if (undoBuilders.TryGetValue(type, out var builder)) {
+            return builder;
         }
 
-        public abstract void SerializeToJson(object target, Utf8JsonWriter writer);
-        public abstract void PopulateFromJson(object target, ref Utf8JsonReader reader, DeserializationContext context);
+        return undoBuilders[type] = (SerializationMap)Activator.CreateInstance(typeof(SerializationMap<>.SpecificSerializationMap).MakeGenericType(type))!;
     }
 
-    internal static class SerializationMap<T> where T : class {
-        private static readonly ILogger logger = Logging.GetLogger(typeof(SerializationMap<T>));
-        private static readonly Type? parentType;
-        private static readonly ConstructorInfo constructor;
-        private static readonly PropertySerializer<T>[] properties;
-        private static readonly int constructorProperties;
-        private static readonly ulong constructorFieldMask;
-        private static readonly ulong requiredConstructorFieldMask;
+    public abstract void SerializeToJson(object target, Utf8JsonWriter writer);
+    public abstract void PopulateFromJson(object target, ref Utf8JsonReader reader, DeserializationContext context);
+}
 
-        public class SpecificSerializationMap : SerializationMap {
-            public override void BuildUndo(object target, UndoSnapshotBuilder builder) {
+internal static class SerializationMap<T> where T : class {
+    private static readonly ILogger logger = Logging.GetLogger(typeof(SerializationMap<T>));
+    private static readonly Type? parentType;
+    private static readonly ConstructorInfo constructor;
+    private static readonly PropertySerializer<T>[] properties;
+    private static readonly int constructorProperties;
+    private static readonly ulong constructorFieldMask;
+    private static readonly ulong requiredConstructorFieldMask;
+
+    public class SpecificSerializationMap : SerializationMap {
+        public override void BuildUndo(object target, UndoSnapshotBuilder builder) {
+            T t = (T)target;
+            foreach (var property in properties) {
+                if (property.type == PropertyType.Normal) {
+                    property.SerializeToUndoBuilder(t, builder);
+                }
+            }
+        }
+
+        public override void ReadUndo(object target, UndoSnapshotReader reader) {
+            try {
+                deserializingCount++;
                 T t = (T)target;
                 foreach (var property in properties) {
                     if (property.type == PropertyType.Normal) {
-                        property.SerializeToUndoBuilder(t, builder);
+                        property.DeserializeFromUndoBuilder(t, reader);
                     }
                 }
             }
-
-            public override void ReadUndo(object target, UndoSnapshotReader reader) {
-                try {
-                    deserializingCount++;
-                    T t = (T)target;
-                    foreach (var property in properties) {
-                        if (property.type == PropertyType.Normal) {
-                            property.DeserializeFromUndoBuilder(t, reader);
-                        }
-                    }
-                }
-                finally {
-                    deserializingCount--;
-                }
-            }
-
-            public override void SerializeToJson(object target, Utf8JsonWriter writer) {
-                SerializationMap<T>.SerializeToJson((T)target, writer);
-            }
-
-            public override void PopulateFromJson(object target, ref Utf8JsonReader reader, DeserializationContext context) {
-                try {
-                    deserializingCount++;
-                    SerializationMap<T>.PopulateFromJson((T)target, ref reader, context);
-                }
-                finally {
-                    deserializingCount--;
-                }
+            finally {
+                deserializingCount--;
             }
         }
 
-        private static bool GetInterfaceSerializer(Type iface, [MaybeNullWhen(false)] out Type serializerType, out Type? keyType, [MaybeNullWhen(false)] out Type elementType) {
-            if (iface.IsGenericType) {
-                var definition = iface.GetGenericTypeDefinition();
-                if (definition == typeof(ICollection<>)) {
-                    elementType = iface.GetGenericArguments()[0];
-                    keyType = null;
+        public override void SerializeToJson(object target, Utf8JsonWriter writer) {
+            SerializationMap<T>.SerializeToJson((T)target, writer);
+        }
+
+        public override void PopulateFromJson(object target, ref Utf8JsonReader reader, DeserializationContext context) {
+            try {
+                deserializingCount++;
+                SerializationMap<T>.PopulateFromJson((T)target, ref reader, context);
+            }
+            finally {
+                deserializingCount--;
+            }
+        }
+    }
+
+    private static bool GetInterfaceSerializer(Type iface, [MaybeNullWhen(false)] out Type serializerType, out Type? keyType, [MaybeNullWhen(false)] out Type elementType) {
+        if (iface.IsGenericType) {
+            var definition = iface.GetGenericTypeDefinition();
+            if (definition == typeof(ICollection<>)) {
+                elementType = iface.GetGenericArguments()[0];
+                keyType = null;
+                if (ValueSerializer.IsValueSerializerSupported(elementType)) {
+                    serializerType = typeof(CollectionSerializer<,,>);
+                    return true;
+                }
+            }
+
+            if (definition == typeof(IDictionary<,>)) {
+                var args = iface.GetGenericArguments();
+                if (ValueSerializer.IsValueSerializerSupported(args[0])) {
+                    keyType = args[0];
+                    elementType = args[1];
                     if (ValueSerializer.IsValueSerializerSupported(elementType)) {
-                        serializerType = typeof(CollectionSerializer<,,>);
+                        serializerType = typeof(DictionarySerializer<,,,>);
                         return true;
                     }
                 }
-
-                if (definition == typeof(IDictionary<,>)) {
-                    var args = iface.GetGenericArguments();
-                    if (ValueSerializer.IsValueSerializerSupported(args[0])) {
-                        keyType = args[0];
-                        elementType = args[1];
-                        if (ValueSerializer.IsValueSerializerSupported(elementType)) {
-                            serializerType = typeof(DictionarySerializer<,,,>);
-                            return true;
-                        }
-                    }
-                }
             }
-
-            keyType = elementType = serializerType = null;
-            return false;
         }
 
-        static SerializationMap() {
-            List<PropertySerializer<T>> list = [];
+        keyType = elementType = serializerType = null;
+        return false;
+    }
 
-            bool isModel = typeof(ModelObject).IsAssignableFrom(typeof(T));
-            if (typeof(T).GetCustomAttribute<DeserializeWithNonPublicConstructorAttribute>() != null) {
-                constructor = typeof(T).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+    static SerializationMap() {
+        List<PropertySerializer<T>> list = [];
+
+        bool isModel = typeof(ModelObject).IsAssignableFrom(typeof(T));
+        if (typeof(T).GetCustomAttribute<DeserializeWithNonPublicConstructorAttribute>() != null) {
+            constructor = typeof(T).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+        }
+        else {
+            constructor = typeof(T).GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];
+        }
+        var constructorParameters = constructor.GetParameters();
+        List<PropertyInfo> processedProperties = [];
+        if (constructorParameters.Length > 0) {
+            int firstReadOnlyArg = 0;
+            if (isModel) {
+                parentType = constructorParameters[0].ParameterType;
+                if (!typeof(ModelObject).IsAssignableFrom(parentType)) {
+                    throw new NotSupportedException("First parameter of constructor of type " + typeof(T) + " should be 'parent'");
+                }
+
+                firstReadOnlyArg = 1;
             }
-            else {
-                constructor = typeof(T).GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];
-            }
-            var constructorParameters = constructor.GetParameters();
-            List<PropertyInfo> processedProperties = [];
-            if (constructorParameters.Length > 0) {
-                int firstReadOnlyArg = 0;
-                if (isModel) {
-                    parentType = constructorParameters[0].ParameterType;
-                    if (!typeof(ModelObject).IsAssignableFrom(parentType)) {
-                        throw new NotSupportedException("First parameter of constructor of type " + typeof(T) + " should be 'parent'");
-                    }
-
-                    firstReadOnlyArg = 1;
+            for (int i = firstReadOnlyArg; i < constructorParameters.Length; i++) {
+                var argument = constructorParameters[i];
+                if (!ValueSerializer.IsValueSerializerSupported(argument.ParameterType)) {
+                    throw new NotSupportedException("Constructor of type " + typeof(T) + " parameter " + argument.Name + " should be value");
                 }
-                for (int i = firstReadOnlyArg; i < constructorParameters.Length; i++) {
-                    var argument = constructorParameters[i];
-                    if (!ValueSerializer.IsValueSerializerSupported(argument.ParameterType)) {
-                        throw new NotSupportedException("Constructor of type " + typeof(T) + " parameter " + argument.Name + " should be value");
-                    }
 
-                    PropertyInfo property = typeof(T).GetProperty(argument.Name!) ?? throw new NotSupportedException("Constructor of type " + typeof(T) + " parameter " + argument.Name + " should have matching property");
-                    processedProperties.Add(property);
-                    PropertySerializer<T> serializer = (PropertySerializer<T>)Activator.CreateInstance(typeof(ValuePropertySerializer<,>).MakeGenericType(typeof(T), argument.ParameterType), property)!;
-                    list.Add(serializer);
-                    constructorFieldMask |= 1ul << (i - firstReadOnlyArg);
-                    if (!argument.IsOptional) {
-                        requiredConstructorFieldMask |= 1ul << (i - firstReadOnlyArg);
-                    }
+                PropertyInfo property = typeof(T).GetProperty(argument.Name!) ?? throw new NotSupportedException("Constructor of type " + typeof(T) + " parameter " + argument.Name + " should have matching property");
+                processedProperties.Add(property);
+                PropertySerializer<T> serializer = (PropertySerializer<T>)Activator.CreateInstance(typeof(ValuePropertySerializer<,>).MakeGenericType(typeof(T), argument.ParameterType), property)!;
+                list.Add(serializer);
+                constructorFieldMask |= 1ul << (i - firstReadOnlyArg);
+                if (!argument.IsOptional) {
+                    requiredConstructorFieldMask |= 1ul << (i - firstReadOnlyArg);
                 }
             }
+        }
 
-            constructorProperties = list.Count;
+        constructorProperties = list.Count;
 
-            foreach (var property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
-                if (property.GetCustomAttribute<SkipSerializationAttribute>() != null) {
-                    continue;
+        foreach (var property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+            if (property.GetCustomAttribute<SkipSerializationAttribute>() != null) {
+                continue;
+            }
+
+            if (processedProperties.Contains(property)) {
+                continue;
+            }
+
+            var propertyType = property.PropertyType;
+            Type? serializerType = null, elementType = null, keyType = null;
+            if (property.CanWrite && property.GetSetMethod() != null) {
+                if (ValueSerializer.IsValueSerializerSupported(propertyType)) {
+                    serializerType = typeof(ValuePropertySerializer<,>);
                 }
-
-                if (processedProperties.Contains(property)) {
-                    continue;
-                }
-
-                var propertyType = property.PropertyType;
-                Type? serializerType = null, elementType = null, keyType = null;
-                if (property.CanWrite && property.GetSetMethod() != null) {
-                    if (ValueSerializer.IsValueSerializerSupported(propertyType)) {
-                        serializerType = typeof(ValuePropertySerializer<,>);
-                    }
-                    else if (typeof(ModelObject).IsAssignableFrom(propertyType)) {
-                        serializerType = typeof(ReadWriteReferenceSerializer<,>);
-                    }
-                    else {
-                        throw new NotSupportedException("Type " + typeof(T) + " has property " + property.Name + " that cannot be serialized");
-                    }
+                else if (typeof(ModelObject).IsAssignableFrom(propertyType)) {
+                    serializerType = typeof(ReadWriteReferenceSerializer<,>);
                 }
                 else {
-                    if (typeof(ModelObject).IsAssignableFrom(propertyType)) {
-                        serializerType = typeof(ReadOnlyReferenceSerializer<,>);
-                    }
-                    else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>) && ValueSerializer.IsValueSerializerSupported(propertyType.GetGenericArguments()[0])) {
-                        serializerType = typeof(ReadOnlyCollectionSerializer<,,>);
-                        elementType = propertyType.GetGenericArguments()[0];
-                    }
-                    else if (!propertyType.IsInterface || !GetInterfaceSerializer(propertyType, out serializerType, out keyType, out elementType)) {
-                        foreach (Type iface in propertyType.GetInterfaces()) {
-                            if (GetInterfaceSerializer(iface, out serializerType, out keyType, out elementType)) {
-                                break;
-                            }
+                    throw new NotSupportedException("Type " + typeof(T) + " has property " + property.Name + " that cannot be serialized");
+                }
+            }
+            else {
+                if (typeof(ModelObject).IsAssignableFrom(propertyType)) {
+                    serializerType = typeof(ReadOnlyReferenceSerializer<,>);
+                }
+                else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>) && ValueSerializer.IsValueSerializerSupported(propertyType.GetGenericArguments()[0])) {
+                    serializerType = typeof(ReadOnlyCollectionSerializer<,,>);
+                    elementType = propertyType.GetGenericArguments()[0];
+                }
+                else if (!propertyType.IsInterface || !GetInterfaceSerializer(propertyType, out serializerType, out keyType, out elementType)) {
+                    foreach (Type iface in propertyType.GetInterfaces()) {
+                        if (GetInterfaceSerializer(iface, out serializerType, out keyType, out elementType)) {
+                            break;
                         }
                     }
                 }
-
-                if (serializerType != null) {
-                    var typeArgs = elementType == null ? new[] { typeof(T), propertyType } : keyType == null ? new[] { typeof(T), propertyType, elementType } : new[] { typeof(T), propertyType, keyType, elementType };
-                    list.Add((PropertySerializer<T>)Activator.CreateInstance(serializerType.MakeGenericType(typeArgs), property)!);
-                }
             }
-            properties = list.ToArray();
+
+            if (serializerType != null) {
+                var typeArgs = elementType == null ? new[] { typeof(T), propertyType } : keyType == null ? new[] { typeof(T), propertyType, elementType } : new[] { typeof(T), propertyType, keyType, elementType };
+                list.Add((PropertySerializer<T>)Activator.CreateInstance(serializerType.MakeGenericType(typeArgs), property)!);
+            }
+        }
+        properties = list.ToArray();
+    }
+
+    public static void SerializeToJson(T? value, Utf8JsonWriter writer) {
+        if (value == null) {
+            writer.WriteNullValue();
+            return;
+        }
+        writer.WriteStartObject();
+        foreach (var property in properties) {
+            if (property.type == PropertyType.Obsolete) {
+                continue;
+            }
+
+            writer.WritePropertyName(property.propertyName);
+            property.SerializeToJson(value, writer);
+        }
+        writer.WriteEndObject();
+    }
+
+    private static PropertySerializer<T>? FindProperty(ref Utf8JsonReader reader, ref int lastMatch) {
+        if (reader.TokenType != JsonTokenType.PropertyName) {
+            return null;
         }
 
-        public static void SerializeToJson(T? value, Utf8JsonWriter writer) {
-            if (value == null) {
-                writer.WriteNullValue();
-                return;
+        for (int i = lastMatch + 1; i < properties.Length; i++) {
+            if (reader.ValueTextEquals(properties[i].propertyName.EncodedUtf8Bytes)) {
+                lastMatch = i;
+                return properties[i];
             }
-            writer.WriteStartObject();
-            foreach (var property in properties) {
-                if (property.type == PropertyType.Obsolete) {
-                    continue;
-                }
-
-                writer.WritePropertyName(property.propertyName);
-                property.SerializeToJson(value, writer);
-            }
-            writer.WriteEndObject();
         }
 
-        private static PropertySerializer<T>? FindProperty(ref Utf8JsonReader reader, ref int lastMatch) {
-            if (reader.TokenType != JsonTokenType.PropertyName) {
-                return null;
+        for (int i = 0; i < lastMatch; i++) {
+            if (reader.ValueTextEquals(properties[i].propertyName.EncodedUtf8Bytes)) {
+                lastMatch = i;
+                return properties[i];
+            }
+        }
+
+        return null;
+    }
+
+    public static T? DeserializeFromJson(ModelObject? owner, ref Utf8JsonReader reader, DeserializationContext context) {
+        if (reader.TokenType == JsonTokenType.Null) {
+            return null;
+        }
+
+        if (reader.TokenType != JsonTokenType.StartObject) {
+            throw new JsonException("Expected start object");
+        }
+
+        int depth = reader.CurrentDepth;
+        try {
+            T obj;
+            if (parentType != null || constructorProperties > 0) {
+                if (parentType != null && !parentType.IsInstanceOfType(owner)) {
+                    throw new NotSupportedException("Parent is of wrong type");
+                }
+
+                int firstReadOnlyArg = parentType == null ? 0 : 1;
+                object?[] constructorArgs = new object[constructorProperties + firstReadOnlyArg];
+                constructorArgs[0] = owner;
+                if (constructorProperties > 0) {
+                    var savedReaderState = reader;
+                    int lastMatch = -1;
+                    ulong constructorMissingFields = constructorFieldMask;
+                    _ = reader.Read(); // StartObject
+                    while (constructorMissingFields != 0 && reader.TokenType != JsonTokenType.EndObject) {
+                        var property = FindProperty(ref reader, ref lastMatch);
+                        if (property != null && lastMatch < constructorProperties) {
+                            _ = reader.Read(); // PropertyName
+                            constructorMissingFields &= ~(1ul << lastMatch);
+                            constructorArgs[lastMatch + firstReadOnlyArg] = property.DeserializeFromJson(ref reader, context);
+                        }
+                        else {
+                            reader.Skip();
+                        }
+                        _ = reader.Read(); // Property value (String, Number, True, False, Null) or end of property value (EndObject, EndArray)
+                    }
+
+                    if ((constructorMissingFields & requiredConstructorFieldMask) != 0) {
+                        throw new JsonException("Json has missing constructor parameters");
+                    }
+
+                    reader = savedReaderState;
+                }
+
+                obj = (T)constructor.Invoke(constructorArgs);
+            }
+            else {
+                obj = Activator.CreateInstance<T>();
             }
 
-            for (int i = lastMatch + 1; i < properties.Length; i++) {
-                if (reader.ValueTextEquals(properties[i].propertyName.EncodedUtf8Bytes)) {
-                    lastMatch = i;
-                    return properties[i];
-                }
+            PopulateFromJson(obj, ref reader, context);
+            return obj;
+        }
+        catch (Exception ex) {
+            context.Exception(ex, "Unable to deserialize " + typeof(T).Name, ErrorSeverity.MajorDataLoss);
+            if (reader.TokenType == JsonTokenType.StartObject && reader.CurrentDepth == depth) {
+                _ = reader.Read();
             }
 
-            for (int i = 0; i < lastMatch; i++) {
-                if (reader.ValueTextEquals(properties[i].propertyName.EncodedUtf8Bytes)) {
-                    lastMatch = i;
-                    return properties[i];
-                }
+            while (reader.CurrentDepth > depth) {
+                _ = reader.Read();
             }
 
             return null;
         }
+    }
 
-        public static T? DeserializeFromJson(ModelObject? owner, ref Utf8JsonReader reader, DeserializationContext context) {
-            if (reader.TokenType == JsonTokenType.Null) {
-                return null;
-            }
-
-            if (reader.TokenType != JsonTokenType.StartObject) {
-                throw new JsonException("Expected start object");
-            }
-
-            int depth = reader.CurrentDepth;
-            try {
-                T obj;
-                if (parentType != null || constructorProperties > 0) {
-                    if (parentType != null && !parentType.IsInstanceOfType(owner)) {
-                        throw new NotSupportedException("Parent is of wrong type");
-                    }
-
-                    int firstReadOnlyArg = parentType == null ? 0 : 1;
-                    object?[] constructorArgs = new object[constructorProperties + firstReadOnlyArg];
-                    constructorArgs[0] = owner;
-                    if (constructorProperties > 0) {
-                        var savedReaderState = reader;
-                        int lastMatch = -1;
-                        ulong constructorMissingFields = constructorFieldMask;
-                        _ = reader.Read(); // StartObject
-                        while (constructorMissingFields != 0 && reader.TokenType != JsonTokenType.EndObject) {
-                            var property = FindProperty(ref reader, ref lastMatch);
-                            if (property != null && lastMatch < constructorProperties) {
-                                _ = reader.Read(); // PropertyName
-                                constructorMissingFields &= ~(1ul << lastMatch);
-                                constructorArgs[lastMatch + firstReadOnlyArg] = property.DeserializeFromJson(ref reader, context);
-                            }
-                            else {
-                                reader.Skip();
-                            }
-                            _ = reader.Read(); // Property value (String, Number, True, False, Null) or end of property value (EndObject, EndArray)
-                        }
-
-                        if ((constructorMissingFields & requiredConstructorFieldMask) != 0) {
-                            throw new JsonException("Json has missing constructor parameters");
-                        }
-
-                        reader = savedReaderState;
-                    }
-
-                    obj = (T)constructor.Invoke(constructorArgs);
-                }
-                else {
-                    obj = Activator.CreateInstance<T>();
-                }
-
-                PopulateFromJson(obj, ref reader, context);
-                return obj;
-            }
-            catch (Exception ex) {
-                context.Exception(ex, "Unable to deserialize " + typeof(T).Name, ErrorSeverity.MajorDataLoss);
-                if (reader.TokenType == JsonTokenType.StartObject && reader.CurrentDepth == depth) {
-                    _ = reader.Read();
-                }
-
-                while (reader.CurrentDepth > depth) {
-                    _ = reader.Read();
-                }
-
-                return null;
-            }
+    public static void PopulateFromJson(T obj, ref Utf8JsonReader reader, DeserializationContext allObjects) {
+        if (obj is ModelObject modelObject) {
+            allObjects.Add(modelObject);
         }
 
-        public static void PopulateFromJson(T obj, ref Utf8JsonReader reader, DeserializationContext allObjects) {
-            if (obj is ModelObject modelObject) {
-                allObjects.Add(modelObject);
-            }
+        if (reader.TokenType != JsonTokenType.StartObject) {
+            throw new JsonException("Expected start object");
+        }
 
-            if (reader.TokenType != JsonTokenType.StartObject) {
-                throw new JsonException("Expected start object");
-            }
-
-            int lastMatch = -1;
-            _ = reader.Read();
-            while (reader.TokenType != JsonTokenType.EndObject) {
-                var property = FindProperty(ref reader, ref lastMatch);
-                if (property == null || lastMatch < constructorProperties) {
-                    if (property == null) {
-                        logger.Error("Json has extra property: " + reader.GetString());
-                    }
-
-                    reader.Skip();
+        int lastMatch = -1;
+        _ = reader.Read();
+        while (reader.TokenType != JsonTokenType.EndObject) {
+            var property = FindProperty(ref reader, ref lastMatch);
+            if (property == null || lastMatch < constructorProperties) {
+                if (property == null) {
+                    logger.Error("Json has extra property: " + reader.GetString());
                 }
-                else {
-                    _ = reader.Read();
-                    try {
-                        property.DeserializeFromJson(obj, ref reader, allObjects);
-                    }
-                    catch (InvalidOperationException ex) {
-                        allObjects.Exception(ex, "Encountered an unexpected value when reading the project file", ErrorSeverity.MajorDataLoss);
-                    }
-                }
+
+                reader.Skip();
+            }
+            else {
                 _ = reader.Read();
+                try {
+                    property.DeserializeFromJson(obj, ref reader, allObjects);
+                }
+                catch (InvalidOperationException ex) {
+                    allObjects.Exception(ex, "Encountered an unexpected value when reading the project file", ErrorSeverity.MajorDataLoss);
+                }
             }
+            _ = reader.Read();
+        }
+    }
+}
+
+public class DeserializationContext {
+    private readonly List<ModelObject> allObjects = [];
+    private readonly ErrorCollector? collector;
+
+    public DeserializationContext(ErrorCollector? errorCollector) {
+        collector = errorCollector;
+    }
+
+    public void Add(ModelObject obj) {
+        allObjects.Add(obj);
+    }
+
+    public void Notify() {
+        foreach (var o in allObjects) {
+            o.AfterDeserialize();
+        }
+
+        foreach (var o in allObjects) {
+            o.ThisChanged(false);
         }
     }
 
-    public class DeserializationContext {
-        private readonly List<ModelObject> allObjects = [];
-        private readonly ErrorCollector? collector;
+    public void Error(string message, ErrorSeverity severity) {
+        collector?.Error(message, severity);
+    }
 
-        public DeserializationContext(ErrorCollector? errorCollector) {
-            collector = errorCollector;
-        }
-
-        public void Add(ModelObject obj) {
-            allObjects.Add(obj);
-        }
-
-        public void Notify() {
-            foreach (var o in allObjects) {
-                o.AfterDeserialize();
-            }
-
-            foreach (var o in allObjects) {
-                o.ThisChanged(false);
-            }
-        }
-
-        public void Error(string message, ErrorSeverity severity) {
-            collector?.Error(message, severity);
-        }
-
-        public void Exception(Exception exception, string message, ErrorSeverity severity) {
-            collector?.Exception(exception, message, severity);
-        }
+    public void Exception(Exception exception, string message, ErrorSeverity severity) {
+        collector?.Exception(exception, message, severity);
     }
 }

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -3,219 +3,218 @@ using System.Collections.Generic;
 using System.IO;
 using Yafc.UI;
 
-namespace Yafc.Model {
-    public class UndoSystem {
-        public uint version { get; private set; } = 2;
-        private bool undoBatchVisualOnly = true;
-        private readonly List<UndoSnapshot> currentUndoBatch = [];
-        private readonly List<ModelObject> changedList = [];
-        private readonly Stack<UndoBatch> undo = new Stack<UndoBatch>();
-        private readonly Stack<UndoBatch> redo = new Stack<UndoBatch>();
-        private bool suspended;
-        private bool scheduled;
-        internal void CreateUndoSnapshot(ModelObject target, bool visualOnly) {
-            if (SerializationMap.IsDeserializing) {
-                throw new InvalidOperationException("Do not record an undo event while deserializing.");
-            }
-            if (changedList.Count == 0) {
-                version++;
-                if (!suspended && !scheduled) {
-                    Schedule();
-                }
-            }
-            undoBatchVisualOnly &= visualOnly;
-
-            if (target.objectVersion == version) {
-                return;
-            }
-
-            changedList.Add(target);
-            target.objectVersion = version;
-            if (visualOnly && undo.Count > 0 && undo.Peek().Contains(target)) {
-                return;
-            }
-
-            var builder = target.GetUndoBuilder();
-            currentUndoBatch.Add(builder.MakeUndoSnapshot(target));
+namespace Yafc.Model;
+public class UndoSystem {
+    public uint version { get; private set; } = 2;
+    private bool undoBatchVisualOnly = true;
+    private readonly List<UndoSnapshot> currentUndoBatch = [];
+    private readonly List<ModelObject> changedList = [];
+    private readonly Stack<UndoBatch> undo = new Stack<UndoBatch>();
+    private readonly Stack<UndoBatch> redo = new Stack<UndoBatch>();
+    private bool suspended;
+    private bool scheduled;
+    internal void CreateUndoSnapshot(ModelObject target, bool visualOnly) {
+        if (SerializationMap.IsDeserializing) {
+            throw new InvalidOperationException("Do not record an undo event while deserializing.");
         }
-
-        private static void MakeUndoBatch(object? state) {
-            UndoSystem system = (UndoSystem)state!; // null-forgiving: Only called by the instance method Schedule, which passes its this.
-            system.scheduled = false;
-            bool visualOnly = system.undoBatchVisualOnly;
-            for (int i = 0; i < system.changedList.Count; i++) {
-                system.changedList[i].ThisChanged(visualOnly);
-            }
-
-            system.changedList.Clear();
-            if (system.currentUndoBatch.Count == 0) {
-                return;
-            }
-
-            UndoBatch batch = new UndoBatch(system.currentUndoBatch.ToArray(), visualOnly);
-            system.undo.Push(batch);
-            system.undoBatchVisualOnly = true;
-            system.redo.Clear();
-            system.currentUndoBatch.Clear();
-        }
-
-        private void Schedule() {
-            InputSystem.Instance.DispatchOnGestureFinish(MakeUndoBatch, this);
-            scheduled = true;
-        }
-
-        public void Suspend() {
-            suspended = true;
-        }
-
-        public void Resume() {
-            suspended = false;
-            if (!scheduled && changedList.Count > 0) {
+        if (changedList.Count == 0) {
+            version++;
+            if (!suspended && !scheduled) {
                 Schedule();
             }
         }
+        undoBatchVisualOnly &= visualOnly;
 
-        public void PerformUndo() {
-            if (undo.Count == 0 || changedList.Count > 0) {
-                return;
-            }
-
-            redo.Push(undo.Pop().Restore(++version));
+        if (target.objectVersion == version) {
+            return;
         }
 
-        public void PerformRedo() {
-            if (redo.Count == 0 || changedList.Count > 0) {
-                return;
-            }
-
-            undo.Push(redo.Pop().Restore(++version));
+        changedList.Add(target);
+        target.objectVersion = version;
+        if (visualOnly && undo.Count > 0 && undo.Peek().Contains(target)) {
+            return;
         }
 
-        public void RecordChange() {
-            ++version;
-        }
-
-        public bool HasChangesPending(ModelObject obj) {
-            return changedList.Contains(obj);
-        }
-    }
-    internal readonly struct UndoSnapshot {
-        internal readonly ModelObject target;
-        internal readonly object?[]? managedReferences;
-        internal readonly byte[]? unmanagedData;
-
-        public UndoSnapshot(ModelObject target, object?[]? managed, byte[]? unmanaged) {
-            this.target = target;
-            managedReferences = managed;
-            unmanagedData = unmanaged;
-        }
-
-        public UndoSnapshot Restore() {
-            var builder = target.GetUndoBuilder();
-            var redo = builder.MakeUndoSnapshot(target);
-            builder.RevertToUndoSnapshot(target, this);
-            return redo;
-        }
+        var builder = target.GetUndoBuilder();
+        currentUndoBatch.Add(builder.MakeUndoSnapshot(target));
     }
 
-    internal readonly struct UndoBatch {
-        public readonly UndoSnapshot[] snapshots;
-        public readonly bool visualOnly;
-        public UndoBatch(UndoSnapshot[] snapshots, bool visualOnly) {
-            this.snapshots = snapshots;
-            this.visualOnly = visualOnly;
-        }
-        public UndoBatch Restore(uint undoState) {
-            for (int i = 0; i < snapshots.Length; i++) {
-                snapshots[i] = snapshots[i].Restore();
-                snapshots[i].target.objectVersion = undoState;
-            }
-            foreach (var snapshot in snapshots) {
-                snapshot.target.AfterDeserialize();
-            }
-
-            foreach (var snapshot in snapshots) {
-                snapshot.target.ThisChanged(visualOnly);
-            }
-
-            return this;
+    private static void MakeUndoBatch(object? state) {
+        UndoSystem system = (UndoSystem)state!; // null-forgiving: Only called by the instance method Schedule, which passes its this.
+        system.scheduled = false;
+        bool visualOnly = system.undoBatchVisualOnly;
+        for (int i = 0; i < system.changedList.Count; i++) {
+            system.changedList[i].ThisChanged(visualOnly);
         }
 
-        public bool Contains(ModelObject target) {
-            foreach (var snapshot in snapshots) {
-                if (snapshot.target == target) {
-                    return true;
-                }
-            }
-            return false;
+        system.changedList.Clear();
+        if (system.currentUndoBatch.Count == 0) {
+            return;
+        }
+
+        UndoBatch batch = new UndoBatch(system.currentUndoBatch.ToArray(), visualOnly);
+        system.undo.Push(batch);
+        system.undoBatchVisualOnly = true;
+        system.redo.Clear();
+        system.currentUndoBatch.Clear();
+    }
+
+    private void Schedule() {
+        InputSystem.Instance.DispatchOnGestureFinish(MakeUndoBatch, this);
+        scheduled = true;
+    }
+
+    public void Suspend() {
+        suspended = true;
+    }
+
+    public void Resume() {
+        suspended = false;
+        if (!scheduled && changedList.Count > 0) {
+            Schedule();
         }
     }
 
-    internal class UndoSnapshotBuilder {
-        private readonly MemoryStream stream = new MemoryStream();
-        private readonly List<object?> managedRefs = [];
-        public readonly BinaryWriter writer;
-        private readonly ModelObject currentTarget;
-
-        internal UndoSnapshotBuilder(ModelObject target) {
-            writer = new BinaryWriter(stream);
-            currentTarget = target;
+    public void PerformUndo() {
+        if (undo.Count == 0 || changedList.Count > 0) {
+            return;
         }
 
-        internal UndoSnapshot Build() {
-            byte[]? buffer = null;
-            if (stream.Position > 0) {
-                buffer = new byte[stream.Position];
-                Array.Copy(stream.GetBuffer(), buffer, stream.Position);
-            }
-            UndoSnapshot result = new UndoSnapshot(currentTarget, managedRefs.Count > 0 ? managedRefs.ToArray() : null, buffer);
-            stream.Position = 0;
-            managedRefs.Clear();
-            return result;
-        }
-
-        public void WriteManagedReference(object? reference) {
-            managedRefs.Add(reference);
-        }
-
-        public void WriteManagedReferences(IEnumerable<object> references) {
-            managedRefs.AddRange(references);
-        }
+        redo.Push(undo.Pop().Restore(++version));
     }
 
-    internal class UndoSnapshotReader {
-        private static readonly BinaryReader NullReader = new BinaryReader(Stream.Null);
-        public BinaryReader reader { get; }
-        private int refId;
-        private readonly object?[]? managed;
-
-        internal UndoSnapshotReader(UndoSnapshot snapshot) {
-            if (snapshot.unmanagedData != null) {
-                MemoryStream stream = new MemoryStream(snapshot.unmanagedData, false);
-                reader = new BinaryReader(stream);
-            }
-            else {
-                reader = NullReader;
-            }
-
-            managed = snapshot.managedReferences;
-            refId = 0;
+    public void PerformRedo() {
+        if (redo.Count == 0 || changedList.Count > 0) {
+            return;
         }
 
-        public object? ReadManagedReference() {
-            if (managed == null) {
-                throw new InvalidOperationException("No managed objects are available to read in this undo snapshot.");
-            }
-            return managed[refId++];
+        undo.Push(redo.Pop().Restore(++version));
+    }
+
+    public void RecordChange() {
+        ++version;
+    }
+
+    public bool HasChangesPending(ModelObject obj) {
+        return changedList.Contains(obj);
+    }
+}
+internal readonly struct UndoSnapshot {
+    internal readonly ModelObject target;
+    internal readonly object?[]? managedReferences;
+    internal readonly byte[]? unmanagedData;
+
+    public UndoSnapshot(ModelObject target, object?[]? managed, byte[]? unmanaged) {
+        this.target = target;
+        managedReferences = managed;
+        unmanagedData = unmanaged;
+    }
+
+    public UndoSnapshot Restore() {
+        var builder = target.GetUndoBuilder();
+        var redo = builder.MakeUndoSnapshot(target);
+        builder.RevertToUndoSnapshot(target, this);
+        return redo;
+    }
+}
+
+internal readonly struct UndoBatch {
+    public readonly UndoSnapshot[] snapshots;
+    public readonly bool visualOnly;
+    public UndoBatch(UndoSnapshot[] snapshots, bool visualOnly) {
+        this.snapshots = snapshots;
+        this.visualOnly = visualOnly;
+    }
+    public UndoBatch Restore(uint undoState) {
+        for (int i = 0; i < snapshots.Length; i++) {
+            snapshots[i] = snapshots[i].Restore();
+            snapshots[i].target.objectVersion = undoState;
+        }
+        foreach (var snapshot in snapshots) {
+            snapshot.target.AfterDeserialize();
         }
 
-        public T? ReadOwnedReference<T>(ModelObject owner) where T : ModelObject {
-            T? obj = ReadManagedReference() as T;
-            if (obj != null && obj.ownerObject != owner) {
-                obj.ownerObject = owner;
-            }
-
-            return obj;
+        foreach (var snapshot in snapshots) {
+            snapshot.target.ThisChanged(visualOnly);
         }
+
+        return this;
+    }
+
+    public bool Contains(ModelObject target) {
+        foreach (var snapshot in snapshots) {
+            if (snapshot.target == target) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+internal class UndoSnapshotBuilder {
+    private readonly MemoryStream stream = new MemoryStream();
+    private readonly List<object?> managedRefs = [];
+    public readonly BinaryWriter writer;
+    private readonly ModelObject currentTarget;
+
+    internal UndoSnapshotBuilder(ModelObject target) {
+        writer = new BinaryWriter(stream);
+        currentTarget = target;
+    }
+
+    internal UndoSnapshot Build() {
+        byte[]? buffer = null;
+        if (stream.Position > 0) {
+            buffer = new byte[stream.Position];
+            Array.Copy(stream.GetBuffer(), buffer, stream.Position);
+        }
+        UndoSnapshot result = new UndoSnapshot(currentTarget, managedRefs.Count > 0 ? managedRefs.ToArray() : null, buffer);
+        stream.Position = 0;
+        managedRefs.Clear();
+        return result;
+    }
+
+    public void WriteManagedReference(object? reference) {
+        managedRefs.Add(reference);
+    }
+
+    public void WriteManagedReferences(IEnumerable<object> references) {
+        managedRefs.AddRange(references);
+    }
+}
+
+internal class UndoSnapshotReader {
+    private static readonly BinaryReader NullReader = new BinaryReader(Stream.Null);
+    public BinaryReader reader { get; }
+    private int refId;
+    private readonly object?[]? managed;
+
+    internal UndoSnapshotReader(UndoSnapshot snapshot) {
+        if (snapshot.unmanagedData != null) {
+            MemoryStream stream = new MemoryStream(snapshot.unmanagedData, false);
+            reader = new BinaryReader(stream);
+        }
+        else {
+            reader = NullReader;
+        }
+
+        managed = snapshot.managedReferences;
+        refId = 0;
+    }
+
+    public object? ReadManagedReference() {
+        if (managed == null) {
+            throw new InvalidOperationException("No managed objects are available to read in this undo snapshot.");
+        }
+        return managed[refId++];
+    }
+
+    public T? ReadOwnedReference<T>(ModelObject owner) where T : ModelObject {
+        T? obj = ReadManagedReference() as T;
+        if (obj != null && obj.ownerObject != owner) {
+            obj.ownerObject = owner;
+        }
+
+        return obj;
     }
 }

--- a/Yafc.Model/Serialization/ValueSerializers.cs
+++ b/Yafc.Model/Serialization/ValueSerializers.cs
@@ -3,447 +3,446 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 
-namespace Yafc.Model {
-    internal static class ValueSerializer {
-        public static bool IsValueSerializerSupported(Type type) {
-            if (type == typeof(int) || type == typeof(float) || type == typeof(bool) || type == typeof(ulong) || type == typeof(string) || type == typeof(Type) || type == typeof(Guid) || type == typeof(PageReference)) {
-                return true;
+namespace Yafc.Model;
+internal static class ValueSerializer {
+    public static bool IsValueSerializerSupported(Type type) {
+        if (type == typeof(int) || type == typeof(float) || type == typeof(bool) || type == typeof(ulong) || type == typeof(string) || type == typeof(Type) || type == typeof(Guid) || type == typeof(PageReference)) {
+            return true;
+        }
+
+        if (typeof(FactorioObject).IsAssignableFrom(type)) {
+            return true;
+        }
+
+        if (type.IsEnum && type.GetEnumUnderlyingType() == typeof(int)) {
+            return true;
+        }
+
+        if (type.IsClass && (typeof(ModelObject).IsAssignableFrom(type) || type.GetCustomAttribute<SerializableAttribute>() != null)) {
+            return true;
+        }
+
+        if (!type.IsClass && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+            return IsValueSerializerSupported(type.GetGenericArguments()[0]);
+        }
+
+        return false;
+    }
+}
+
+internal abstract class ValueSerializer<T> {
+    public static readonly ValueSerializer<T> Default = (ValueSerializer<T>)CreateValueSerializer();
+
+    private static object CreateValueSerializer() {
+        if (typeof(T) == typeof(int)) {
+            return new IntSerializer();
+        }
+
+        if (typeof(T) == typeof(float)) {
+            return new FloatSerializer();
+        }
+
+        if (typeof(T) == typeof(bool)) {
+            return new BoolSerializer();
+        }
+
+        if (typeof(T) == typeof(ulong)) {
+            return new ULongSerializer();
+        }
+
+        if (typeof(T) == typeof(string)) {
+            return new StringSerializer();
+        }
+
+        if (typeof(T) == typeof(Type)) {
+            return new TypeSerializer();
+        }
+
+        if (typeof(T) == typeof(Guid)) {
+            return new GuidSerializer();
+        }
+
+        if (typeof(T) == typeof(PageReference)) {
+            return new PageReferenceSerializer();
+        }
+
+        // null-forgiving: Activator.CreateInstance does not return null.
+        if (typeof(FactorioObject).IsAssignableFrom(typeof(T))) {
+            return Activator.CreateInstance(typeof(FactorioObjectSerializer<>).MakeGenericType(typeof(T)))!;
+        }
+
+        if (typeof(T).IsEnum && typeof(T).GetEnumUnderlyingType() == typeof(int)) {
+            return Activator.CreateInstance(typeof(EnumSerializer<>).MakeGenericType(typeof(T)))!;
+        }
+
+        if (typeof(T).IsClass) {
+            if (typeof(ModelObject).IsAssignableFrom(typeof(T))) {
+                return Activator.CreateInstance(typeof(ModelObjectSerializer<>).MakeGenericType(typeof(T)))!;
             }
 
-            if (typeof(FactorioObject).IsAssignableFrom(type)) {
-                return true;
-            }
+            return Activator.CreateInstance(typeof(PlainClassesSerializer<>).MakeGenericType(typeof(T)))!;
+        }
+        if (!typeof(T).IsClass && typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>)) {
+            return Activator.CreateInstance(typeof(NullableSerializer<>).MakeGenericType(typeof(T).GetGenericArguments()[0]))!;
+        }
 
-            if (type.IsEnum && type.GetEnumUnderlyingType() == typeof(int)) {
-                return true;
-            }
+        throw new InvalidOperationException($"No known serializer for {typeof(T)}.");
+    }
 
-            if (type.IsClass && (typeof(ModelObject).IsAssignableFrom(type) || type.GetCustomAttribute<SerializableAttribute>() != null)) {
-                return true;
-            }
+    public abstract T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner);
+    public abstract void WriteToJson(Utf8JsonWriter writer, T? value);
+    public virtual string GetJsonProperty(T value) {
+        throw new NotSupportedException("Using type " + typeof(T) + " as dictionary key is not supported");
+    }
 
-            if (!type.IsClass && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)) {
-                return IsValueSerializerSupported(type.GetGenericArguments()[0]);
-            }
+    public virtual T? ReadFromJsonProperty(ref Utf8JsonReader reader, DeserializationContext context, object owner) {
+        return ReadFromJson(ref reader, context, owner);
+    }
 
-            return false;
+    public abstract T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner);
+    public abstract void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value);
+    public virtual bool CanBeNull => false;
+}
+
+internal class ModelObjectSerializer<T> : ValueSerializer<T> where T : ModelObject {
+    public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return SerializationMap<T>.DeserializeFromJson((ModelObject?)owner, ref reader, context);
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, T? value) {
+        SerializationMap<T>.SerializeToJson(value, writer);
+    }
+
+    public override T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.ReadOwnedReference<T>((ModelObject)owner);
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
+        writer.WriteManagedReference(value);
+    }
+
+    public override bool CanBeNull => true;
+}
+
+internal class NullableSerializer<T> : ValueSerializer<T?> where T : struct {
+    private static readonly ValueSerializer<T> baseSerializer = ValueSerializer<T>.Default;
+    public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        if (reader.TokenType == JsonTokenType.Null) {
+            return null;
+        }
+
+        return baseSerializer.ReadFromJson(ref reader, context, owner);
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, T? value) {
+        if (value == null) {
+            writer.WriteNullValue();
+        }
+        else {
+            baseSerializer.WriteToJson(writer, value.Value);
         }
     }
 
-    internal abstract class ValueSerializer<T> {
-        public static readonly ValueSerializer<T> Default = (ValueSerializer<T>)CreateValueSerializer();
-
-        private static object CreateValueSerializer() {
-            if (typeof(T) == typeof(int)) {
-                return new IntSerializer();
-            }
-
-            if (typeof(T) == typeof(float)) {
-                return new FloatSerializer();
-            }
-
-            if (typeof(T) == typeof(bool)) {
-                return new BoolSerializer();
-            }
-
-            if (typeof(T) == typeof(ulong)) {
-                return new ULongSerializer();
-            }
-
-            if (typeof(T) == typeof(string)) {
-                return new StringSerializer();
-            }
-
-            if (typeof(T) == typeof(Type)) {
-                return new TypeSerializer();
-            }
-
-            if (typeof(T) == typeof(Guid)) {
-                return new GuidSerializer();
-            }
-
-            if (typeof(T) == typeof(PageReference)) {
-                return new PageReferenceSerializer();
-            }
-
-            // null-forgiving: Activator.CreateInstance does not return null.
-            if (typeof(FactorioObject).IsAssignableFrom(typeof(T))) {
-                return Activator.CreateInstance(typeof(FactorioObjectSerializer<>).MakeGenericType(typeof(T)))!;
-            }
-
-            if (typeof(T).IsEnum && typeof(T).GetEnumUnderlyingType() == typeof(int)) {
-                return Activator.CreateInstance(typeof(EnumSerializer<>).MakeGenericType(typeof(T)))!;
-            }
-
-            if (typeof(T).IsClass) {
-                if (typeof(ModelObject).IsAssignableFrom(typeof(T))) {
-                    return Activator.CreateInstance(typeof(ModelObjectSerializer<>).MakeGenericType(typeof(T)))!;
-                }
-
-                return Activator.CreateInstance(typeof(PlainClassesSerializer<>).MakeGenericType(typeof(T)))!;
-            }
-            if (!typeof(T).IsClass && typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>)) {
-                return Activator.CreateInstance(typeof(NullableSerializer<>).MakeGenericType(typeof(T).GetGenericArguments()[0]))!;
-            }
-
-            throw new InvalidOperationException($"No known serializer for {typeof(T)}.");
+    public override T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        if (!reader.reader.ReadBoolean()) {
+            return null;
         }
 
-        public abstract T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner);
-        public abstract void WriteToJson(Utf8JsonWriter writer, T? value);
-        public virtual string GetJsonProperty(T value) {
-            throw new NotSupportedException("Using type " + typeof(T) + " as dictionary key is not supported");
-        }
-
-        public virtual T? ReadFromJsonProperty(ref Utf8JsonReader reader, DeserializationContext context, object owner) {
-            return ReadFromJson(ref reader, context, owner);
-        }
-
-        public abstract T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner);
-        public abstract void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value);
-        public virtual bool CanBeNull => false;
+        return baseSerializer.ReadFromUndoSnapshot(reader, owner);
     }
 
-    internal class ModelObjectSerializer<T> : ValueSerializer<T> where T : ModelObject {
-        public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return SerializationMap<T>.DeserializeFromJson((ModelObject?)owner, ref reader, context);
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, T? value) {
-            SerializationMap<T>.SerializeToJson(value, writer);
-        }
-
-        public override T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.ReadOwnedReference<T>((ModelObject)owner);
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
-            writer.WriteManagedReference(value);
-        }
-
-        public override bool CanBeNull => true;
-    }
-
-    internal class NullableSerializer<T> : ValueSerializer<T?> where T : struct {
-        private static readonly ValueSerializer<T> baseSerializer = ValueSerializer<T>.Default;
-        public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            if (reader.TokenType == JsonTokenType.Null) {
-                return null;
-            }
-
-            return baseSerializer.ReadFromJson(ref reader, context, owner);
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, T? value) {
-            if (value == null) {
-                writer.WriteNullValue();
-            }
-            else {
-                baseSerializer.WriteToJson(writer, value.Value);
-            }
-        }
-
-        public override T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            if (!reader.reader.ReadBoolean()) {
-                return null;
-            }
-
-            return baseSerializer.ReadFromUndoSnapshot(reader, owner);
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
-            writer.writer.Write(value != null);
-            if (value != null) {
-                baseSerializer.WriteToUndoSnapshot(writer, value.Value);
-            }
-        }
-
-        public override bool CanBeNull => true;
-    }
-
-    internal class IntSerializer : ValueSerializer<int> {
-        public override int ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return reader.GetInt32();
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, int value) {
-            writer.WriteNumberValue(value);
-        }
-
-        public override int ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.reader.ReadInt32();
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, int value) {
-            writer.writer.Write(value);
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
+        writer.writer.Write(value != null);
+        if (value != null) {
+            baseSerializer.WriteToUndoSnapshot(writer, value.Value);
         }
     }
 
-    internal class FloatSerializer : ValueSerializer<float> {
-        public override float ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return reader.GetSingle();
+    public override bool CanBeNull => true;
+}
+
+internal class IntSerializer : ValueSerializer<int> {
+    public override int ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return reader.GetInt32();
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, int value) {
+        writer.WriteNumberValue(value);
+    }
+
+    public override int ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.reader.ReadInt32();
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, int value) {
+        writer.writer.Write(value);
+    }
+}
+
+internal class FloatSerializer : ValueSerializer<float> {
+    public override float ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return reader.GetSingle();
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, float value) {
+        writer.WriteNumberValue(value);
+    }
+
+    public override float ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.reader.ReadSingle();
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, float value) {
+        writer.writer.Write(value);
+    }
+}
+
+internal class GuidSerializer : ValueSerializer<Guid> {
+    public override Guid ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return new Guid(reader.GetString()!); // null-forgiving: If reader.GetString() returns null, we don't have a good backup and we'll find out immediately
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, Guid value) {
+        writer.WriteStringValue(value.ToString("N"));
+    }
+
+    public override string GetJsonProperty(Guid value) {
+        return value.ToString("N");
+    }
+
+    public override Guid ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return new Guid(reader.reader.ReadBytes(16));
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, Guid value) {
+        writer.writer.Write(value.ToByteArray());
+    }
+}
+
+internal class PageReferenceSerializer : ValueSerializer<PageReference> {
+    public override PageReference? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        string? str = reader.GetString();
+        if (str == null) {
+            return null;
         }
 
-        public override void WriteToJson(Utf8JsonWriter writer, float value) {
-            writer.WriteNumberValue(value);
-        }
+        return new PageReference(new Guid(str));
+    }
 
-        public override float ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.reader.ReadSingle();
+    public override void WriteToJson(Utf8JsonWriter writer, PageReference? value) {
+        if (value == null) {
+            writer.WriteNullValue();
         }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, float value) {
-            writer.writer.Write(value);
+        else {
+            writer.WriteStringValue(value.guid.ToString("N"));
         }
     }
 
-    internal class GuidSerializer : ValueSerializer<Guid> {
-        public override Guid ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return new Guid(reader.GetString()!); // null-forgiving: If reader.GetString() returns null, we don't have a good backup and we'll find out immediately
+    public override PageReference? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.ReadManagedReference() as PageReference;
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, PageReference? value) {
+        writer.WriteManagedReference(value);
+    }
+
+    public override bool CanBeNull => true;
+}
+
+internal class TypeSerializer : ValueSerializer<Type> {
+    public override Type? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        string? s = reader.GetString();
+        if (s == null) {
+            return null;
         }
 
-        public override void WriteToJson(Utf8JsonWriter writer, Guid value) {
-            writer.WriteStringValue(value.ToString("N"));
+        if (s.StartsWith("YAFC.")) {
+            s = "Yafc." + s[5..];
+        }
+        Type? type = Type.GetType(s);
+        if (type == null) {
+            context.Error("Type " + s + " does not exist. Possible plugin version change", ErrorSeverity.MinorDataLoss);
         }
 
-        public override string GetJsonProperty(Guid value) {
-            return value.ToString("N");
+        return type;
+    }
+    public override void WriteToJson(Utf8JsonWriter writer, Type? value) {
+        ArgumentNullException.ThrowIfNull(value, nameof(value));
+        string? name = value.FullName;
+        // TODO: Once no one will want to roll back to 0.7.2 or earlier, remove this if block.
+        if (name?.StartsWith("Yafc.") ?? false) {
+            name = "YAFC." + name[5..];
+        }
+        writer.WriteStringValue(name);
+    }
+
+    public override string GetJsonProperty(Type value) {
+        if (value.FullName is null) {
+            // If value doesn't have a FullName, we're in a bad state and I don't know what to do.
+            throw new ArgumentException($"value must be a type that has a FullName.", nameof(value));
         }
 
-        public override Guid ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return new Guid(reader.reader.ReadBytes(16));
+        string name = value.FullName;
+        // TODO: Once no one will want to roll back to 0.7.2 or earlier, remove this if block.
+        if (name.StartsWith("Yafc.")) {
+            name = "YAFC." + name[5..];
+        }
+        return name;
+    }
+
+    public override Type? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.ReadManagedReference() as Type;
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, Type? value) {
+        writer.WriteManagedReference(value);
+    }
+}
+
+internal class BoolSerializer : ValueSerializer<bool> {
+    public override bool ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return reader.GetBoolean();
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, bool value) {
+        writer.WriteBooleanValue(value);
+    }
+
+    public override bool ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.reader.ReadBoolean();
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, bool value) {
+        writer.writer.Write(value);
+    }
+}
+
+internal class ULongSerializer : ValueSerializer<ulong> {
+    public override ulong ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return reader.GetUInt64();
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, ulong value) {
+        writer.WriteNumberValue(value);
+    }
+
+    public override ulong ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.reader.ReadUInt64();
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, ulong value) {
+        writer.writer.Write(value);
+    }
+}
+
+internal class StringSerializer : ValueSerializer<string> {
+    public override string? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return reader.GetString();
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, string? value) {
+        writer.WriteStringValue(value);
+    }
+
+    public override string GetJsonProperty(string value) {
+        return value;
+    }
+
+    public override string? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.ReadManagedReference() as string;
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, string? value) {
+        writer.WriteManagedReference(value);
+    }
+
+    public override bool CanBeNull => true;
+}
+
+internal class FactorioObjectSerializer<T> : ValueSerializer<T> where T : FactorioObject {
+    public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        string? s = reader.GetString();
+        if (s == null) {
+            return null;
         }
 
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, Guid value) {
-            writer.writer.Write(value.ToByteArray());
+        if (!Database.objectsByTypeName.TryGetValue(s, out var obj)) {
+            var substitute = Database.FindClosestVariant(s);
+            if (substitute is T t) {
+                context.Error("Fluid " + t.locName + " doesn't have correct temperature information. May require adjusting its temperature.", ErrorSeverity.MinorDataLoss);
+                return t;
+            }
+            context.Error("Factorio object '" + s + "' no longer exist. Check mods configuration.", ErrorSeverity.MinorDataLoss);
+        }
+        return obj as T;
+    }
+
+    public override void WriteToJson(Utf8JsonWriter writer, T? value) {
+        if (value == null) {
+            writer.WriteNullValue();
+        }
+        else {
+            writer.WriteStringValue(value.typeDotName);
+        }
+    }
+    public override string GetJsonProperty(T value) {
+        return value.typeDotName;
+    }
+
+    public override T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        return reader.ReadManagedReference() as T;
+    }
+
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
+        writer.WriteManagedReference(value);
+    }
+
+    public override bool CanBeNull => true;
+}
+
+internal class EnumSerializer<T> : ValueSerializer<T> where T : struct, Enum {
+    public EnumSerializer() {
+        if (Unsafe.SizeOf<T>() != 4) {
+            throw new NotSupportedException("Only int enums are supported");
         }
     }
 
-    internal class PageReferenceSerializer : ValueSerializer<PageReference> {
-        public override PageReference? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            string? str = reader.GetString();
-            if (str == null) {
-                return null;
-            }
-
-            return new PageReference(new Guid(str));
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, PageReference? value) {
-            if (value == null) {
-                writer.WriteNullValue();
-            }
-            else {
-                writer.WriteStringValue(value.guid.ToString("N"));
-            }
-        }
-
-        public override PageReference? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.ReadManagedReference() as PageReference;
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, PageReference? value) {
-            writer.WriteManagedReference(value);
-        }
-
-        public override bool CanBeNull => true;
+    public override T ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        int val = reader.GetInt32();
+        return Unsafe.As<int, T>(ref val);
     }
 
-    internal class TypeSerializer : ValueSerializer<Type> {
-        public override Type? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            string? s = reader.GetString();
-            if (s == null) {
-                return null;
-            }
-
-            if (s.StartsWith("YAFC.")) {
-                s = "Yafc." + s[5..];
-            }
-            Type? type = Type.GetType(s);
-            if (type == null) {
-                context.Error("Type " + s + " does not exist. Possible plugin version change", ErrorSeverity.MinorDataLoss);
-            }
-
-            return type;
-        }
-        public override void WriteToJson(Utf8JsonWriter writer, Type? value) {
-            ArgumentNullException.ThrowIfNull(value, nameof(value));
-            string? name = value.FullName;
-            // TODO: Once no one will want to roll back to 0.7.2 or earlier, remove this if block.
-            if (name?.StartsWith("Yafc.") ?? false) {
-                name = "YAFC." + name[5..];
-            }
-            writer.WriteStringValue(name);
-        }
-
-        public override string GetJsonProperty(Type value) {
-            if (value.FullName is null) {
-                // If value doesn't have a FullName, we're in a bad state and I don't know what to do.
-                throw new ArgumentException($"value must be a type that has a FullName.", nameof(value));
-            }
-
-            string name = value.FullName;
-            // TODO: Once no one will want to roll back to 0.7.2 or earlier, remove this if block.
-            if (name.StartsWith("Yafc.")) {
-                name = "YAFC." + name[5..];
-            }
-            return name;
-        }
-
-        public override Type? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.ReadManagedReference() as Type;
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, Type? value) {
-            writer.WriteManagedReference(value);
-        }
+    public override void WriteToJson(Utf8JsonWriter writer, T value) {
+        writer.WriteNumberValue(Unsafe.As<T, int>(ref value));
     }
 
-    internal class BoolSerializer : ValueSerializer<bool> {
-        public override bool ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return reader.GetBoolean();
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, bool value) {
-            writer.WriteBooleanValue(value);
-        }
-
-        public override bool ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.reader.ReadBoolean();
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, bool value) {
-            writer.writer.Write(value);
-        }
+    public override T ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        int val = reader.reader.ReadInt32();
+        return Unsafe.As<int, T>(ref val);
     }
 
-    internal class ULongSerializer : ValueSerializer<ulong> {
-        public override ulong ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return reader.GetUInt64();
-        }
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T value) {
+        writer.writer.Write(Unsafe.As<T, int>(ref value));
+    }
+}
 
-        public override void WriteToJson(Utf8JsonWriter writer, ulong value) {
-            writer.WriteNumberValue(value);
-        }
-
-        public override ulong ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.reader.ReadUInt64();
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, ulong value) {
-            writer.writer.Write(value);
-        }
+internal class PlainClassesSerializer<T> : ValueSerializer<T> where T : class {
+    private static readonly SerializationMap builder = SerializationMap.GetSerializationMap(typeof(T));
+    public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
+        return SerializationMap<T>.DeserializeFromJson(null, ref reader, context);
     }
 
-    internal class StringSerializer : ValueSerializer<string> {
-        public override string? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return reader.GetString();
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, string? value) {
-            writer.WriteStringValue(value);
-        }
-
-        public override string GetJsonProperty(string value) {
-            return value;
-        }
-
-        public override string? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.ReadManagedReference() as string;
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, string? value) {
-            writer.WriteManagedReference(value);
-        }
-
-        public override bool CanBeNull => true;
+    public override void WriteToJson(Utf8JsonWriter writer, T? value) {
+        SerializationMap<T>.SerializeToJson(value, writer);
     }
 
-    internal class FactorioObjectSerializer<T> : ValueSerializer<T> where T : FactorioObject {
-        public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            string? s = reader.GetString();
-            if (s == null) {
-                return null;
-            }
-
-            if (!Database.objectsByTypeName.TryGetValue(s, out var obj)) {
-                var substitute = Database.FindClosestVariant(s);
-                if (substitute is T t) {
-                    context.Error("Fluid " + t.locName + " doesn't have correct temperature information. May require adjusting its temperature.", ErrorSeverity.MinorDataLoss);
-                    return t;
-                }
-                context.Error("Factorio object '" + s + "' no longer exist. Check mods configuration.", ErrorSeverity.MinorDataLoss);
-            }
-            return obj as T;
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, T? value) {
-            if (value == null) {
-                writer.WriteNullValue();
-            }
-            else {
-                writer.WriteStringValue(value.typeDotName);
-            }
-        }
-        public override string GetJsonProperty(T value) {
-            return value.typeDotName;
-        }
-
-        public override T? ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            return reader.ReadManagedReference() as T;
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
-            writer.WriteManagedReference(value);
-        }
-
-        public override bool CanBeNull => true;
+    public override T ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
+        T obj = (T?)reader.ReadManagedReference() ?? throw new InvalidOperationException("Read an unexpected null value from the undo snapshot; cannot undo.");
+        builder.ReadUndo(obj, reader);
+        return obj;
     }
-
-    internal class EnumSerializer<T> : ValueSerializer<T> where T : struct, Enum {
-        public EnumSerializer() {
-            if (Unsafe.SizeOf<T>() != 4) {
-                throw new NotSupportedException("Only int enums are supported");
-            }
-        }
-
-        public override T ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            int val = reader.GetInt32();
-            return Unsafe.As<int, T>(ref val);
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, T value) {
-            writer.WriteNumberValue(Unsafe.As<T, int>(ref value));
-        }
-
-        public override T ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            int val = reader.reader.ReadInt32();
-            return Unsafe.As<int, T>(ref val);
-        }
-
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T value) {
-            writer.writer.Write(Unsafe.As<T, int>(ref value));
-        }
-    }
-
-    internal class PlainClassesSerializer<T> : ValueSerializer<T> where T : class {
-        private static readonly SerializationMap builder = SerializationMap.GetSerializationMap(typeof(T));
-        public override T? ReadFromJson(ref Utf8JsonReader reader, DeserializationContext context, object? owner) {
-            return SerializationMap<T>.DeserializeFromJson(null, ref reader, context);
-        }
-
-        public override void WriteToJson(Utf8JsonWriter writer, T? value) {
-            SerializationMap<T>.SerializeToJson(value, writer);
-        }
-
-        public override T ReadFromUndoSnapshot(UndoSnapshotReader reader, object owner) {
-            T obj = (T?)reader.ReadManagedReference() ?? throw new InvalidOperationException("Read an unexpected null value from the undo snapshot; cannot undo.");
-            builder.ReadUndo(obj, reader);
-            return obj;
-        }
-        public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
-            writer.WriteManagedReference(value ?? throw new InvalidOperationException("Unexpected request to write a null value to the undo snapshot; cannot save undo state."));
-            builder.BuildUndo(value, writer);
-        }
+    public override void WriteToUndoSnapshot(UndoSnapshotBuilder writer, T? value) {
+        writer.WriteManagedReference(value ?? throw new InvalidOperationException("Unexpected request to write a null value to the undo snapshot; cannot save undo state."));
+        builder.BuildUndo(value, writer);
     }
 }

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -3,122 +3,121 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace Yafc.Parser {
-    internal static class DataParserUtils {
-        private static class ConvertersFromLua<T> {
-            public static Func<object, T, T>? convert;
-        }
+namespace Yafc.Parser;
+internal static class DataParserUtils {
+    private static class ConvertersFromLua<T> {
+        public static Func<object, T, T>? convert;
+    }
 
-        static DataParserUtils() {
-            ConvertersFromLua<int>.convert = (o, def) => o is long l ? (int)l : o is double d ? (int)d : o is string s && int.TryParse(s, out int res) ? res : def;
-            ConvertersFromLua<float>.convert = (o, def) => o is long l ? l : o is double d ? (float)d : o is string s && float.TryParse(s, out float res) ? res : def;
-            ConvertersFromLua<bool>.convert = delegate (object src, bool def) {
-                if (src is bool b) {
-                    return b;
-                }
-
-                if (src == null) {
-                    return def;
-                }
-
-                if (src.Equals("true")) {
-                    return true;
-                }
-
-                if (src.Equals("false")) {
-                    return false;
-                }
-
-                return def;
-            };
-        }
-
-        private static bool Parse<T>(object? value, out T result, T def) {
-            if (value == null) {
-                result = def;
-                return false;
+    static DataParserUtils() {
+        ConvertersFromLua<int>.convert = (o, def) => o is long l ? (int)l : o is double d ? (int)d : o is string s && int.TryParse(s, out int res) ? res : def;
+        ConvertersFromLua<float>.convert = (o, def) => o is long l ? l : o is double d ? (float)d : o is string s && float.TryParse(s, out float res) ? res : def;
+        ConvertersFromLua<bool>.convert = delegate (object src, bool def) {
+            if (src is bool b) {
+                return b;
             }
 
-            if (value is T t) {
-                result = t;
+            if (src == null) {
+                return def;
+            }
+
+            if (src.Equals("true")) {
                 return true;
             }
-            var converter = ConvertersFromLua<T>.convert;
-            if (converter == null) {
-                result = def;
+
+            if (src.Equals("false")) {
                 return false;
             }
 
-            result = converter(value, def);
+            return def;
+        };
+    }
+
+    private static bool Parse<T>(object? value, out T result, T def) {
+        if (value == null) {
+            result = def;
+            return false;
+        }
+
+        if (value is T t) {
+            result = t;
             return true;
         }
-
-        private static bool Parse<T>(object? value, [MaybeNullWhen(false)] out T result) {
-            return Parse(value, out result, default!); // null-forgiving: The three-argument Parse takes a non-null default to guarantee a non-null result. We don't make that guarantee.
+        var converter = ConvertersFromLua<T>.convert;
+        if (converter == null) {
+            result = def;
+            return false;
         }
 
-        public static bool Get<T>(this LuaTable? table, string key, out T result, T def) {
-            return Parse(table?[key], out result, def);
-        }
-
-        public static bool Get<T>(this LuaTable? table, int key, out T result, T def) {
-            return Parse(table?[key], out result, def);
-        }
-
-        public static bool Get<T>(this LuaTable? table, string key, [NotNullWhen(true)] out T? result) {
-            return Parse(table?[key], out result);
-        }
-
-        public static bool Get<T>(this LuaTable? table, int key, [NotNullWhen(true)] out T? result) {
-            return Parse(table?[key], out result);
-        }
-
-        public static T Get<T>(this LuaTable? table, string key, T def) {
-            _ = Parse(table?[key], out var result, def);
-            return result;
-        }
-
-        public static T Get<T>(this LuaTable table, int key, T def) {
-            _ = Parse(table[key], out var result, def);
-            return result;
-        }
-
-        public static T? Get<T>(this LuaTable table, string key) {
-            _ = Parse(table[key], out T? result);
-            return result;
-        }
-
-        public static T? Get<T>(this LuaTable table, int key) {
-            _ = Parse(table[key], out T? result);
-            return result;
-        }
-
-        public static T[] SingleElementArray<T>(this T item) {
-            return [item];
-        }
-
-        public static IEnumerable<T> ArrayElements<T>(this LuaTable? table) {
-            return table?.ArrayElements.OfType<T>() ?? [];
-        }
+        result = converter(value, def);
+        return true;
     }
 
-    public static class SpecialNames {
-        public const string BurnableFluid = "burnable-fluid.";
-        public const string Heat = "heat";
-        public const string Void = "void";
-        public const string Electricity = "electricity";
-        public const string HotFluid = "hot-fluid";
-        public const string SpecificFluid = "fluid.";
-        public const string MiningRecipe = "mining.";
-        public const string BoilerRecipe = "boiler.";
-        public const string FakeRecipe = "fake-recipe";
-        public const string FixedRecipe = "fixed-recipe.";
-        public const string GeneratorRecipe = "generator";
-        public const string PumpingRecipe = "pump.";
-        public const string Labs = "labs.";
-        public const string RocketLaunch = "launch";
-        public const string RocketCraft = "rocket.";
-        public const string ReactorRecipe = "reactor";
-        public const string ResearchUnit = "research-unit";
+    private static bool Parse<T>(object? value, [MaybeNullWhen(false)] out T result) {
+        return Parse(value, out result, default!); // null-forgiving: The three-argument Parse takes a non-null default to guarantee a non-null result. We don't make that guarantee.
     }
+
+    public static bool Get<T>(this LuaTable? table, string key, out T result, T def) {
+        return Parse(table?[key], out result, def);
+    }
+
+    public static bool Get<T>(this LuaTable? table, int key, out T result, T def) {
+        return Parse(table?[key], out result, def);
+    }
+
+    public static bool Get<T>(this LuaTable? table, string key, [NotNullWhen(true)] out T? result) {
+        return Parse(table?[key], out result);
+    }
+
+    public static bool Get<T>(this LuaTable? table, int key, [NotNullWhen(true)] out T? result) {
+        return Parse(table?[key], out result);
+    }
+
+    public static T Get<T>(this LuaTable? table, string key, T def) {
+        _ = Parse(table?[key], out var result, def);
+        return result;
+    }
+
+    public static T Get<T>(this LuaTable table, int key, T def) {
+        _ = Parse(table[key], out var result, def);
+        return result;
+    }
+
+    public static T? Get<T>(this LuaTable table, string key) {
+        _ = Parse(table[key], out T? result);
+        return result;
+    }
+
+    public static T? Get<T>(this LuaTable table, int key) {
+        _ = Parse(table[key], out T? result);
+        return result;
+    }
+
+    public static T[] SingleElementArray<T>(this T item) {
+        return [item];
+    }
+
+    public static IEnumerable<T> ArrayElements<T>(this LuaTable? table) {
+        return table?.ArrayElements.OfType<T>() ?? [];
+    }
+}
+
+public static class SpecialNames {
+    public const string BurnableFluid = "burnable-fluid.";
+    public const string Heat = "heat";
+    public const string Void = "void";
+    public const string Electricity = "electricity";
+    public const string HotFluid = "hot-fluid";
+    public const string SpecificFluid = "fluid.";
+    public const string MiningRecipe = "mining.";
+    public const string BoilerRecipe = "boiler.";
+    public const string FakeRecipe = "fake-recipe";
+    public const string FixedRecipe = "fixed-recipe.";
+    public const string GeneratorRecipe = "generator";
+    public const string PumpingRecipe = "pump.";
+    public const string Labs = "labs.";
+    public const string RocketLaunch = "launch";
+    public const string RocketCraft = "rocket.";
+    public const string ReactorRecipe = "reactor";
+    public const string ResearchUnit = "research-unit";
 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -10,657 +10,656 @@ using Serilog;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc.Parser {
-    internal partial class FactorioDataDeserializer {
-        private static readonly ILogger logger = Logging.GetLogger<FactorioDataDeserializer>();
-        private LuaTable raw = null!; // null-forgiving: Initialized at the beginning of LoadData.
-        private bool GetRef<T>(LuaTable table, string key, [MaybeNullWhen(false)] out T result) where T : FactorioObject, new() {
-            result = null;
-            if (!table.Get(key, out string? name)) {
-                return false;
-            }
-
-            result = GetObject<T>(name);
-            return true;
+namespace Yafc.Parser;
+internal partial class FactorioDataDeserializer {
+    private static readonly ILogger logger = Logging.GetLogger<FactorioDataDeserializer>();
+    private LuaTable raw = null!; // null-forgiving: Initialized at the beginning of LoadData.
+    private bool GetRef<T>(LuaTable table, string key, [MaybeNullWhen(false)] out T result) where T : FactorioObject, new() {
+        result = null;
+        if (!table.Get(key, out string? name)) {
+            return false;
         }
 
-        private T? GetRef<T>(LuaTable table, string key) where T : FactorioObject, new() {
-            _ = GetRef<T>(table, key, out var result);
-            return result;
+        result = GetObject<T>(name);
+        return true;
+    }
+
+    private T? GetRef<T>(LuaTable table, string key) where T : FactorioObject, new() {
+        _ = GetRef<T>(table, key, out var result);
+        return result;
+    }
+
+    private Fluid GetFluidFixedTemp(string key, int temperature) {
+        var basic = GetObject<Fluid>(key);
+        if (basic.temperature == temperature) {
+            return basic;
         }
 
-        private Fluid GetFluidFixedTemp(string key, int temperature) {
-            var basic = GetObject<Fluid>(key);
-            if (basic.temperature == temperature) {
-                return basic;
-            }
-
-            if (temperature < basic.temperatureRange.min) {
-                temperature = basic.temperatureRange.min;
-            }
-
-            string idWithTemp = key + "@" + temperature;
-            if (basic.temperature == 0) {
-                basic.SetTemperature(temperature);
-                registeredObjects[(typeof(Fluid), idWithTemp)] = basic;
-                return basic;
-            }
-
-            if (registeredObjects.TryGetValue((typeof(Fluid), idWithTemp), out var fluidWithTemp)) {
-                return (Fluid)fluidWithTemp;
-            }
-
-            var split = SplitFluid(basic, temperature);
-            allObjects.Add(split);
-            registeredObjects[(typeof(Fluid), idWithTemp)] = split;
-            return split;
+        if (temperature < basic.temperatureRange.min) {
+            temperature = basic.temperatureRange.min;
         }
 
-        private void UpdateSplitFluids() {
-            HashSet<List<Fluid>> processedFluidLists = [];
+        string idWithTemp = key + "@" + temperature;
+        if (basic.temperature == 0) {
+            basic.SetTemperature(temperature);
+            registeredObjects[(typeof(Fluid), idWithTemp)] = basic;
+            return basic;
+        }
 
-            foreach (var fluid in allObjects.OfType<Fluid>()) {
-                if (fluid.temperature == 0) {
-                    fluid.temperature = fluid.temperatureRange.min;
+        if (registeredObjects.TryGetValue((typeof(Fluid), idWithTemp), out var fluidWithTemp)) {
+            return (Fluid)fluidWithTemp;
+        }
+
+        var split = SplitFluid(basic, temperature);
+        allObjects.Add(split);
+        registeredObjects[(typeof(Fluid), idWithTemp)] = split;
+        return split;
+    }
+
+    private void UpdateSplitFluids() {
+        HashSet<List<Fluid>> processedFluidLists = [];
+
+        foreach (var fluid in allObjects.OfType<Fluid>()) {
+            if (fluid.temperature == 0) {
+                fluid.temperature = fluid.temperatureRange.min;
+            }
+
+            if (fluid.variants == null || !processedFluidLists.Add(fluid.variants)) {
+                continue;
+            }
+
+            fluid.variants.Sort(DataUtils.FluidTemperatureComparer);
+            fluidVariants[fluid.type + "." + fluid.name] = fluid.variants;
+            foreach (var variant in fluid.variants) {
+                AddTemperatureToFluidIcon(variant);
+                variant.name += "@" + variant.temperature;
+            }
+        }
+    }
+
+    private static void AddTemperatureToFluidIcon(Fluid fluid) {
+        string iconStr = fluid.temperature + "d";
+        fluid.iconSpec =
+        [
+            .. fluid.iconSpec,
+            .. iconStr.Take(4).Select((x, n) => new FactorioIconPart("__.__/" + x) { y = -16, x = (n * 7) - 12, scale = 0.28f }),
+        ];
+    }
+
+    /// <summary>
+    /// Process the data loaded from Factorio and the mods, and load the project specified by <paramref name="projectPath"/>.
+    /// </summary>
+    /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
+    /// <param name="data">The Lua table data (containing data.raw) that was populated by the lua scripts.</param>
+    /// <param name="prototypes">The Lua table defines.prototypes that was populated by the lua scripts.</param>
+    /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+    /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+    /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+    /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
+    /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+    /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
+    /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
+    /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
+    public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, bool netProduction, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
+        progress.Report(("Loading", "Loading items"));
+        raw = (LuaTable?)data["raw"] ?? throw new ArgumentException("Could not load data.raw from data argument", nameof(data));
+        LuaTable itemPrototypes = (LuaTable?)prototypes?["item"] ?? throw new ArgumentException("Could not load prototypes.item from data argument", nameof(prototypes));
+        foreach (object prototypeName in itemPrototypes.ObjectElements.Keys) {
+            DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress, errorCollector);
+        }
+
+        Module[] universalModulesArray = [.. universalModules];
+        IEnumerable<Module> FilteredModules(Recipe item) {
+            // When the blacklist is available, filter out modules that are in this blacklist
+            Func<Module, bool> AllowedModulesFilter(Recipe key) {
+                return module => module.moduleSpecification.limitation_blacklist == null || !module.moduleSpecification.limitation_blacklist.Contains(key);
+            }
+
+            return universalModulesArray.Where(AllowedModulesFilter(item));
+        }
+        recipeModules.Seal(FilteredModules);
+
+        allModules.AddRange(allObjects.OfType<Module>());
+        progress.Report(("Loading", "Loading fluids"));
+        DeserializePrototypes(raw, "fluid", DeserializeFluid, progress, errorCollector);
+        progress.Report(("Loading", "Loading recipes"));
+        DeserializePrototypes(raw, "recipe", DeserializeRecipe, progress, errorCollector);
+        progress.Report(("Loading", "Loading technologies"));
+        DeserializePrototypes(raw, "technology", DeserializeTechnology, progress, errorCollector);
+        progress.Report(("Loading", "Loading entities"));
+        DeserializeRocketEntities(raw["rocket-silo-rocket"] as LuaTable);
+        LuaTable entityPrototypes = (LuaTable?)prototypes["entity"] ?? throw new ArgumentException("Could not load prototypes.item from data argument", nameof(prototypes));
+        foreach (object prototypeName in entityPrototypes.ObjectElements.Keys) {
+            DeserializePrototypes(raw, (string)prototypeName, DeserializeEntity, progress, errorCollector);
+        }
+
+        ParseModYafcHandles(data["script_enabled"] as LuaTable);
+        progress.Report(("Post-processing", "Computing maps"));
+        // Deterministically sort all objects
+
+        allObjects.Sort((a, b) => a.sortingOrder == b.sortingOrder ? string.Compare(a.typeDotName, b.typeDotName, StringComparison.Ordinal) : a.sortingOrder - b.sortingOrder);
+        for (int i = 0; i < allObjects.Count; i++) {
+            allObjects[i].id = (FactorioId)i;
+        }
+
+        UpdateSplitFluids();
+        var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
+        UpdateRecipeIngredientFluids();
+        UpdateRecipeCatalysts();
+        CalculateMaps(netProduction);
+        ExportBuiltData();
+        progress.Report(("Post-processing", "Calculating dependencies"));
+        Dependencies.Calculate();
+        TechnologyLoopsFinder.FindTechnologyLoops();
+        progress.Report(("Post-processing", "Creating project"));
+        Project project = Project.ReadFromFile(projectPath, errorCollector);
+        Analysis.ProcessAnalyses(progress, project, errorCollector);
+        progress.Report(("Rendering icons", ""));
+        iconRenderedProgress = progress;
+        iconRenderTask.Wait();
+        return project;
+    }
+
+    private IProgress<(string, string)>? iconRenderedProgress;
+
+    private Icon CreateSimpleIcon(Dictionary<(string mod, string path), IntPtr> cache, string graphicsPath) => CreateIconFromSpec(cache, new FactorioIconPart("__core__/graphics/" + graphicsPath + ".png"));
+
+    private void RenderIcons() {
+        Dictionary<(string mod, string path), IntPtr> cache = [];
+        try {
+            foreach (char digit in "0123456789d") {
+                cache[(".", digit.ToString())] = SDL_image.IMG_Load("Data/Digits/" + digit + ".png");
+            }
+
+            DataUtils.NoFuelIcon = CreateSimpleIcon(cache, "fuel-icon-red");
+            DataUtils.WarningIcon = CreateSimpleIcon(cache, "warning-icon");
+            DataUtils.HandIcon = CreateSimpleIcon(cache, "hand");
+
+            Dictionary<string, Icon> simpleSpritesCache = [];
+            int rendered = 0;
+
+            foreach (var o in allObjects) {
+                if (++rendered % 100 == 0) {
+                    iconRenderedProgress?.Report(("Rendering icons", $"{rendered}/{allObjects.Count}"));
                 }
 
-                if (fluid.variants == null || !processedFluidLists.Add(fluid.variants)) {
-                    continue;
-                }
+                if (o.iconSpec != null && o.iconSpec.Length > 0) {
+                    bool simpleSprite = o.iconSpec.Length == 1 && o.iconSpec[0].IsSimple();
+                    if (simpleSprite && simpleSpritesCache.TryGetValue(o.iconSpec[0].path, out var icon)) {
+                        o.icon = icon;
+                        continue;
+                    }
 
-                fluid.variants.Sort(DataUtils.FluidTemperatureComparer);
-                fluidVariants[fluid.type + "." + fluid.name] = fluid.variants;
-                foreach (var variant in fluid.variants) {
-                    AddTemperatureToFluidIcon(variant);
-                    variant.name += "@" + variant.temperature;
+                    try {
+                        o.icon = CreateIconFromSpec(cache, o.iconSpec);
+                        if (simpleSprite) {
+                            simpleSpritesCache[o.iconSpec[0].path] = o.icon;
+                        }
+                    }
+                    catch (Exception ex) {
+                        Console.Error.WriteException(ex);
+                    }
+                }
+                else if (o is Recipe recipe && recipe.mainProduct != null) {
+                    o.icon = recipe.mainProduct.icon;
                 }
             }
         }
+        finally {
+            foreach (var (_, image) in cache) {
+                if (image != IntPtr.Zero) {
+                    SDL.SDL_FreeSurface(image);
+                }
+            }
+        }
+    }
 
-        private static void AddTemperatureToFluidIcon(Fluid fluid) {
-            string iconStr = fluid.temperature + "d";
-            fluid.iconSpec =
+    private unsafe Icon CreateIconFromSpec(Dictionary<(string mod, string path), IntPtr> cache, params FactorioIconPart[] spec) {
+        const int IconSize = IconCollection.IconSize;
+        nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
+        _ = SDL.SDL_SetSurfaceBlendMode(targetSurface, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+        foreach (var icon in spec) {
+            var modpath = FactorioDataSource.ResolveModPath("", icon.path);
+            if (!cache.TryGetValue(modpath, out nint image)) {
+                byte[] imageSource = FactorioDataSource.ReadModFile(modpath.mod, modpath.path);
+                if (imageSource == null) {
+                    image = cache[modpath] = IntPtr.Zero;
+                }
+                else {
+                    fixed (byte* data = imageSource) {
+                        nint src = SDL.SDL_RWFromMem((IntPtr)data, imageSource.Length);
+                        image = SDL_image.IMG_Load_RW(src, (int)SDL.SDL_bool.SDL_TRUE);
+                        if (image != IntPtr.Zero) {
+                            ref var surface = ref RenderingUtils.AsSdlSurface(image);
+                            uint format = Unsafe.AsRef<SDL.SDL_PixelFormat>((void*)surface.format).format;
+                            if (format != SDL.SDL_PIXELFORMAT_RGB24 && format != SDL.SDL_PIXELFORMAT_RGBA8888) {
+                                // SDL is failing to blit palette surfaces, converting them
+                                nint old = image;
+                                image = SDL.SDL_ConvertSurfaceFormat(old, SDL.SDL_PIXELFORMAT_RGBA8888, 0);
+                                SDL.SDL_FreeSurface(old);
+                            }
+
+                            if (surface.h > IconSize * 2) {
+                                image = SoftwareScaler.DownscaleIcon(image, IconSize);
+                            }
+                        }
+                        cache[modpath] = image;
+                    }
+                }
+            }
+            if (image == IntPtr.Zero) {
+                continue;
+            }
+
+            ref var sdlSurface = ref RenderingUtils.AsSdlSurface(image);
+            int targetSize = icon.scale == 1f ? IconSize : MathUtils.Ceil(icon.size * icon.scale) * (IconSize / 32); // TODO research formula
+            _ = SDL.SDL_SetSurfaceColorMod(image, MathUtils.FloatToByte(icon.r), MathUtils.FloatToByte(icon.g), MathUtils.FloatToByte(icon.b));
+            //SDL.SDL_SetSurfaceAlphaMod(image, MathUtils.FloatToByte(icon.a));
+            int basePosition = (IconSize - targetSize) / 2;
+            SDL.SDL_Rect targetRect = new SDL.SDL_Rect {
+                x = basePosition,
+                y = basePosition,
+                w = targetSize,
+                h = targetSize
+            };
+            if (icon.x != 0) {
+                targetRect.x = MathUtils.Clamp(targetRect.x + MathUtils.Round(icon.x * IconSize / icon.size), 0, IconSize - targetRect.w);
+            }
+
+            if (icon.y != 0) {
+                targetRect.y = MathUtils.Clamp(targetRect.y + MathUtils.Round(icon.y * IconSize / icon.size), 0, IconSize - targetRect.h);
+            }
+
+            SDL.SDL_Rect srcRect = new SDL.SDL_Rect {
+                w = sdlSurface.h, // That is correct (cutting mip maps)
+                h = sdlSurface.h
+            };
+            _ = SDL.SDL_BlitScaled(image, ref srcRect, targetSurface, ref targetRect);
+        }
+        return IconCollection.AddIcon(targetSurface);
+    }
+
+    private static void DeserializePrototypes(LuaTable data, string type, Action<LuaTable, ErrorCollector> deserializer, IProgress<(string, string)> progress, ErrorCollector errorCollector) {
+        object? table = data[type];
+        progress.Report(("Building objects", type));
+        if (table is not LuaTable luaTable) {
+            return;
+        }
+
+        foreach (var entry in luaTable.ObjectElements) {
+            if (entry.Value is LuaTable entryTable) {
+                deserializer(entryTable, errorCollector);
+            }
+        }
+    }
+
+    private static float ParseEnergy(string? energy) {
+        if (energy is null || energy.Length < 2) {
+            return 0f;
+        }
+
+        char energyMul = energy[^2];
+        // internally store energy in megawatts / megajoules to be closer to 1
+        if (char.IsLetter(energyMul)) {
+            float energyBase = float.Parse(energy[..^2]);
+            switch (energyMul) {
+                case 'k':
+                case 'K': return energyBase * 1e-3f;
+                case 'M': return energyBase;
+                case 'G': return energyBase * 1e3f;
+                case 'T': return energyBase * 1e6f;
+                case 'P': return energyBase * 1e9f;
+                case 'E': return energyBase * 1e12f;
+                case 'Z': return energyBase * 1e15f;
+                case 'Y': return energyBase * 1e18f;
+            }
+        }
+        return float.Parse(energy[..^1]) * 1e-6f;
+    }
+
+    private void DeserializeItem(LuaTable table, ErrorCollector _) {
+        if (table.Get("type", "") == "module" && table.Get("effect", out LuaTable? moduleEffect)) {
+            string name = table.Get("name", "");
+            Module module = GetObject<Item, Module>(name);
+            module.moduleSpecification = new ModuleSpecification {
+                consumption = moduleEffect.Get("consumption", out LuaTable? t) ? t.Get("bonus", 0f) : 0f,
+                speed = moduleEffect.Get("speed", out t) ? t.Get("bonus", 0f) : 0f,
+                productivity = moduleEffect.Get("productivity", out t) ? t.Get("bonus", 0f) : 0f,
+                pollution = moduleEffect.Get("pollution", out t) ? t.Get("bonus", 0f) : 0f,
+            };
+            if (table.Get("limitation", out LuaTable? limitation)) {
+                var limitationArr = limitation.ArrayElements<string>().Select(GetObject<Recipe>).ToArray();
+                if (limitationArr.Length > 0) {
+                    module.moduleSpecification.limitation = limitationArr;
+                    foreach (var recipe in module.moduleSpecification.limitation) {
+                        recipeModules.Add(recipe, module, true);
+                    }
+                }
+            }
+
+            // Load blacklisted modules for these recipes, this will be applied later against the universal modules
+            if (table.Get("limitation_blacklist", out LuaTable? limitation_blacklist)) {
+                Recipe[] limitationArr = limitation_blacklist.ArrayElements<string>().Select(GetObject<Recipe>).ToArray();
+                if (limitationArr.Length > 0) {
+                    module.moduleSpecification.limitation_blacklist = limitationArr;
+                }
+            }
+
+            if (module.moduleSpecification.limitation == null) {
+                universalModules.Add(module);
+            }
+        }
+
+        Item item = DeserializeCommon<Item>(table, "item");
+
+        if (table.Get("place_result", out string? placeResult) && !string.IsNullOrEmpty(placeResult)) {
+            placeResults[item] = [placeResult];
+        }
+
+        item.stackSize = table.Get("stack_size", 1);
+        if (item.locName == null && table.Get("placed_as_equipment_result", out string? result)) {
+            Localize("equipment-name." + result, null);
+            if (localeBuilder.Length > 0) {
+                item.locName = FinishLocalize();
+            }
+        }
+        if (table.Get("fuel_value", out string? fuelValue)) {
+            item.fuelValue = ParseEnergy(fuelValue);
+            item.fuelResult = GetRef<Item>(table, "burnt_result");
+            if (table.Get("fuel_category", out string? category)) {
+                fuels.Add(category, item);
+            }
+        }
+
+        Product[]? launchProducts = null;
+        if (table.Get("rocket_launch_product", out LuaTable? product)) {
+            launchProducts = LoadProduct("rocket_launch_product", item.stackSize)(product).SingleElementArray();
+        }
+        else if (table.Get("rocket_launch_products", out LuaTable? products)) {
+            launchProducts = products.ArrayElements<LuaTable>().Select(LoadProduct("rocket_launch_products", item.stackSize)).ToArray();
+        }
+
+        if (launchProducts != null && launchProducts.Length > 0) {
+            var recipe = CreateSpecialRecipe(item, SpecialNames.RocketLaunch, "launched");
+            recipe.ingredients =
             [
-                .. fluid.iconSpec,
-                .. iconStr.Take(4).Select((x, n) => new FactorioIconPart("__.__/" + x) { y = -16, x = (n * 7) - 12, scale = 0.28f }),
+                new Ingredient(item, item.stackSize),
+                new Ingredient(rocketLaunch, 1)
             ];
+            recipe.products = launchProducts;
+            recipe.time = 0f; // TODO what to put here?
+        }
+    }
+
+    private Fluid SplitFluid(Fluid basic, int temperature) {
+        logger.Information("Splitting fluid {FluidName} at {Temperature}", basic.name, temperature);
+        basic.variants ??= [basic];
+        var copy = basic.Clone();
+        copy.SetTemperature(temperature);
+        copy.variants!.Add(copy); // null-forgiving: Clone was given a non-null variants.
+        if (copy.fuelValue > 0f) {
+            fuels.Add(SpecialNames.BurnableFluid, copy);
         }
 
-        /// <summary>
-        /// Process the data loaded from Factorio and the mods, and load the project specified by <paramref name="projectPath"/>.
-        /// </summary>
-        /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
-        /// <param name="data">The Lua table data (containing data.raw) that was populated by the lua scripts.</param>
-        /// <param name="prototypes">The Lua table defines.prototypes that was populated by the lua scripts.</param>
-        /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
-        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
-        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
-        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
-        /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
-        /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
-        /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
-        /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
-        public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, bool netProduction, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
-            progress.Report(("Loading", "Loading items"));
-            raw = (LuaTable?)data["raw"] ?? throw new ArgumentException("Could not load data.raw from data argument", nameof(data));
-            LuaTable itemPrototypes = (LuaTable?)prototypes?["item"] ?? throw new ArgumentException("Could not load prototypes.item from data argument", nameof(prototypes));
-            foreach (object prototypeName in itemPrototypes.ObjectElements.Keys) {
-                DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress, errorCollector);
-            }
+        fuels.Add(SpecialNames.SpecificFluid + basic.name, copy);
+        return copy;
+    }
 
-            Module[] universalModulesArray = [.. universalModules];
-            IEnumerable<Module> FilteredModules(Recipe item) {
-                // When the blacklist is available, filter out modules that are in this blacklist
-                Func<Module, bool> AllowedModulesFilter(Recipe key) {
-                    return module => module.moduleSpecification.limitation_blacklist == null || !module.moduleSpecification.limitation_blacklist.Contains(key);
-                }
-
-                return universalModulesArray.Where(AllowedModulesFilter(item));
-            }
-            recipeModules.Seal(FilteredModules);
-
-            allModules.AddRange(allObjects.OfType<Module>());
-            progress.Report(("Loading", "Loading fluids"));
-            DeserializePrototypes(raw, "fluid", DeserializeFluid, progress, errorCollector);
-            progress.Report(("Loading", "Loading recipes"));
-            DeserializePrototypes(raw, "recipe", DeserializeRecipe, progress, errorCollector);
-            progress.Report(("Loading", "Loading technologies"));
-            DeserializePrototypes(raw, "technology", DeserializeTechnology, progress, errorCollector);
-            progress.Report(("Loading", "Loading entities"));
-            DeserializeRocketEntities(raw["rocket-silo-rocket"] as LuaTable);
-            LuaTable entityPrototypes = (LuaTable?)prototypes["entity"] ?? throw new ArgumentException("Could not load prototypes.item from data argument", nameof(prototypes));
-            foreach (object prototypeName in entityPrototypes.ObjectElements.Keys) {
-                DeserializePrototypes(raw, (string)prototypeName, DeserializeEntity, progress, errorCollector);
-            }
-
-            ParseModYafcHandles(data["script_enabled"] as LuaTable);
-            progress.Report(("Post-processing", "Computing maps"));
-            // Deterministically sort all objects
-
-            allObjects.Sort((a, b) => a.sortingOrder == b.sortingOrder ? string.Compare(a.typeDotName, b.typeDotName, StringComparison.Ordinal) : a.sortingOrder - b.sortingOrder);
-            for (int i = 0; i < allObjects.Count; i++) {
-                allObjects[i].id = (FactorioId)i;
-            }
-
-            UpdateSplitFluids();
-            var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
-            UpdateRecipeIngredientFluids();
-            UpdateRecipeCatalysts();
-            CalculateMaps(netProduction);
-            ExportBuiltData();
-            progress.Report(("Post-processing", "Calculating dependencies"));
-            Dependencies.Calculate();
-            TechnologyLoopsFinder.FindTechnologyLoops();
-            progress.Report(("Post-processing", "Creating project"));
-            Project project = Project.ReadFromFile(projectPath, errorCollector);
-            Analysis.ProcessAnalyses(progress, project, errorCollector);
-            progress.Report(("Rendering icons", ""));
-            iconRenderedProgress = progress;
-            iconRenderTask.Wait();
-            return project;
+    private void DeserializeFluid(LuaTable table, ErrorCollector _) {
+        var fluid = DeserializeCommon<Fluid>(table, "fluid");
+        fluid.originalName = fluid.name;
+        if (table.Get("fuel_value", out string? fuelValue)) {
+            fluid.fuelValue = ParseEnergy(fuelValue);
+            fuels.Add(SpecialNames.BurnableFluid, fluid);
+        }
+        fuels.Add(SpecialNames.SpecificFluid + fluid.name, fluid);
+        if (table.Get("heat_capacity", out string? heatCap)) {
+            fluid.heatCapacity = ParseEnergy(heatCap);
         }
 
-        private IProgress<(string, string)>? iconRenderedProgress;
+        fluid.temperatureRange = new TemperatureRange(table.Get("default_temperature", 0), table.Get("max_temperature", 0));
+    }
 
-        private Icon CreateSimpleIcon(Dictionary<(string mod, string path), IntPtr> cache, string graphicsPath) => CreateIconFromSpec(cache, new FactorioIconPart("__core__/graphics/" + graphicsPath + ".png"));
-
-        private void RenderIcons() {
-            Dictionary<(string mod, string path), IntPtr> cache = [];
-            try {
-                foreach (char digit in "0123456789d") {
-                    cache[(".", digit.ToString())] = SDL_image.IMG_Load("Data/Digits/" + digit + ".png");
-                }
-
-                DataUtils.NoFuelIcon = CreateSimpleIcon(cache, "fuel-icon-red");
-                DataUtils.WarningIcon = CreateSimpleIcon(cache, "warning-icon");
-                DataUtils.HandIcon = CreateSimpleIcon(cache, "hand");
-
-                Dictionary<string, Icon> simpleSpritesCache = [];
-                int rendered = 0;
-
-                foreach (var o in allObjects) {
-                    if (++rendered % 100 == 0) {
-                        iconRenderedProgress?.Report(("Rendering icons", $"{rendered}/{allObjects.Count}"));
-                    }
-
-                    if (o.iconSpec != null && o.iconSpec.Length > 0) {
-                        bool simpleSprite = o.iconSpec.Length == 1 && o.iconSpec[0].IsSimple();
-                        if (simpleSprite && simpleSpritesCache.TryGetValue(o.iconSpec[0].path, out var icon)) {
-                            o.icon = icon;
-                            continue;
-                        }
-
-                        try {
-                            o.icon = CreateIconFromSpec(cache, o.iconSpec);
-                            if (simpleSprite) {
-                                simpleSpritesCache[o.iconSpec[0].path] = o.icon;
-                            }
-                        }
-                        catch (Exception ex) {
-                            Console.Error.WriteException(ex);
-                        }
-                    }
-                    else if (o is Recipe recipe && recipe.mainProduct != null) {
-                        o.icon = recipe.mainProduct.icon;
-                    }
-                }
-            }
-            finally {
-                foreach (var (_, image) in cache) {
-                    if (image != IntPtr.Zero) {
-                        SDL.SDL_FreeSurface(image);
-                    }
-                }
-            }
+    private Goods? LoadItemOrFluid(LuaTable table, bool useTemperature, out string? name, string nameField = "name") {
+        if (!table.Get(nameField, out name)) {
+            return null;
         }
 
-        private unsafe Icon CreateIconFromSpec(Dictionary<(string mod, string path), IntPtr> cache, params FactorioIconPart[] spec) {
-            const int IconSize = IconCollection.IconSize;
-            nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
-            _ = SDL.SDL_SetSurfaceBlendMode(targetSurface, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
-            foreach (var icon in spec) {
-                var modpath = FactorioDataSource.ResolveModPath("", icon.path);
-                if (!cache.TryGetValue(modpath, out nint image)) {
-                    byte[] imageSource = FactorioDataSource.ReadModFile(modpath.mod, modpath.path);
-                    if (imageSource == null) {
-                        image = cache[modpath] = IntPtr.Zero;
+        if (table.Get("type", out string? type) && type == "fluid") {
+            if (useTemperature) {
+                return GetFluidFixedTemp(name, table.Get("temperature", out int temperature) ? temperature : 0);
+            }
+
+            return GetObject<Fluid>(name);
+        }
+
+        return GetObject<Item>(name);
+    }
+
+    private bool LoadItemData(LuaTable table, bool useTemperature, string typeDotName, [NotNull] out Goods? goods, out float amount) {
+        if (table.Get<string>("name", out _)) {
+            goods = LoadItemOrFluid(table, useTemperature, out string? name);
+            _ = table.Get("amount", out amount);
+            if (goods is null) {
+                throw new NotSupportedException($"Could not load one of the products for {typeDotName}, possibly named '{name}'.");
+            }
+            return true; // true means 'may have extra data'
+        }
+        else {
+            _ = table.Get(2, out amount);
+            if (!table.Get(1, out string? name)) {
+                throw new NotSupportedException($"Could not load one of the products for {typeDotName}, due to a missing name.");
+            }
+            goods = GetObject<Item>(name);
+            return false;
+        }
+    }
+
+    private readonly StringBuilder localeBuilder = new StringBuilder();
+
+    private void Localize(object obj) {
+        if (obj is LuaTable table) {
+            if (!table.Get(1, out string? key)) {
+                return;
+            }
+
+            Localize(key, table);
+        }
+        else {
+            _ = localeBuilder.Append(obj);
+        }
+    }
+
+    private string FinishLocalize() {
+        _ = localeBuilder.Replace("\\n", "\n");
+
+        // Cleaning up tags using simple state machine
+        // 0 = outside of tag, 1 = first potential tag char, 2 = inside possible tag, 3 = inside definite tag
+        // tag is definite when it contains '=' or starts with '/' or '.'
+        int state = 0, tagStart = 0;
+        for (int i = 0; i < localeBuilder.Length; i++) {
+            char chr = localeBuilder[i];
+            switch (state) {
+                case 0:
+                    if (chr == '[') {
+                        state = 1;
+                        tagStart = i;
+                    }
+                    break;
+                case 1:
+                    if (chr == ']') {
+                        state = 0;
                     }
                     else {
-                        fixed (byte* data = imageSource) {
-                            nint src = SDL.SDL_RWFromMem((IntPtr)data, imageSource.Length);
-                            image = SDL_image.IMG_Load_RW(src, (int)SDL.SDL_bool.SDL_TRUE);
-                            if (image != IntPtr.Zero) {
-                                ref var surface = ref RenderingUtils.AsSdlSurface(image);
-                                uint format = Unsafe.AsRef<SDL.SDL_PixelFormat>((void*)surface.format).format;
-                                if (format != SDL.SDL_PIXELFORMAT_RGB24 && format != SDL.SDL_PIXELFORMAT_RGBA8888) {
-                                    // SDL is failing to blit palette surfaces, converting them
-                                    nint old = image;
-                                    image = SDL.SDL_ConvertSurfaceFormat(old, SDL.SDL_PIXELFORMAT_RGBA8888, 0);
-                                    SDL.SDL_FreeSurface(old);
-                                }
-
-                                if (surface.h > IconSize * 2) {
-                                    image = SoftwareScaler.DownscaleIcon(image, IconSize);
-                                }
-                            }
-                            cache[modpath] = image;
-                        }
+                        state = (chr is '/' or '.') ? 3 : 2;
                     }
-                }
-                if (image == IntPtr.Zero) {
-                    continue;
-                }
 
-                ref var sdlSurface = ref RenderingUtils.AsSdlSurface(image);
-                int targetSize = icon.scale == 1f ? IconSize : MathUtils.Ceil(icon.size * icon.scale) * (IconSize / 32); // TODO research formula
-                _ = SDL.SDL_SetSurfaceColorMod(image, MathUtils.FloatToByte(icon.r), MathUtils.FloatToByte(icon.g), MathUtils.FloatToByte(icon.b));
-                //SDL.SDL_SetSurfaceAlphaMod(image, MathUtils.FloatToByte(icon.a));
-                int basePosition = (IconSize - targetSize) / 2;
-                SDL.SDL_Rect targetRect = new SDL.SDL_Rect {
-                    x = basePosition,
-                    y = basePosition,
-                    w = targetSize,
-                    h = targetSize
-                };
-                if (icon.x != 0) {
-                    targetRect.x = MathUtils.Clamp(targetRect.x + MathUtils.Round(icon.x * IconSize / icon.size), 0, IconSize - targetRect.w);
-                }
+                    break;
+                case 2:
+                    if (chr == '=') {
+                        state = 3;
+                    }
+                    else if (chr == ']') {
+                        state = 0;
+                    }
 
-                if (icon.y != 0) {
-                    targetRect.y = MathUtils.Clamp(targetRect.y + MathUtils.Round(icon.y * IconSize / icon.size), 0, IconSize - targetRect.h);
-                }
-
-                SDL.SDL_Rect srcRect = new SDL.SDL_Rect {
-                    w = sdlSurface.h, // That is correct (cutting mip maps)
-                    h = sdlSurface.h
-                };
-                _ = SDL.SDL_BlitScaled(image, ref srcRect, targetSurface, ref targetRect);
+                    break;
+                case 3:
+                    if (chr == ']') {
+                        _ = localeBuilder.Remove(tagStart, i - tagStart + 1);
+                        i = tagStart - 1;
+                        state = 0;
+                    }
+                    break;
             }
-            return IconCollection.AddIcon(targetSurface);
         }
 
-        private static void DeserializePrototypes(LuaTable data, string type, Action<LuaTable, ErrorCollector> deserializer, IProgress<(string, string)> progress, ErrorCollector errorCollector) {
-            object? table = data[type];
-            progress.Report(("Building objects", type));
-            if (table is not LuaTable luaTable) {
+        string s = localeBuilder.ToString();
+        _ = localeBuilder.Clear();
+        return s;
+    }
+
+    private void Localize(string? key, LuaTable? table) {
+        if (string.IsNullOrEmpty(key)) {
+            if (table == null) {
                 return;
             }
 
-            foreach (var entry in luaTable.ObjectElements) {
-                if (entry.Value is LuaTable entryTable) {
-                    deserializer(entryTable, errorCollector);
+            foreach (object? elem in table.ArrayElements) {
+                if (elem is LuaTable sub) {
+                    Localize(sub);
+                }
+                else {
+                    _ = localeBuilder.Append(elem);
                 }
             }
+            return;
         }
 
-        private static float ParseEnergy(string? energy) {
-            if (energy is null || energy.Length < 2) {
-                return 0f;
+        key = FactorioLocalization.Localize(key);
+        if (key == null) {
+            if (table != null) {
+                _ = localeBuilder.Append(string.Join(" ", table.ArrayElements<string>()));
             }
 
-            char energyMul = energy[^2];
-            // internally store energy in megawatts / megajoules to be closer to 1
-            if (char.IsLetter(energyMul)) {
-                float energyBase = float.Parse(energy[..^2]);
-                switch (energyMul) {
-                    case 'k':
-                    case 'K': return energyBase * 1e-3f;
-                    case 'M': return energyBase;
-                    case 'G': return energyBase * 1e3f;
-                    case 'T': return energyBase * 1e6f;
-                    case 'P': return energyBase * 1e9f;
-                    case 'E': return energyBase * 1e12f;
-                    case 'Z': return energyBase * 1e15f;
-                    case 'Y': return energyBase * 1e18f;
-                }
-            }
-            return float.Parse(energy[..^1]) * 1e-6f;
+            return;
         }
 
-        private void DeserializeItem(LuaTable table, ErrorCollector _) {
-            if (table.Get("type", "") == "module" && table.Get("effect", out LuaTable? moduleEffect)) {
-                string name = table.Get("name", "");
-                Module module = GetObject<Item, Module>(name);
-                module.moduleSpecification = new ModuleSpecification {
-                    consumption = moduleEffect.Get("consumption", out LuaTable? t) ? t.Get("bonus", 0f) : 0f,
-                    speed = moduleEffect.Get("speed", out t) ? t.Get("bonus", 0f) : 0f,
-                    productivity = moduleEffect.Get("productivity", out t) ? t.Get("bonus", 0f) : 0f,
-                    pollution = moduleEffect.Get("pollution", out t) ? t.Get("bonus", 0f) : 0f,
-                };
-                if (table.Get("limitation", out LuaTable? limitation)) {
-                    var limitationArr = limitation.ArrayElements<string>().Select(GetObject<Recipe>).ToArray();
-                    if (limitationArr.Length > 0) {
-                        module.moduleSpecification.limitation = limitationArr;
-                        foreach (var recipe in module.moduleSpecification.limitation) {
-                            recipeModules.Add(recipe, module, true);
-                        }
-                    }
-                }
-
-                // Load blacklisted modules for these recipes, this will be applied later against the universal modules
-                if (table.Get("limitation_blacklist", out LuaTable? limitation_blacklist)) {
-                    Recipe[] limitationArr = limitation_blacklist.ArrayElements<string>().Select(GetObject<Recipe>).ToArray();
-                    if (limitationArr.Length > 0) {
-                        module.moduleSpecification.limitation_blacklist = limitationArr;
-                    }
-                }
-
-                if (module.moduleSpecification.limitation == null) {
-                    universalModules.Add(module);
-                }
-            }
-
-            Item item = DeserializeCommon<Item>(table, "item");
-
-            if (table.Get("place_result", out string? placeResult) && !string.IsNullOrEmpty(placeResult)) {
-                placeResults[item] = [placeResult];
-            }
-
-            item.stackSize = table.Get("stack_size", 1);
-            if (item.locName == null && table.Get("placed_as_equipment_result", out string? result)) {
-                Localize("equipment-name." + result, null);
-                if (localeBuilder.Length > 0) {
-                    item.locName = FinishLocalize();
-                }
-            }
-            if (table.Get("fuel_value", out string? fuelValue)) {
-                item.fuelValue = ParseEnergy(fuelValue);
-                item.fuelResult = GetRef<Item>(table, "burnt_result");
-                if (table.Get("fuel_category", out string? category)) {
-                    fuels.Add(category, item);
-                }
-            }
-
-            Product[]? launchProducts = null;
-            if (table.Get("rocket_launch_product", out LuaTable? product)) {
-                launchProducts = LoadProduct("rocket_launch_product", item.stackSize)(product).SingleElementArray();
-            }
-            else if (table.Get("rocket_launch_products", out LuaTable? products)) {
-                launchProducts = products.ArrayElements<LuaTable>().Select(LoadProduct("rocket_launch_products", item.stackSize)).ToArray();
-            }
-
-            if (launchProducts != null && launchProducts.Length > 0) {
-                var recipe = CreateSpecialRecipe(item, SpecialNames.RocketLaunch, "launched");
-                recipe.ingredients =
-                [
-                    new Ingredient(item, item.stackSize),
-                    new Ingredient(rocketLaunch, 1)
-                ];
-                recipe.products = launchProducts;
-                recipe.time = 0f; // TODO what to put here?
-            }
+        if (!key.Contains("__")) {
+            _ = localeBuilder.Append(key);
+            return;
         }
 
-        private Fluid SplitFluid(Fluid basic, int temperature) {
-            logger.Information("Splitting fluid {FluidName} at {Temperature}", basic.name, temperature);
-            basic.variants ??= [basic];
-            var copy = basic.Clone();
-            copy.SetTemperature(temperature);
-            copy.variants!.Add(copy); // null-forgiving: Clone was given a non-null variants.
-            if (copy.fuelValue > 0f) {
-                fuels.Add(SpecialNames.BurnableFluid, copy);
+        using var parts = ((IEnumerable<string>)key.Split("__")).GetEnumerator();
+        while (parts.MoveNext()) {
+            _ = localeBuilder.Append(parts.Current);
+            if (!parts.MoveNext()) {
+                break;
             }
 
-            fuels.Add(SpecialNames.SpecificFluid + basic.name, copy);
-            return copy;
-        }
-
-        private void DeserializeFluid(LuaTable table, ErrorCollector _) {
-            var fluid = DeserializeCommon<Fluid>(table, "fluid");
-            fluid.originalName = fluid.name;
-            if (table.Get("fuel_value", out string? fuelValue)) {
-                fluid.fuelValue = ParseEnergy(fuelValue);
-                fuels.Add(SpecialNames.BurnableFluid, fluid);
-            }
-            fuels.Add(SpecialNames.SpecificFluid + fluid.name, fluid);
-            if (table.Get("heat_capacity", out string? heatCap)) {
-                fluid.heatCapacity = ParseEnergy(heatCap);
-            }
-
-            fluid.temperatureRange = new TemperatureRange(table.Get("default_temperature", 0), table.Get("max_temperature", 0));
-        }
-
-        private Goods? LoadItemOrFluid(LuaTable table, bool useTemperature, out string? name, string nameField = "name") {
-            if (!table.Get(nameField, out name)) {
-                return null;
-            }
-
-            if (table.Get("type", out string? type) && type == "fluid") {
-                if (useTemperature) {
-                    return GetFluidFixedTemp(name, table.Get("temperature", out int temperature) ? temperature : 0);
-                }
-
-                return GetObject<Fluid>(name);
-            }
-
-            return GetObject<Item>(name);
-        }
-
-        private bool LoadItemData(LuaTable table, bool useTemperature, string typeDotName, [NotNull] out Goods? goods, out float amount) {
-            if (table.Get<string>("name", out _)) {
-                goods = LoadItemOrFluid(table, useTemperature, out string? name);
-                _ = table.Get("amount", out amount);
-                if (goods is null) {
-                    throw new NotSupportedException($"Could not load one of the products for {typeDotName}, possibly named '{name}'.");
-                }
-                return true; // true means 'may have extra data'
-            }
-            else {
-                _ = table.Get(2, out amount);
-                if (!table.Get(1, out string? name)) {
-                    throw new NotSupportedException($"Could not load one of the products for {typeDotName}, due to a missing name.");
-                }
-                goods = GetObject<Item>(name);
-                return false;
-            }
-        }
-
-        private readonly StringBuilder localeBuilder = new StringBuilder();
-
-        private void Localize(object obj) {
-            if (obj is LuaTable table) {
-                if (!table.Get(1, out string? key)) {
-                    return;
-                }
-
-                Localize(key, table);
-            }
-            else {
-                _ = localeBuilder.Append(obj);
-            }
-        }
-
-        private string FinishLocalize() {
-            _ = localeBuilder.Replace("\\n", "\n");
-
-            // Cleaning up tags using simple state machine
-            // 0 = outside of tag, 1 = first potential tag char, 2 = inside possible tag, 3 = inside definite tag
-            // tag is definite when it contains '=' or starts with '/' or '.'
-            int state = 0, tagStart = 0;
-            for (int i = 0; i < localeBuilder.Length; i++) {
-                char chr = localeBuilder[i];
-                switch (state) {
-                    case 0:
-                        if (chr == '[') {
-                            state = 1;
-                            tagStart = i;
-                        }
-                        break;
-                    case 1:
-                        if (chr == ']') {
-                            state = 0;
-                        }
-                        else {
-                            state = (chr is '/' or '.') ? 3 : 2;
-                        }
-
-                        break;
-                    case 2:
-                        if (chr == '=') {
-                            state = 3;
-                        }
-                        else if (chr == ']') {
-                            state = 0;
-                        }
-
-                        break;
-                    case 3:
-                        if (chr == ']') {
-                            _ = localeBuilder.Remove(tagStart, i - tagStart + 1);
-                            i = tagStart - 1;
-                            state = 0;
-                        }
-                        break;
-                }
-            }
-
-            string s = localeBuilder.ToString();
-            _ = localeBuilder.Clear();
-            return s;
-        }
-
-        private void Localize(string? key, LuaTable? table) {
-            if (string.IsNullOrEmpty(key)) {
-                if (table == null) {
-                    return;
-                }
-
-                foreach (object? elem in table.ArrayElements) {
-                    if (elem is LuaTable sub) {
-                        Localize(sub);
-                    }
-                    else {
-                        _ = localeBuilder.Append(elem);
-                    }
-                }
-                return;
-            }
-
-            key = FactorioLocalization.Localize(key);
-            if (key == null) {
-                if (table != null) {
-                    _ = localeBuilder.Append(string.Join(" ", table.ArrayElements<string>()));
-                }
-
-                return;
-            }
-
-            if (!key.Contains("__")) {
-                _ = localeBuilder.Append(key);
-                return;
-            }
-
-            using var parts = ((IEnumerable<string>)key.Split("__")).GetEnumerator();
-            while (parts.MoveNext()) {
-                _ = localeBuilder.Append(parts.Current);
+            string control = parts.Current;
+            if (control is "ITEM" or "FLUID" or "RECIPE" or "ENTITY") {
                 if (!parts.MoveNext()) {
                     break;
                 }
 
-                string control = parts.Current;
-                if (control is "ITEM" or "FLUID" or "RECIPE" or "ENTITY") {
-                    if (!parts.MoveNext()) {
-                        break;
-                    }
+                string subKey = control.ToLowerInvariant() + "-name." + parts.Current;
+                Localize(subKey, null);
+            }
+            else if (control == "CONTROL") {
+                if (!parts.MoveNext()) {
+                    break;
+                }
 
-                    string subKey = control.ToLowerInvariant() + "-name." + parts.Current;
-                    Localize(subKey, null);
+                _ = localeBuilder.Append(parts.Current);
+            }
+            else if (control == "ALT_CONTROL") {
+                if (!parts.MoveNext() || !parts.MoveNext()) {
+                    break;
                 }
-                else if (control == "CONTROL") {
-                    if (!parts.MoveNext()) {
-                        break;
-                    }
 
-                    _ = localeBuilder.Append(parts.Current);
+                _ = localeBuilder.Append(parts.Current);
+            }
+            else if (table != null && int.TryParse(control, out int i)) {
+                if (table.Get(i + 1, out string? s)) {
+                    Localize(s, null);
                 }
-                else if (control == "ALT_CONTROL") {
-                    if (!parts.MoveNext() || !parts.MoveNext()) {
-                        break;
-                    }
-
-                    _ = localeBuilder.Append(parts.Current);
+                else if (table.Get(i + 1, out LuaTable? t)) {
+                    Localize(t);
                 }
-                else if (table != null && int.TryParse(control, out int i)) {
-                    if (table.Get(i + 1, out string? s)) {
-                        Localize(s, null);
-                    }
-                    else if (table.Get(i + 1, out LuaTable? t)) {
-                        Localize(t);
-                    }
-                    else if (table.Get(i + 1, out float f)) {
-                        _ = localeBuilder.Append(f);
-                    }
+                else if (table.Get(i + 1, out float f)) {
+                    _ = localeBuilder.Append(f);
                 }
-                else if (control.StartsWith("plural")) {
-                    _ = localeBuilder.Append("(???)");
-                    if (!parts.MoveNext()) {
-                        break;
-                    }
-                }
-                else {
-                    // Not supported token... Append everything else as-is
-                    while (parts.MoveNext()) {
-                        _ = localeBuilder.Append(parts.Current);
-                    }
-
+            }
+            else if (control.StartsWith("plural")) {
+                _ = localeBuilder.Append("(???)");
+                if (!parts.MoveNext()) {
                     break;
                 }
             }
+            else {
+                // Not supported token... Append everything else as-is
+                while (parts.MoveNext()) {
+                    _ = localeBuilder.Append(parts.Current);
+                }
+
+                break;
+            }
+        }
+    }
+
+    private T DeserializeCommon<T>(LuaTable table, string prototypeType) where T : FactorioObject, new() {
+        if (!table.Get("name", out string? name)) {
+            throw new NotSupportedException($"Read a definition of a {prototypeType} that does not have a name.");
+        }
+        var target = GetObject<T>(name);
+        target.factorioType = table.Get("type", "");
+
+        if (table.Get("localised_name", out object? loc)) {  // Keep UK spelling for Factorio/LUA data objects
+            Localize(loc);
+        }
+        else {
+            Localize(prototypeType + "-name." + target.name, null);
         }
 
-        private T DeserializeCommon<T>(LuaTable table, string prototypeType) where T : FactorioObject, new() {
-            if (!table.Get("name", out string? name)) {
-                throw new NotSupportedException($"Read a definition of a {prototypeType} that does not have a name.");
-            }
-            var target = GetObject<T>(name);
-            target.factorioType = table.Get("type", "");
+        target.locName = localeBuilder.Length == 0 ? null! : FinishLocalize(); // null-forgiving: We have another chance at the end of CalculateMaps.
 
-            if (table.Get("localised_name", out object? loc)) {  // Keep UK spelling for Factorio/LUA data objects
-                Localize(loc);
-            }
-            else {
-                Localize(prototypeType + "-name." + target.name, null);
-            }
-
-            target.locName = localeBuilder.Length == 0 ? null! : FinishLocalize(); // null-forgiving: We have another chance at the end of CalculateMaps.
-
-            if (table.Get("localised_description", out loc)) {  // Keep UK spelling for Factorio/LUA data objects
-                Localize(loc);
-            }
-            else {
-                Localize(prototypeType + "-description." + target.name, null);
-            }
-
-            target.locDescr = localeBuilder.Length == 0 ? null : FinishLocalize();
-
-            _ = table.Get("icon_size", out float defaultIconSize);
-            if (table.Get("icon", out string? s)) {
-                target.iconSpec = new FactorioIconPart(s) { size = defaultIconSize }.SingleElementArray();
-            }
-            else if (table.Get("icons", out LuaTable? iconList)) {
-                target.iconSpec = iconList.ArrayElements<LuaTable>().Select(x => {
-                    if (!x.Get("icon", out string? path)) {
-                        throw new NotSupportedException($"One of the icon layers for {name} does not have a path.");
-                    }
-                    FactorioIconPart part = new FactorioIconPart(path);
-                    _ = x.Get("icon_size", out part.size, defaultIconSize);
-                    _ = x.Get("scale", out part.scale, 1f);
-                    if (x.Get("shift", out LuaTable? shift)) {
-                        _ = shift.Get(1, out part.x);
-                        _ = shift.Get(2, out part.y);
-                    }
-
-                    if (x.Get("tint", out LuaTable? tint)) {
-                        _ = tint.Get("r", out part.r, 1f);
-                        _ = tint.Get("g", out part.g, 1f);
-                        _ = tint.Get("b", out part.b, 1f);
-                        _ = tint.Get("a", out part.a, 1f);
-                    }
-                    return part;
-                }).ToArray();
-            }
-
-            return target;
+        if (table.Get("localised_description", out loc)) {  // Keep UK spelling for Factorio/LUA data objects
+            Localize(loc);
         }
+        else {
+            Localize(prototypeType + "-description." + target.name, null);
+        }
+
+        target.locDescr = localeBuilder.Length == 0 ? null : FinishLocalize();
+
+        _ = table.Get("icon_size", out float defaultIconSize);
+        if (table.Get("icon", out string? s)) {
+            target.iconSpec = new FactorioIconPart(s) { size = defaultIconSize }.SingleElementArray();
+        }
+        else if (table.Get("icons", out LuaTable? iconList)) {
+            target.iconSpec = iconList.ArrayElements<LuaTable>().Select(x => {
+                if (!x.Get("icon", out string? path)) {
+                    throw new NotSupportedException($"One of the icon layers for {name} does not have a path.");
+                }
+                FactorioIconPart part = new FactorioIconPart(path);
+                _ = x.Get("icon_size", out part.size, defaultIconSize);
+                _ = x.Get("scale", out part.scale, 1f);
+                if (x.Get("shift", out LuaTable? shift)) {
+                    _ = shift.Get(1, out part.x);
+                    _ = shift.Get(2, out part.y);
+                }
+
+                if (x.Get("tint", out LuaTable? tint)) {
+                    _ = tint.Get("r", out part.r, 1f);
+                    _ = tint.Get("g", out part.g, 1f);
+                    _ = tint.Get("b", out part.b, 1f);
+                    _ = tint.Get("a", out part.a, 1f);
+                }
+                return part;
+            }).ToArray();
+        }
+
+        return target;
     }
 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -3,664 +3,663 @@ using System.Collections.Generic;
 using System.Linq;
 using Yafc.Model;
 
-namespace Yafc.Parser {
-    internal partial class FactorioDataDeserializer {
-        private readonly List<FactorioObject> allObjects = [];
-        private readonly List<FactorioObject> rootAccessible = [];
-        private readonly Dictionary<(Type? type, string? name), FactorioObject> registeredObjects = [];
-        private readonly DataBucket<string, Goods> fuels = new DataBucket<string, Goods>();
-        private readonly DataBucket<Entity, string> fuelUsers = new DataBucket<Entity, string>();
-        private readonly DataBucket<string, RecipeOrTechnology> recipeCategories = new DataBucket<string, RecipeOrTechnology>();
-        private readonly DataBucket<EntityCrafter, string> recipeCrafters = new DataBucket<EntityCrafter, string>();
-        private readonly DataBucket<Recipe, Module> recipeModules = new DataBucket<Recipe, Module>();
-        private readonly Dictionary<Item, List<string>> placeResults = [];
-        private readonly List<Module> universalModules = [];
-        private readonly List<Module> allModules = [];
-        private readonly HashSet<Item> sciencePacks = [];
-        private readonly Dictionary<string, List<Fluid>> fluidVariants = [];
-        private readonly Dictionary<string, FactorioObject> formerAliases = [];
-        private readonly Dictionary<string, int> rocketInventorySizes = [];
+namespace Yafc.Parser;
+internal partial class FactorioDataDeserializer {
+    private readonly List<FactorioObject> allObjects = [];
+    private readonly List<FactorioObject> rootAccessible = [];
+    private readonly Dictionary<(Type? type, string? name), FactorioObject> registeredObjects = [];
+    private readonly DataBucket<string, Goods> fuels = new DataBucket<string, Goods>();
+    private readonly DataBucket<Entity, string> fuelUsers = new DataBucket<Entity, string>();
+    private readonly DataBucket<string, RecipeOrTechnology> recipeCategories = new DataBucket<string, RecipeOrTechnology>();
+    private readonly DataBucket<EntityCrafter, string> recipeCrafters = new DataBucket<EntityCrafter, string>();
+    private readonly DataBucket<Recipe, Module> recipeModules = new DataBucket<Recipe, Module>();
+    private readonly Dictionary<Item, List<string>> placeResults = [];
+    private readonly List<Module> universalModules = [];
+    private readonly List<Module> allModules = [];
+    private readonly HashSet<Item> sciencePacks = [];
+    private readonly Dictionary<string, List<Fluid>> fluidVariants = [];
+    private readonly Dictionary<string, FactorioObject> formerAliases = [];
+    private readonly Dictionary<string, int> rocketInventorySizes = [];
 
-        private readonly bool expensiveRecipes;
+    private readonly bool expensiveRecipes;
 
-        private readonly Recipe generatorProduction;
-        private readonly Recipe reactorProduction;
-        private readonly Special voidEnergy;
-        private readonly Special heat;
-        private readonly Special electricity;
-        private readonly Special rocketLaunch;
-        private readonly Special researchUnit;
-        private readonly EntityEnergy voidEntityEnergy;
-        private readonly EntityEnergy laborEntityEnergy;
-        private Entity? character;
-        private readonly Version factorioVersion;
+    private readonly Recipe generatorProduction;
+    private readonly Recipe reactorProduction;
+    private readonly Special voidEnergy;
+    private readonly Special heat;
+    private readonly Special electricity;
+    private readonly Special rocketLaunch;
+    private readonly Special researchUnit;
+    private readonly EntityEnergy voidEntityEnergy;
+    private readonly EntityEnergy laborEntityEnergy;
+    private Entity? character;
+    private readonly Version factorioVersion;
 
-        private static readonly Version v0_18 = new Version(0, 18);
+    private static readonly Version v0_18 = new Version(0, 18);
 
-        public FactorioDataDeserializer(bool expensiveRecipes, Version factorioVersion) {
-            this.expensiveRecipes = expensiveRecipes;
-            this.factorioVersion = factorioVersion;
+    public FactorioDataDeserializer(bool expensiveRecipes, Version factorioVersion) {
+        this.expensiveRecipes = expensiveRecipes;
+        this.factorioVersion = factorioVersion;
 
-            Special createSpecialObject(bool isPower, string name, string locName, string locDescr, string icon, string signal) {
-                var obj = GetObject<Special>(name);
-                obj.virtualSignal = signal;
-                obj.factorioType = "special";
-                obj.locName = locName;
-                obj.locDescr = locDescr;
-                obj.iconSpec = new FactorioIconPart(icon).SingleElementArray();
-                obj.power = isPower;
-                if (isPower) {
-                    obj.fuelValue = 1f;
+        Special createSpecialObject(bool isPower, string name, string locName, string locDescr, string icon, string signal) {
+            var obj = GetObject<Special>(name);
+            obj.virtualSignal = signal;
+            obj.factorioType = "special";
+            obj.locName = locName;
+            obj.locDescr = locDescr;
+            obj.iconSpec = new FactorioIconPart(icon).SingleElementArray();
+            obj.power = isPower;
+            if (isPower) {
+                obj.fuelValue = 1f;
+            }
+
+            return obj;
+        }
+
+        electricity = createSpecialObject(true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
+            "__core__/graphics/icons/alerts/electricity-icon-unplugged.png", "signal-E");
+        fuels.Add(SpecialNames.Electricity, electricity);
+
+        heat = createSpecialObject(true, SpecialNames.Heat, "Heat", "This is an object that represents heat energy", "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
+        fuels.Add(SpecialNames.Heat, heat);
+
+        voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
+        fuels.Add(SpecialNames.Void, voidEnergy);
+        rootAccessible.Add(voidEnergy);
+
+        rocketLaunch = createSpecialObject(false, SpecialNames.RocketLaunch, "Rocket launch slot", "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/02-rocket.png", "signal-R");
+        researchUnit = createSpecialObject(false, SpecialNames.ResearchUnit, "Research", "This represents one unit of a research task.", "__base__/graphics/icons/compilatron.png", "signal-L");
+        researchUnit.isResearch = true;
+        Analysis.ExcludeFromAnalysis<CostAnalysis>(researchUnit);
+
+        generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, "generating");
+        generatorProduction.products = new Product(electricity, 1f).SingleElementArray();
+        generatorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
+        generatorProduction.ingredients = [];
+
+        reactorProduction = CreateSpecialRecipe(heat, SpecialNames.ReactorRecipe, "generating");
+        reactorProduction.products = new Product(heat, 1f).SingleElementArray();
+        reactorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
+        reactorProduction.ingredients = [];
+
+        voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
+        laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
+    }
+
+    private T GetObject<T>(string name) where T : FactorioObject, new() {
+        return GetObject<T, T>(name);
+    }
+
+    private TActual GetObject<TNominal, TActual>(string name) where TNominal : FactorioObject where TActual : TNominal, new() {
+        var key = (typeof(TNominal), name);
+        if (registeredObjects.TryGetValue(key, out FactorioObject? existing)) {
+            return (TActual)existing;
+        }
+
+        TActual newItem = new TActual { name = name };
+        allObjects.Add(newItem);
+        registeredObjects[key] = newItem;
+        return newItem;
+    }
+
+    private int Skip(int from, FactorioObjectSortOrder sortOrder) {
+        for (; from < allObjects.Count; from++) {
+            if (allObjects[from].sortingOrder != sortOrder) {
+                break;
+            }
+        }
+
+        return from;
+    }
+
+    private void ExportBuiltData() {
+        Database.rootAccessible = rootAccessible.ToArray();
+        Database.objectsByTypeName = allObjects.ToDictionary(x => x.typeDotName);
+        foreach (var alias in formerAliases) {
+            _ = Database.objectsByTypeName.TryAdd(alias.Key, alias.Value);
+        }
+
+        Database.allSciencePacks = sciencePacks.ToArray();
+        Database.voidEnergy = voidEnergy;
+        Database.researchUnit = researchUnit;
+        Database.electricity = electricity;
+        Database.electricityGeneration = generatorProduction;
+        Database.heat = heat;
+        Database.character = character;
+        int firstSpecial = 0;
+        int firstItem = Skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);
+        int firstFluid = Skip(firstItem, FactorioObjectSortOrder.Items);
+        int firstRecipe = Skip(firstFluid, FactorioObjectSortOrder.Fluids);
+        int firstMechanics = Skip(firstRecipe, FactorioObjectSortOrder.Recipes);
+        int firstTechnology = Skip(firstMechanics, FactorioObjectSortOrder.Mechanics);
+        int firstEntity = Skip(firstTechnology, FactorioObjectSortOrder.Technologies);
+        int last = Skip(firstEntity, FactorioObjectSortOrder.Entities);
+        if (last != allObjects.Count) {
+            throw new Exception("Something is not right");
+        }
+
+        Database.objects = new FactorioIdRange<FactorioObject>(0, last, allObjects);
+        Database.specials = new FactorioIdRange<Special>(firstSpecial, firstItem, allObjects);
+        Database.items = new FactorioIdRange<Item>(firstItem, firstFluid, allObjects);
+        Database.fluids = new FactorioIdRange<Fluid>(firstFluid, firstRecipe, allObjects);
+        Database.goods = new FactorioIdRange<Goods>(firstSpecial, firstRecipe, allObjects);
+        Database.recipes = new FactorioIdRange<Recipe>(firstRecipe, firstTechnology, allObjects);
+        Database.mechanics = new FactorioIdRange<Mechanics>(firstMechanics, firstTechnology, allObjects);
+        Database.recipesAndTechnologies = new FactorioIdRange<RecipeOrTechnology>(firstRecipe, firstEntity, allObjects);
+        Database.technologies = new FactorioIdRange<Technology>(firstTechnology, firstEntity, allObjects);
+        Database.entities = new FactorioIdRange<Entity>(firstEntity, last, allObjects);
+        Database.fluidVariants = fluidVariants;
+
+        Database.allModules = [.. allModules];
+        Database.allBeacons = Database.entities.all.OfType<EntityBeacon>().ToArray();
+        Database.allCrafters = Database.entities.all.OfType<EntityCrafter>().ToArray();
+        Database.allBelts = Database.entities.all.OfType<EntityBelt>().ToArray();
+        Database.allInserters = Database.entities.all.OfType<EntityInserter>().ToArray();
+        Database.allAccumulators = Database.entities.all.OfType<EntityAccumulator>().ToArray();
+        Database.allContainers = Database.entities.all.OfType<EntityContainer>().ToArray();
+    }
+
+    private static bool AreInverseRecipes(Recipe packing, Recipe unpacking) {
+        var packedProduct = packing.products[0];
+
+        // Check for deterministic production
+        if (packedProduct.probability != 1f || unpacking.products.Any(p => p.probability != 1)) {
+            return false;
+        }
+        if (packedProduct.amountMin != packedProduct.amountMax || unpacking.products.Any(p => p.amountMin != p.amountMax)) {
+            return false;
+        }
+        if (unpacking.ingredients.Length != 1 || packing.ingredients.Length != unpacking.products.Length) {
+            return false;
+        }
+
+        // Check for 'packing.ingredients == unpacking.products'.
+        float ratio = 0;
+        Recipe? largerRecipe = null;
+
+        // Check for 'packing.ingredients == unpacking.products'.
+        if (!checkRatios(packing, unpacking, ref ratio, ref largerRecipe)) {
+            return false;
+        }
+
+        // Check for 'unpacking.ingredients == packing.products'.
+        if (!checkRatios(unpacking, packing, ref ratio, ref largerRecipe)) {
+            return false;
+        }
+
+        return true;
+
+
+        // Test to see if running `first` M times and `second` once, or vice versa, can reproduce all the original input.
+        // Track which recipe is larger to keep ratio an integer and prevent floating point rounding issues.
+        static bool checkRatios(Recipe first, Recipe second, ref float ratio, ref Recipe? larger) {
+            Dictionary<Goods, float> ingredients = [];
+
+            foreach (var item in first.ingredients) {
+                if (ingredients.ContainsKey(item.goods)) {
+                    return false; // Refuse to deal with duplicate ingredients.
                 }
-
-                return obj;
+                ingredients[item.goods] = item.amount;
             }
 
-            electricity = createSpecialObject(true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
-                "__core__/graphics/icons/alerts/electricity-icon-unplugged.png", "signal-E");
-            fuels.Add(SpecialNames.Electricity, electricity);
-
-            heat = createSpecialObject(true, SpecialNames.Heat, "Heat", "This is an object that represents heat energy", "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
-            fuels.Add(SpecialNames.Heat, heat);
-
-            voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
-            fuels.Add(SpecialNames.Void, voidEnergy);
-            rootAccessible.Add(voidEnergy);
-
-            rocketLaunch = createSpecialObject(false, SpecialNames.RocketLaunch, "Rocket launch slot", "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/02-rocket.png", "signal-R");
-            researchUnit = createSpecialObject(false, SpecialNames.ResearchUnit, "Research", "This represents one unit of a research task.", "__base__/graphics/icons/compilatron.png", "signal-L");
-            researchUnit.isResearch = true;
-            Analysis.ExcludeFromAnalysis<CostAnalysis>(researchUnit);
-
-            generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, "generating");
-            generatorProduction.products = new Product(electricity, 1f).SingleElementArray();
-            generatorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
-            generatorProduction.ingredients = [];
-
-            reactorProduction = CreateSpecialRecipe(heat, SpecialNames.ReactorRecipe, "generating");
-            reactorProduction.products = new Product(heat, 1f).SingleElementArray();
-            reactorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
-            reactorProduction.ingredients = [];
-
-            voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
-            laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
-        }
-
-        private T GetObject<T>(string name) where T : FactorioObject, new() {
-            return GetObject<T, T>(name);
-        }
-
-        private TActual GetObject<TNominal, TActual>(string name) where TNominal : FactorioObject where TActual : TNominal, new() {
-            var key = (typeof(TNominal), name);
-            if (registeredObjects.TryGetValue(key, out FactorioObject? existing)) {
-                return (TActual)existing;
+            foreach (var item in second.products) {
+                if (!ingredients.TryGetValue(item.goods, out float count)) {
+                    return false;
+                }
+                if (count > item.amount) {
+                    if (!checkProportions(first, count, item.amount, ref ratio, ref larger)) {
+                        return false;
+                    }
+                }
+                else if (count == item.amount) {
+                    if (ratio != 0 && ratio != 1) {
+                        return false;
+                    }
+                    ratio = 1;
+                }
+                else {
+                    if (!checkProportions(second, item.amount, count, ref ratio, ref larger)) {
+                        return false;
+                    }
+                }
             }
-
-            TActual newItem = new TActual { name = name };
-            allObjects.Add(newItem);
-            registeredObjects[key] = newItem;
-            return newItem;
+            return true;
         }
 
-        private int Skip(int from, FactorioObjectSortOrder sortOrder) {
-            for (; from < allObjects.Count; from++) {
-                if (allObjects[from].sortingOrder != sortOrder) {
+        // Within the previous check, make sure the ratio is an integer.
+        // If the ratio was set by a previous ingredient/product Goods, make sure this ratio matches the previous one.
+        static bool checkProportions(Recipe currentLargerRecipe, float largerCount, float smallerCount, ref float ratio, ref Recipe? larger) {
+            if (largerCount / smallerCount != MathF.Floor(largerCount / smallerCount)) {
+                return false;
+            }
+            if (ratio != 0 && ratio != largerCount / smallerCount) {
+                return false;
+            }
+            if (larger != null && larger != currentLargerRecipe) {
+                return false;
+            }
+            ratio = largerCount / smallerCount;
+            larger = currentLargerRecipe;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Locates and stores all the links between different objects, e.g. which crafters can be used by a recipe, which recipes produce a particular product, and so on.
+    /// </summary>
+    /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+    /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+    /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+    /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
+    private void CalculateMaps(bool netProduction) {
+        DataBucket<Goods, Recipe> itemUsages = new DataBucket<Goods, Recipe>();
+        DataBucket<Goods, Recipe> itemProduction = new DataBucket<Goods, Recipe>();
+        DataBucket<Goods, FactorioObject> miscSources = new DataBucket<Goods, FactorioObject>();
+        DataBucket<Entity, Item> entityPlacers = new DataBucket<Entity, Item>();
+        DataBucket<Recipe, Technology> recipeUnlockers = new DataBucket<Recipe, Technology>();
+        // Because actual recipe availability may be different than just "all recipes from that category" because of item slot limit and fluid usage restriction, calculate it here
+        DataBucket<RecipeOrTechnology, EntityCrafter> actualRecipeCrafters = new DataBucket<RecipeOrTechnology, EntityCrafter>();
+        DataBucket<Goods, Entity> usageAsFuel = new DataBucket<Goods, Entity>();
+        List<Recipe> allRecipes = [];
+        List<Mechanics> allMechanics = [];
+
+        // step 1 - collect maps
+
+        foreach (var o in allObjects) {
+            switch (o) {
+                case Technology technology:
+                    foreach (var recipe in technology.unlockRecipes) {
+                        recipeUnlockers.Add(recipe, technology);
+                    }
+
                     break;
+                case Recipe recipe:
+                    allRecipes.Add(recipe);
+                    foreach (var product in recipe.products) {
+                        // If the ingredient has variants and is an output, we aren't doing catalyst things: water@15-90 to water@90 does produce water@90,
+                        // even if it consumes 10 water@15-90 to produce 9 water@90.
+                        Ingredient? ingredient = recipe.ingredients.FirstOrDefault(i => i.goods == product.goods && i.variants is null);
+                        float inputAmount = netProduction ? (ingredient?.amount ?? 0) : 0;
+                        float outputAmount = product.amount;
+                        if (outputAmount > inputAmount) {
+                            itemProduction.Add(product.goods, recipe);
+                        }
+                    }
+
+                    foreach (var ingredient in recipe.ingredients) {
+                        // The reverse also applies. 9 water@15-90 to produce 10 water@15 consumes water@90, even though it's a net water producer.
+                        float inputAmount = ingredient.amount;
+                        Product? product = ingredient.variants is null ? recipe.products.FirstOrDefault(p => p.goods == ingredient.goods) : null;
+                        float outputAmount = netProduction ? (product?.amount ?? 0) : 0;
+
+                        if (ingredient.variants == null && inputAmount > outputAmount) {
+                            itemUsages.Add(ingredient.goods, recipe);
+                        }
+                        else if (ingredient.variants != null) {
+                            ingredient.goods = ingredient.variants[0];
+                            foreach (var variant in ingredient.variants) {
+                                itemUsages.Add(variant, recipe);
+                            }
+                        }
+                    }
+                    if (recipe is Mechanics mechanics) {
+                        allMechanics.Add(mechanics);
+                    }
+
+                    break;
+                case Item item:
+                    if (placeResults.TryGetValue(item, out var placeResultNames)) {
+                        item.placeResult = GetObject<Entity>(placeResultNames[0]);
+                        foreach (string name in placeResultNames) {
+                            entityPlacers.Add(GetObject<Entity>(name), item);
+                        }
+                    }
+                    if (item.fuelResult != null) {
+                        miscSources.Add(item.fuelResult, item);
+                    }
+
+                    break;
+                case Entity entity:
+                    foreach (var product in entity.loot) {
+                        miscSources.Add(product.goods, entity);
+                    }
+
+                    if (entity is EntityCrafter crafter) {
+                        crafter.recipes = recipeCrafters.GetRaw(crafter).SelectMany(x => recipeCategories.GetRaw(x).Where(y => y.CanFit(crafter.itemInputs, crafter.fluidInputs, crafter.inputs))).ToArray();
+                        foreach (var recipe in crafter.recipes) {
+                            actualRecipeCrafters.Add(recipe, crafter, true);
+                        }
+                    }
+                    if (entity.energy != null && entity.energy != voidEntityEnergy) {
+                        var fuelList = fuelUsers.GetRaw(entity).SelectMany(fuels.GetRaw);
+                        if (entity.energy.type == EntityEnergyType.FluidHeat) {
+                            fuelList = fuelList.Where(x => x is Fluid f && entity.energy.acceptedTemperature.Contains(f.temperature) && f.temperature > entity.energy.workingTemperature.min);
+                        }
+
+                        var fuelListArr = fuelList.ToArray();
+                        entity.energy.fuels = fuelListArr;
+                        foreach (var fuel in fuelListArr) {
+                            usageAsFuel.Add(fuel, entity);
+                        }
+                    }
+                    break;
+            }
+        }
+
+        voidEntityEnergy.fuels = [voidEnergy];
+
+        actualRecipeCrafters.Seal();
+        usageAsFuel.Seal();
+        recipeUnlockers.Seal();
+        entityPlacers.Seal();
+
+        // step 2 - fill maps
+
+        foreach (var o in allObjects) {
+            switch (o) {
+                case RecipeOrTechnology recipeOrTechnology:
+                    if (recipeOrTechnology is Recipe recipe) {
+                        recipe.FallbackLocalization(recipe.mainProduct, "A recipe to create");
+                        recipe.technologyUnlock = recipeUnlockers.GetArray(recipe);
+                    }
+                    recipeOrTechnology.crafters = actualRecipeCrafters.GetArray(recipeOrTechnology);
+                    break;
+                case Goods goods:
+                    goods.usages = itemUsages.GetArray(goods);
+                    goods.production = itemProduction.GetArray(goods);
+                    goods.miscSources = miscSources.GetArray(goods);
+                    if (o is Item item) {
+                        if (item.placeResult != null) {
+                            item.FallbackLocalization(item.placeResult, "An item to build");
+                        }
+                    }
+                    else if (o is Fluid fluid && fluid.variants != null) {
+                        string temperatureDescr = "Temperature: " + fluid.temperature + "°";
+                        if (fluid.locDescr == null) {
+                            fluid.locDescr = temperatureDescr;
+                        }
+                        else {
+                            fluid.locDescr = temperatureDescr + "\n" + fluid.locDescr;
+                        }
+                    }
+
+                    goods.fuelFor = usageAsFuel.GetArray(goods);
+                    break;
+                case Entity entity:
+                    entity.itemsToPlace = entityPlacers.GetArray(entity);
+                    break;
+            }
+        }
+
+        Queue<EntityCrafter> crafters = new(allObjects.OfType<EntityCrafter>());
+
+        while (crafters.TryDequeue(out EntityCrafter? crafter)) {
+            // If this is a crafter with a fixed recipe with data.raw.recipe["fixed-recipe-name"].enabled = false
+            // (Exclude Mechanics; they aren't recipes in Factorio's fixed_recipe sense.)
+            if (recipeCrafters.GetRaw(crafter).SingleOrDefault(s => s.StartsWith(SpecialNames.FixedRecipe), false) != null
+                && crafter.recipes.SingleOrDefault(r => r.GetType() == typeof(Recipe), false) is Recipe { enabled: false } fixedRecipe) {
+
+                bool addedUnlocks = false;
+                foreach (Recipe itemRecipe in crafter.itemsToPlace.SelectMany(i => i.production)) {
+                    // and (a recipe that creates an item that places) the crafter is accessible
+                    // from the beginning of the game, the fixed recipe is also accessible.
+                    if (itemRecipe.enabled) {
+                        fixedRecipe.enabled = true;
+                        addedUnlocks = true;
+                        break;
+                    }
+                    // otherwise, the recipe is also unlocked by all technologies that
+                    // unlock (a recipe that creates an item that places) the crafter.
+                    else if (itemRecipe.technologyUnlock.Except(fixedRecipe.technologyUnlock).Any()) {
+                        // Add the missing technology/ies
+                        fixedRecipe.technologyUnlock = [.. fixedRecipe.technologyUnlock.Union(itemRecipe.technologyUnlock)];
+                        addedUnlocks = true;
+                    }
+                }
+
+                if (addedUnlocks) {
+                    // If we added unlocks, and the fixed recipe creates (items that place) crafters,
+                    // queue those crafters for a second check, in case they also have fixed recipes.
+                    Item[] products = [.. fixedRecipe.products.Select(p => p.goods).OfType<Item>()];
+                    foreach (EntityCrafter newCrafter in allObjects.OfType<EntityCrafter>()) {
+                        if (newCrafter.itemsToPlace.Intersect(products).Any()) {
+                            crafters.Enqueue(newCrafter);
+                        }
+                    }
                 }
             }
-
-            return from;
         }
 
-        private void ExportBuiltData() {
-            Database.rootAccessible = rootAccessible.ToArray();
-            Database.objectsByTypeName = allObjects.ToDictionary(x => x.typeDotName);
-            foreach (var alias in formerAliases) {
-                _ = Database.objectsByTypeName.TryAdd(alias.Key, alias.Value);
-            }
-
-            Database.allSciencePacks = sciencePacks.ToArray();
-            Database.voidEnergy = voidEnergy;
-            Database.researchUnit = researchUnit;
-            Database.electricity = electricity;
-            Database.electricityGeneration = generatorProduction;
-            Database.heat = heat;
-            Database.character = character;
-            int firstSpecial = 0;
-            int firstItem = Skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);
-            int firstFluid = Skip(firstItem, FactorioObjectSortOrder.Items);
-            int firstRecipe = Skip(firstFluid, FactorioObjectSortOrder.Fluids);
-            int firstMechanics = Skip(firstRecipe, FactorioObjectSortOrder.Recipes);
-            int firstTechnology = Skip(firstMechanics, FactorioObjectSortOrder.Mechanics);
-            int firstEntity = Skip(firstTechnology, FactorioObjectSortOrder.Technologies);
-            int last = Skip(firstEntity, FactorioObjectSortOrder.Entities);
-            if (last != allObjects.Count) {
-                throw new Exception("Something is not right");
-            }
-
-            Database.objects = new FactorioIdRange<FactorioObject>(0, last, allObjects);
-            Database.specials = new FactorioIdRange<Special>(firstSpecial, firstItem, allObjects);
-            Database.items = new FactorioIdRange<Item>(firstItem, firstFluid, allObjects);
-            Database.fluids = new FactorioIdRange<Fluid>(firstFluid, firstRecipe, allObjects);
-            Database.goods = new FactorioIdRange<Goods>(firstSpecial, firstRecipe, allObjects);
-            Database.recipes = new FactorioIdRange<Recipe>(firstRecipe, firstTechnology, allObjects);
-            Database.mechanics = new FactorioIdRange<Mechanics>(firstMechanics, firstTechnology, allObjects);
-            Database.recipesAndTechnologies = new FactorioIdRange<RecipeOrTechnology>(firstRecipe, firstEntity, allObjects);
-            Database.technologies = new FactorioIdRange<Technology>(firstTechnology, firstEntity, allObjects);
-            Database.entities = new FactorioIdRange<Entity>(firstEntity, last, allObjects);
-            Database.fluidVariants = fluidVariants;
-
-            Database.allModules = [.. allModules];
-            Database.allBeacons = Database.entities.all.OfType<EntityBeacon>().ToArray();
-            Database.allCrafters = Database.entities.all.OfType<EntityCrafter>().ToArray();
-            Database.allBelts = Database.entities.all.OfType<EntityBelt>().ToArray();
-            Database.allInserters = Database.entities.all.OfType<EntityInserter>().ToArray();
-            Database.allAccumulators = Database.entities.all.OfType<EntityAccumulator>().ToArray();
-            Database.allContainers = Database.entities.all.OfType<EntityContainer>().ToArray();
+        foreach (var mechanic in allMechanics) {
+            mechanic.locName = mechanic.source.locName + " " + mechanic.locName;
+            mechanic.locDescr = mechanic.source.locDescr;
+            mechanic.iconSpec = mechanic.source.iconSpec;
         }
 
-        private static bool AreInverseRecipes(Recipe packing, Recipe unpacking) {
-            var packedProduct = packing.products[0];
-
-            // Check for deterministic production
-            if (packedProduct.probability != 1f || unpacking.products.Any(p => p.probability != 1)) {
-                return false;
-            }
-            if (packedProduct.amountMin != packedProduct.amountMax || unpacking.products.Any(p => p.amountMin != p.amountMax)) {
-                return false;
-            }
-            if (unpacking.ingredients.Length != 1 || packing.ingredients.Length != unpacking.products.Length) {
-                return false;
+        // step 3 - detect packing/unpacking (e.g. barreling/unbarreling, stacking/unstacking, etc.) and voiding recipes
+        foreach (var recipe in allRecipes) {
+            if (recipe.specialType != FactorioObjectSpecialType.Normal) {
+                continue;
             }
 
-            // Check for 'packing.ingredients == unpacking.products'.
-            float ratio = 0;
-            Recipe? largerRecipe = null;
+            if (recipe.products.Length == 0) {
+                recipe.specialType = FactorioObjectSpecialType.Voiding;
+                continue;
+            }
+            if (recipe.products.Length != 1 || recipe.ingredients.Length == 0) {
+                continue;
+            }
 
-            // Check for 'packing.ingredients == unpacking.products'.
-            if (!checkRatios(packing, unpacking, ref ratio, ref largerRecipe)) {
+            Goods packed = recipe.products[0].goods;
+            if (countNonDsrRecipes(packed.usages) != 1 && countNonDsrRecipes(packed.production) != 1) {
+                continue;
+            }
+
+            if (recipe.ingredients.Sum(i => i.amount) <= recipe.products.Sum(p => p.amount)) {
+                // If `recipe` is part of packing/unpacking pair, it's the unpacking half. Ignore it until we find the packing half of the pair.
+                continue;
+            }
+
+            foreach (var unpacking in packed.usages) {
+                if (AreInverseRecipes(recipe, unpacking)) {
+                    if (packed is Fluid && unpacking.products.All(p => p.goods is Fluid)) {
+                        recipe.specialType = FactorioObjectSpecialType.Pressurization;
+                        unpacking.specialType = FactorioObjectSpecialType.Pressurization;
+                        packed.specialType = FactorioObjectSpecialType.Pressurization;
+                    }
+                    else if (packed is Item && unpacking.products.All(p => p.goods is Item)) {
+                        if (unpacking.products.Length == 1) {
+                            recipe.specialType = FactorioObjectSpecialType.Stacking;
+                            unpacking.specialType = FactorioObjectSpecialType.Stacking;
+                            packed.specialType = FactorioObjectSpecialType.Stacking;
+                        }
+                        else {
+                            recipe.specialType = FactorioObjectSpecialType.Crating;
+                            unpacking.specialType = FactorioObjectSpecialType.Crating;
+                            packed.specialType = FactorioObjectSpecialType.Crating;
+                        }
+                    }
+                    else if (packed is Item && unpacking.products.Any(p => p.goods is Item) && unpacking.products.Any(p => p.goods is Fluid)) {
+                        recipe.specialType = FactorioObjectSpecialType.Barreling;
+                        unpacking.specialType = FactorioObjectSpecialType.Barreling;
+                        packed.specialType = FactorioObjectSpecialType.Barreling;
+                    }
+                    else { continue; }
+
+                    // The packed good is used in other recipes or is fuel, constructs a building, or is a module. Only the unpacking recipe should be flagged as special.
+                    if (countNonDsrRecipes(packed.usages) != 1 || (packed is Item item && (item.fuelValue != 0 || item.placeResult != null || item is Module))) {
+                        recipe.specialType = FactorioObjectSpecialType.Normal;
+                        packed.specialType = FactorioObjectSpecialType.Normal;
+                    }
+
+                    // The packed good can be mined or has a non-packing source. Only the packing recipe should be flagged as special.
+                    if (packed.miscSources.OfType<Entity>().Any() || countNonDsrRecipes(packed.production) > 1) {
+                        unpacking.specialType = FactorioObjectSpecialType.Normal;
+                        packed.specialType = FactorioObjectSpecialType.Normal;
+                    }
+                }
+            }
+        }
+
+        foreach (var any in allObjects) {
+            any.locName ??= any.name;
+        }
+
+        foreach (var (_, list) in fluidVariants) {
+            foreach (var fluid in list) {
+                fluid.locName += " " + fluid.temperature + "°";
+            }
+        }
+        // The recipes added by deadlock_stacked_recipes (with CompressedFluids, if present) need to be filtered out to get decent results.
+        static int countNonDsrRecipes(IEnumerable<Recipe> recipes) {
+            return recipes.Count(r => !r.name.Contains("StackedRecipe-") && !r.name.Contains("DSR_HighPressure-"));
+        }
+    }
+
+    private Recipe CreateSpecialRecipe(FactorioObject production, string category, string hint) {
+        string fullName = category + (category.EndsWith('.') ? "" : ".") + production.name;
+        if (registeredObjects.TryGetValue((typeof(Mechanics), fullName), out var recipeRaw)) {
+            return (Recipe)recipeRaw;
+        }
+
+        var recipe = GetObject<Mechanics>(fullName);
+        recipe.time = 1f;
+        recipe.factorioType = SpecialNames.FakeRecipe;
+        recipe.name = fullName;
+        recipe.source = production;
+        recipe.locName = hint;
+        recipe.enabled = true;
+        recipe.hidden = true;
+        recipe.technologyUnlock = [];
+        recipeCategories.Add(category, recipe);
+        return recipe;
+    }
+
+    private class DataBucket<TKey, TValue> : IEqualityComparer<List<TValue>> where TKey : notnull where TValue : notnull {
+        private readonly Dictionary<TKey, IList<TValue>> storage = [];
+        /// <summary>This function provides a default list of values for the key for when the key is not present in the storage.</summary>
+        /// <remarks>The provided function must *must not* return null.</remarks>
+        private Func<TKey, IEnumerable<TValue>> defaultList = NoExtraItems;
+
+        /// <summary>When true, it is not allowed to add new items to this bucket.</summary>
+        private bool isSealed;
+
+        /// <summary>
+        /// Replaces the list values in storage with array values while (optionally) adding extra values depending on the item.
+        /// </summary>
+        /// <param name="addExtraItems">Function to provide extra items, *must not* return null.</param>
+        public void Seal(Func<TKey, IEnumerable<TValue>>? addExtraItems = null) {
+            if (isSealed) {
+                throw new InvalidOperationException("Data bucket is already sealed");
+            }
+
+            if (addExtraItems != null) {
+                defaultList = addExtraItems;
+            }
+
+            KeyValuePair<TKey, IList<TValue>>[] values = storage.ToArray();
+            foreach ((TKey key, IList<TValue> value) in values) {
+                if (value is not List<TValue> list) {
+                    // Unexpected type, (probably) never happens
+                    continue;
+                }
+
+                // Add the extra values to the list when provided before storing the complete array.
+                IEnumerable<TValue> completeList = addExtraItems != null ? list.Concat(addExtraItems(key)) : list;
+                TValue[] completeArray = completeList.ToArray();
+
+                storage[key] = completeArray;
+            }
+
+            isSealed = true;
+        }
+
+        public void Add(TKey key, TValue value, bool checkUnique = false) {
+            if (isSealed) {
+                throw new InvalidOperationException("Data bucket is sealed");
+            }
+
+            if (key == null) {
+                return;
+            }
+
+            if (!storage.TryGetValue(key, out var list)) {
+                storage[key] = [value];
+            }
+            else if (!checkUnique || !list.Contains(value)) {
+                list.Add(value);
+            }
+        }
+
+        public TValue[] GetArray(TKey key) {
+            if (!storage.TryGetValue(key, out var list)) {
+                return defaultList(key).ToArray();
+            }
+
+            return list is TValue[] value ? value : list.ToArray();
+        }
+
+        public IList<TValue> GetRaw(TKey key) {
+            if (!storage.TryGetValue(key, out var list)) {
+                list = defaultList(key).ToList();
+                if (isSealed) {
+                    list = list.ToArray();
+                }
+
+                storage[key] = list;
+            }
+            return list;
+        }
+
+        ///<summary>Just return an empty enumerable.</summary>
+        private static IEnumerable<TValue> NoExtraItems(TKey item) {
+            return [];
+        }
+
+        public bool Equals(List<TValue>? x, List<TValue>? y) {
+            if (x is null && y is null) {
+                return true;
+            }
+
+            if (x is null || y is null || x.Count != y.Count) {
                 return false;
             }
 
-            // Check for 'unpacking.ingredients == packing.products'.
-            if (!checkRatios(unpacking, packing, ref ratio, ref largerRecipe)) {
-                return false;
+            var comparer = EqualityComparer<TValue>.Default;
+            for (int i = 0; i < x.Count; i++) {
+                if (!comparer.Equals(x[i], y[i])) {
+                    return false;
+                }
             }
 
             return true;
-
-
-            // Test to see if running `first` M times and `second` once, or vice versa, can reproduce all the original input.
-            // Track which recipe is larger to keep ratio an integer and prevent floating point rounding issues.
-            static bool checkRatios(Recipe first, Recipe second, ref float ratio, ref Recipe? larger) {
-                Dictionary<Goods, float> ingredients = [];
-
-                foreach (var item in first.ingredients) {
-                    if (ingredients.ContainsKey(item.goods)) {
-                        return false; // Refuse to deal with duplicate ingredients.
-                    }
-                    ingredients[item.goods] = item.amount;
-                }
-
-                foreach (var item in second.products) {
-                    if (!ingredients.TryGetValue(item.goods, out float count)) {
-                        return false;
-                    }
-                    if (count > item.amount) {
-                        if (!checkProportions(first, count, item.amount, ref ratio, ref larger)) {
-                            return false;
-                        }
-                    }
-                    else if (count == item.amount) {
-                        if (ratio != 0 && ratio != 1) {
-                            return false;
-                        }
-                        ratio = 1;
-                    }
-                    else {
-                        if (!checkProportions(second, item.amount, count, ref ratio, ref larger)) {
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            }
-
-            // Within the previous check, make sure the ratio is an integer.
-            // If the ratio was set by a previous ingredient/product Goods, make sure this ratio matches the previous one.
-            static bool checkProportions(Recipe currentLargerRecipe, float largerCount, float smallerCount, ref float ratio, ref Recipe? larger) {
-                if (largerCount / smallerCount != MathF.Floor(largerCount / smallerCount)) {
-                    return false;
-                }
-                if (ratio != 0 && ratio != largerCount / smallerCount) {
-                    return false;
-                }
-                if (larger != null && larger != currentLargerRecipe) {
-                    return false;
-                }
-                ratio = largerCount / smallerCount;
-                larger = currentLargerRecipe;
-                return true;
-            }
         }
 
-        /// <summary>
-        /// Locates and stores all the links between different objects, e.g. which crafters can be used by a recipe, which recipes produce a particular product, and so on.
-        /// </summary>
-        /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
-        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
-        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
-        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
-        private void CalculateMaps(bool netProduction) {
-            DataBucket<Goods, Recipe> itemUsages = new DataBucket<Goods, Recipe>();
-            DataBucket<Goods, Recipe> itemProduction = new DataBucket<Goods, Recipe>();
-            DataBucket<Goods, FactorioObject> miscSources = new DataBucket<Goods, FactorioObject>();
-            DataBucket<Entity, Item> entityPlacers = new DataBucket<Entity, Item>();
-            DataBucket<Recipe, Technology> recipeUnlockers = new DataBucket<Recipe, Technology>();
-            // Because actual recipe availability may be different than just "all recipes from that category" because of item slot limit and fluid usage restriction, calculate it here
-            DataBucket<RecipeOrTechnology, EntityCrafter> actualRecipeCrafters = new DataBucket<RecipeOrTechnology, EntityCrafter>();
-            DataBucket<Goods, Entity> usageAsFuel = new DataBucket<Goods, Entity>();
-            List<Recipe> allRecipes = [];
-            List<Mechanics> allMechanics = [];
-
-            // step 1 - collect maps
-
-            foreach (var o in allObjects) {
-                switch (o) {
-                    case Technology technology:
-                        foreach (var recipe in technology.unlockRecipes) {
-                            recipeUnlockers.Add(recipe, technology);
-                        }
-
-                        break;
-                    case Recipe recipe:
-                        allRecipes.Add(recipe);
-                        foreach (var product in recipe.products) {
-                            // If the ingredient has variants and is an output, we aren't doing catalyst things: water@15-90 to water@90 does produce water@90,
-                            // even if it consumes 10 water@15-90 to produce 9 water@90.
-                            Ingredient? ingredient = recipe.ingredients.FirstOrDefault(i => i.goods == product.goods && i.variants is null);
-                            float inputAmount = netProduction ? (ingredient?.amount ?? 0) : 0;
-                            float outputAmount = product.amount;
-                            if (outputAmount > inputAmount) {
-                                itemProduction.Add(product.goods, recipe);
-                            }
-                        }
-
-                        foreach (var ingredient in recipe.ingredients) {
-                            // The reverse also applies. 9 water@15-90 to produce 10 water@15 consumes water@90, even though it's a net water producer.
-                            float inputAmount = ingredient.amount;
-                            Product? product = ingredient.variants is null ? recipe.products.FirstOrDefault(p => p.goods == ingredient.goods) : null;
-                            float outputAmount = netProduction ? (product?.amount ?? 0) : 0;
-
-                            if (ingredient.variants == null && inputAmount > outputAmount) {
-                                itemUsages.Add(ingredient.goods, recipe);
-                            }
-                            else if (ingredient.variants != null) {
-                                ingredient.goods = ingredient.variants[0];
-                                foreach (var variant in ingredient.variants) {
-                                    itemUsages.Add(variant, recipe);
-                                }
-                            }
-                        }
-                        if (recipe is Mechanics mechanics) {
-                            allMechanics.Add(mechanics);
-                        }
-
-                        break;
-                    case Item item:
-                        if (placeResults.TryGetValue(item, out var placeResultNames)) {
-                            item.placeResult = GetObject<Entity>(placeResultNames[0]);
-                            foreach (string name in placeResultNames) {
-                                entityPlacers.Add(GetObject<Entity>(name), item);
-                            }
-                        }
-                        if (item.fuelResult != null) {
-                            miscSources.Add(item.fuelResult, item);
-                        }
-
-                        break;
-                    case Entity entity:
-                        foreach (var product in entity.loot) {
-                            miscSources.Add(product.goods, entity);
-                        }
-
-                        if (entity is EntityCrafter crafter) {
-                            crafter.recipes = recipeCrafters.GetRaw(crafter).SelectMany(x => recipeCategories.GetRaw(x).Where(y => y.CanFit(crafter.itemInputs, crafter.fluidInputs, crafter.inputs))).ToArray();
-                            foreach (var recipe in crafter.recipes) {
-                                actualRecipeCrafters.Add(recipe, crafter, true);
-                            }
-                        }
-                        if (entity.energy != null && entity.energy != voidEntityEnergy) {
-                            var fuelList = fuelUsers.GetRaw(entity).SelectMany(fuels.GetRaw);
-                            if (entity.energy.type == EntityEnergyType.FluidHeat) {
-                                fuelList = fuelList.Where(x => x is Fluid f && entity.energy.acceptedTemperature.Contains(f.temperature) && f.temperature > entity.energy.workingTemperature.min);
-                            }
-
-                            var fuelListArr = fuelList.ToArray();
-                            entity.energy.fuels = fuelListArr;
-                            foreach (var fuel in fuelListArr) {
-                                usageAsFuel.Add(fuel, entity);
-                            }
-                        }
-                        break;
-                }
-            }
-
-            voidEntityEnergy.fuels = [voidEnergy];
-
-            actualRecipeCrafters.Seal();
-            usageAsFuel.Seal();
-            recipeUnlockers.Seal();
-            entityPlacers.Seal();
-
-            // step 2 - fill maps
-
-            foreach (var o in allObjects) {
-                switch (o) {
-                    case RecipeOrTechnology recipeOrTechnology:
-                        if (recipeOrTechnology is Recipe recipe) {
-                            recipe.FallbackLocalization(recipe.mainProduct, "A recipe to create");
-                            recipe.technologyUnlock = recipeUnlockers.GetArray(recipe);
-                        }
-                        recipeOrTechnology.crafters = actualRecipeCrafters.GetArray(recipeOrTechnology);
-                        break;
-                    case Goods goods:
-                        goods.usages = itemUsages.GetArray(goods);
-                        goods.production = itemProduction.GetArray(goods);
-                        goods.miscSources = miscSources.GetArray(goods);
-                        if (o is Item item) {
-                            if (item.placeResult != null) {
-                                item.FallbackLocalization(item.placeResult, "An item to build");
-                            }
-                        }
-                        else if (o is Fluid fluid && fluid.variants != null) {
-                            string temperatureDescr = "Temperature: " + fluid.temperature + "°";
-                            if (fluid.locDescr == null) {
-                                fluid.locDescr = temperatureDescr;
-                            }
-                            else {
-                                fluid.locDescr = temperatureDescr + "\n" + fluid.locDescr;
-                            }
-                        }
-
-                        goods.fuelFor = usageAsFuel.GetArray(goods);
-                        break;
-                    case Entity entity:
-                        entity.itemsToPlace = entityPlacers.GetArray(entity);
-                        break;
-                }
-            }
-
-            Queue<EntityCrafter> crafters = new(allObjects.OfType<EntityCrafter>());
-
-            while (crafters.TryDequeue(out EntityCrafter? crafter)) {
-                // If this is a crafter with a fixed recipe with data.raw.recipe["fixed-recipe-name"].enabled = false
-                // (Exclude Mechanics; they aren't recipes in Factorio's fixed_recipe sense.)
-                if (recipeCrafters.GetRaw(crafter).SingleOrDefault(s => s.StartsWith(SpecialNames.FixedRecipe), false) != null
-                    && crafter.recipes.SingleOrDefault(r => r.GetType() == typeof(Recipe), false) is Recipe { enabled: false } fixedRecipe) {
-
-                    bool addedUnlocks = false;
-                    foreach (Recipe itemRecipe in crafter.itemsToPlace.SelectMany(i => i.production)) {
-                        // and (a recipe that creates an item that places) the crafter is accessible
-                        // from the beginning of the game, the fixed recipe is also accessible.
-                        if (itemRecipe.enabled) {
-                            fixedRecipe.enabled = true;
-                            addedUnlocks = true;
-                            break;
-                        }
-                        // otherwise, the recipe is also unlocked by all technologies that
-                        // unlock (a recipe that creates an item that places) the crafter.
-                        else if (itemRecipe.technologyUnlock.Except(fixedRecipe.technologyUnlock).Any()) {
-                            // Add the missing technology/ies
-                            fixedRecipe.technologyUnlock = [.. fixedRecipe.technologyUnlock.Union(itemRecipe.technologyUnlock)];
-                            addedUnlocks = true;
-                        }
-                    }
-
-                    if (addedUnlocks) {
-                        // If we added unlocks, and the fixed recipe creates (items that place) crafters,
-                        // queue those crafters for a second check, in case they also have fixed recipes.
-                        Item[] products = [.. fixedRecipe.products.Select(p => p.goods).OfType<Item>()];
-                        foreach (EntityCrafter newCrafter in allObjects.OfType<EntityCrafter>()) {
-                            if (newCrafter.itemsToPlace.Intersect(products).Any()) {
-                                crafters.Enqueue(newCrafter);
-                            }
-                        }
-                    }
-                }
-            }
-
-            foreach (var mechanic in allMechanics) {
-                mechanic.locName = mechanic.source.locName + " " + mechanic.locName;
-                mechanic.locDescr = mechanic.source.locDescr;
-                mechanic.iconSpec = mechanic.source.iconSpec;
-            }
-
-            // step 3 - detect packing/unpacking (e.g. barreling/unbarreling, stacking/unstacking, etc.) and voiding recipes
-            foreach (var recipe in allRecipes) {
-                if (recipe.specialType != FactorioObjectSpecialType.Normal) {
-                    continue;
-                }
-
-                if (recipe.products.Length == 0) {
-                    recipe.specialType = FactorioObjectSpecialType.Voiding;
-                    continue;
-                }
-                if (recipe.products.Length != 1 || recipe.ingredients.Length == 0) {
-                    continue;
-                }
-
-                Goods packed = recipe.products[0].goods;
-                if (countNonDsrRecipes(packed.usages) != 1 && countNonDsrRecipes(packed.production) != 1) {
-                    continue;
-                }
-
-                if (recipe.ingredients.Sum(i => i.amount) <= recipe.products.Sum(p => p.amount)) {
-                    // If `recipe` is part of packing/unpacking pair, it's the unpacking half. Ignore it until we find the packing half of the pair.
-                    continue;
-                }
-
-                foreach (var unpacking in packed.usages) {
-                    if (AreInverseRecipes(recipe, unpacking)) {
-                        if (packed is Fluid && unpacking.products.All(p => p.goods is Fluid)) {
-                            recipe.specialType = FactorioObjectSpecialType.Pressurization;
-                            unpacking.specialType = FactorioObjectSpecialType.Pressurization;
-                            packed.specialType = FactorioObjectSpecialType.Pressurization;
-                        }
-                        else if (packed is Item && unpacking.products.All(p => p.goods is Item)) {
-                            if (unpacking.products.Length == 1) {
-                                recipe.specialType = FactorioObjectSpecialType.Stacking;
-                                unpacking.specialType = FactorioObjectSpecialType.Stacking;
-                                packed.specialType = FactorioObjectSpecialType.Stacking;
-                            }
-                            else {
-                                recipe.specialType = FactorioObjectSpecialType.Crating;
-                                unpacking.specialType = FactorioObjectSpecialType.Crating;
-                                packed.specialType = FactorioObjectSpecialType.Crating;
-                            }
-                        }
-                        else if (packed is Item && unpacking.products.Any(p => p.goods is Item) && unpacking.products.Any(p => p.goods is Fluid)) {
-                            recipe.specialType = FactorioObjectSpecialType.Barreling;
-                            unpacking.specialType = FactorioObjectSpecialType.Barreling;
-                            packed.specialType = FactorioObjectSpecialType.Barreling;
-                        }
-                        else { continue; }
-
-                        // The packed good is used in other recipes or is fuel, constructs a building, or is a module. Only the unpacking recipe should be flagged as special.
-                        if (countNonDsrRecipes(packed.usages) != 1 || (packed is Item item && (item.fuelValue != 0 || item.placeResult != null || item is Module))) {
-                            recipe.specialType = FactorioObjectSpecialType.Normal;
-                            packed.specialType = FactorioObjectSpecialType.Normal;
-                        }
-
-                        // The packed good can be mined or has a non-packing source. Only the packing recipe should be flagged as special.
-                        if (packed.miscSources.OfType<Entity>().Any() || countNonDsrRecipes(packed.production) > 1) {
-                            unpacking.specialType = FactorioObjectSpecialType.Normal;
-                            packed.specialType = FactorioObjectSpecialType.Normal;
-                        }
-                    }
-                }
-            }
-
-            foreach (var any in allObjects) {
-                any.locName ??= any.name;
-            }
-
-            foreach (var (_, list) in fluidVariants) {
-                foreach (var fluid in list) {
-                    fluid.locName += " " + fluid.temperature + "°";
-                }
-            }
-            // The recipes added by deadlock_stacked_recipes (with CompressedFluids, if present) need to be filtered out to get decent results.
-            static int countNonDsrRecipes(IEnumerable<Recipe> recipes) {
-                return recipes.Count(r => !r.name.Contains("StackedRecipe-") && !r.name.Contains("DSR_HighPressure-"));
-            }
+        public int GetHashCode(List<TValue> obj) {
+            int count = obj.Count;
+            return count == 0 ? 0 : (((obj.Count * 347) + obj[0].GetHashCode()) * 347) + obj[count - 1].GetHashCode();
         }
+    }
 
-        private Recipe CreateSpecialRecipe(FactorioObject production, string category, string hint) {
-            string fullName = category + (category.EndsWith('.') ? "" : ".") + production.name;
-            if (registeredObjects.TryGetValue((typeof(Mechanics), fullName), out var recipeRaw)) {
-                return (Recipe)recipeRaw;
-            }
+    public Type? TypeNameToType(string? typeName) {
+        return typeName switch {
+            "item" => typeof(Item),
+            "fluid" => typeof(Fluid),
+            "technology" => typeof(Technology),
+            "recipe" => typeof(Recipe),
+            "entity" => typeof(Entity),
+            _ => null,
+        };
+    }
 
-            var recipe = GetObject<Mechanics>(fullName);
-            recipe.time = 1f;
-            recipe.factorioType = SpecialNames.FakeRecipe;
-            recipe.name = fullName;
-            recipe.source = production;
-            recipe.locName = hint;
-            recipe.enabled = true;
-            recipe.hidden = true;
-            recipe.technologyUnlock = [];
-            recipeCategories.Add(category, recipe);
-            return recipe;
-        }
-
-        private class DataBucket<TKey, TValue> : IEqualityComparer<List<TValue>> where TKey : notnull where TValue : notnull {
-            private readonly Dictionary<TKey, IList<TValue>> storage = [];
-            /// <summary>This function provides a default list of values for the key for when the key is not present in the storage.</summary>
-            /// <remarks>The provided function must *must not* return null.</remarks>
-            private Func<TKey, IEnumerable<TValue>> defaultList = NoExtraItems;
-
-            /// <summary>When true, it is not allowed to add new items to this bucket.</summary>
-            private bool isSealed;
-
-            /// <summary>
-            /// Replaces the list values in storage with array values while (optionally) adding extra values depending on the item.
-            /// </summary>
-            /// <param name="addExtraItems">Function to provide extra items, *must not* return null.</param>
-            public void Seal(Func<TKey, IEnumerable<TValue>>? addExtraItems = null) {
-                if (isSealed) {
-                    throw new InvalidOperationException("Data bucket is already sealed");
-                }
-
-                if (addExtraItems != null) {
-                    defaultList = addExtraItems;
-                }
-
-                KeyValuePair<TKey, IList<TValue>>[] values = storage.ToArray();
-                foreach ((TKey key, IList<TValue> value) in values) {
-                    if (value is not List<TValue> list) {
-                        // Unexpected type, (probably) never happens
-                        continue;
-                    }
-
-                    // Add the extra values to the list when provided before storing the complete array.
-                    IEnumerable<TValue> completeList = addExtraItems != null ? list.Concat(addExtraItems(key)) : list;
-                    TValue[] completeArray = completeList.ToArray();
-
-                    storage[key] = completeArray;
-                }
-
-                isSealed = true;
-            }
-
-            public void Add(TKey key, TValue value, bool checkUnique = false) {
-                if (isSealed) {
-                    throw new InvalidOperationException("Data bucket is sealed");
-                }
-
-                if (key == null) {
-                    return;
-                }
-
-                if (!storage.TryGetValue(key, out var list)) {
-                    storage[key] = [value];
-                }
-                else if (!checkUnique || !list.Contains(value)) {
-                    list.Add(value);
-                }
-            }
-
-            public TValue[] GetArray(TKey key) {
-                if (!storage.TryGetValue(key, out var list)) {
-                    return defaultList(key).ToArray();
-                }
-
-                return list is TValue[] value ? value : list.ToArray();
-            }
-
-            public IList<TValue> GetRaw(TKey key) {
-                if (!storage.TryGetValue(key, out var list)) {
-                    list = defaultList(key).ToList();
-                    if (isSealed) {
-                        list = list.ToArray();
-                    }
-
-                    storage[key] = list;
-                }
-                return list;
-            }
-
-            ///<summary>Just return an empty enumerable.</summary>
-            private static IEnumerable<TValue> NoExtraItems(TKey item) {
-                return [];
-            }
-
-            public bool Equals(List<TValue>? x, List<TValue>? y) {
-                if (x is null && y is null) {
-                    return true;
-                }
-
-                if (x is null || y is null || x.Count != y.Count) {
-                    return false;
-                }
-
-                var comparer = EqualityComparer<TValue>.Default;
-                for (int i = 0; i < x.Count; i++) {
-                    if (!comparer.Equals(x[i], y[i])) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            public int GetHashCode(List<TValue> obj) {
-                int count = obj.Count;
-                return count == 0 ? 0 : (((obj.Count * 347) + obj[0].GetHashCode()) * 347) + obj[count - 1].GetHashCode();
-            }
-        }
-
-        public Type? TypeNameToType(string? typeName) {
-            return typeName switch {
-                "item" => typeof(Item),
-                "fluid" => typeof(Fluid),
-                "technology" => typeof(Technology),
-                "recipe" => typeof(Recipe),
-                "entity" => typeof(Entity),
-                _ => null,
-            };
-        }
-
-        private void ParseModYafcHandles(LuaTable? scriptEnabled) {
-            if (scriptEnabled != null) {
-                foreach (object? element in scriptEnabled.ArrayElements) {
-                    if (element is LuaTable table) {
-                        _ = table.Get("type", out string? type);
-                        _ = table.Get("name", out string? name);
-                        if (registeredObjects.TryGetValue((TypeNameToType(type), name), out var existing)) {
-                            rootAccessible.Add(existing);
-                        }
+    private void ParseModYafcHandles(LuaTable? scriptEnabled) {
+        if (scriptEnabled != null) {
+            foreach (object? element in scriptEnabled.ArrayElements) {
+                if (element is LuaTable table) {
+                    _ = table.Get("type", out string? type);
+                    _ = table.Get("name", out string? name);
+                    if (registeredObjects.TryGetValue((TypeNameToType(type), name), out var existing)) {
+                        rootAccessible.Add(existing);
                     }
                 }
             }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -4,571 +4,570 @@ using System.Linq;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc.Parser {
-    internal partial class FactorioDataDeserializer {
-        private const float EstimationDistanceFromCenter = 3000f;
-        private bool GetFluidBoxFilter(LuaTable table, string fluidBoxName, int temperature, [NotNullWhen(true)] out Fluid? fluid, out TemperatureRange range) {
-            fluid = null;
-            range = default;
-            if (!table.Get(fluidBoxName, out LuaTable? fluidBoxData)) {
-                return false;
-            }
-
-            if (!fluidBoxData.Get("filter", out string? fluidName)) {
-                return false;
-            }
-
-            fluid = temperature == 0 ? GetObject<Fluid>(fluidName) : GetFluidFixedTemp(fluidName, temperature);
-            _ = fluidBoxData.Get("minimum_temperature", out range.min, fluid.temperatureRange.min);
-            _ = fluidBoxData.Get("maximum_temperature", out range.max, fluid.temperatureRange.max);
-            return true;
+namespace Yafc.Parser;
+internal partial class FactorioDataDeserializer {
+    private const float EstimationDistanceFromCenter = 3000f;
+    private bool GetFluidBoxFilter(LuaTable table, string fluidBoxName, int temperature, [NotNullWhen(true)] out Fluid? fluid, out TemperatureRange range) {
+        fluid = null;
+        range = default;
+        if (!table.Get(fluidBoxName, out LuaTable? fluidBoxData)) {
+            return false;
         }
 
-        private int CountFluidBoxes(LuaTable list, bool input) {
-            int count = 0;
-            foreach (var fluidBox in list.ArrayElements<LuaTable>()) {
-                if (fluidBox.Get("production_type", out string? prodType) && (prodType == "input-output" || (input && prodType == "input") || (!input && prodType == "output"))) {
-                    ++count;
+        if (!fluidBoxData.Get("filter", out string? fluidName)) {
+            return false;
+        }
+
+        fluid = temperature == 0 ? GetObject<Fluid>(fluidName) : GetFluidFixedTemp(fluidName, temperature);
+        _ = fluidBoxData.Get("minimum_temperature", out range.min, fluid.temperatureRange.min);
+        _ = fluidBoxData.Get("maximum_temperature", out range.max, fluid.temperatureRange.max);
+        return true;
+    }
+
+    private int CountFluidBoxes(LuaTable list, bool input) {
+        int count = 0;
+        foreach (var fluidBox in list.ArrayElements<LuaTable>()) {
+            if (fluidBox.Get("production_type", out string? prodType) && (prodType == "input-output" || (input && prodType == "input") || (!input && prodType == "output"))) {
+                ++count;
+            }
+        }
+
+        return count;
+    }
+
+    private void ReadFluidEnergySource(LuaTable energySource, Entity entity) {
+        var energy = entity.energy;
+        _ = energySource.Get("burns_fluid", out bool burns, false);
+        energy.type = burns ? EntityEnergyType.FluidFuel : EntityEnergyType.FluidHeat;
+
+        energy.workingTemperature = TemperatureRange.Any;
+        if (energySource.Get("fluid_usage_per_tick", out float fuelLimit)) {
+            energy.fuelConsumptionLimit = fuelLimit * 60f;
+        }
+
+        if (GetFluidBoxFilter(energySource, "fluid_box", 0, out var fluid, out var filterTemperature)) {
+            string fuelCategory = SpecialNames.SpecificFluid + fluid.name;
+            fuelUsers.Add(entity, fuelCategory);
+            if (!burns) {
+                var temperature = fluid.temperatureRange;
+                int maxT = energySource.Get("maximum_temperature", int.MaxValue);
+                temperature.max = Math.Min(temperature.max, maxT);
+                energy.workingTemperature = temperature;
+                energy.acceptedTemperature = filterTemperature;
+            }
+        }
+        else if (burns) {
+            fuelUsers.Add(entity, SpecialNames.BurnableFluid);
+        }
+        else {
+            fuelUsers.Add(entity, SpecialNames.HotFluid);
+        }
+    }
+
+    private void ReadEnergySource(LuaTable energySource, Entity entity, float defaultDrain = 0f) {
+        _ = energySource.Get("type", out string type, "burner");
+        if (type == "void") {
+            entity.energy = voidEntityEnergy;
+            return;
+        }
+        EntityEnergy energy = new EntityEnergy();
+        entity.energy = energy;
+        energy.emissions = energySource.Get("emissions_per_minute", 0f);
+        energy.effectivity = energySource.Get("effectivity", 1f);
+        switch (type) {
+            case "electric":
+                fuelUsers.Add(entity, SpecialNames.Electricity);
+                energy.type = EntityEnergyType.Electric;
+                string? drainS = energySource.Get<string>("drain");
+                energy.drain = drainS == null ? defaultDrain : ParseEnergy(drainS);
+                break;
+            case "burner":
+                energy.type = EntityEnergyType.SolidFuel;
+                if (energySource.Get("fuel_categories", out LuaTable? categories)) {
+                    foreach (string cat in categories.ArrayElements<string>()) {
+                        fuelUsers.Add(entity, cat);
+                    }
+                }
+                else {
+                    fuelUsers.Add(entity, energySource.Get("fuel_category", "chemical"));
+                }
+
+                break;
+            case "heat":
+                energy.type = EntityEnergyType.Heat;
+                fuelUsers.Add(entity, SpecialNames.Heat);
+                energy.workingTemperature = new TemperatureRange(energySource.Get("min_working_temperature", 15), energySource.Get("max_temperature", 15));
+                break;
+            case "fluid":
+                ReadFluidEnergySource(energySource, entity);
+                break;
+        }
+    }
+
+    private int GetSize(LuaTable box) {
+        _ = box.Get(1, out LuaTable? topLeft);
+        _ = box.Get(2, out LuaTable? bottomRight);
+        _ = topLeft.Get(1, out float x0);
+        _ = topLeft.Get(2, out float y0);
+        _ = bottomRight.Get(1, out float x1);
+        _ = bottomRight.Get(2, out float y1);
+        return Math.Max(MathUtils.Round(x1 - x0), MathUtils.Round(y1 - y0));
+    }
+
+    private void ParseModules(LuaTable table, EntityWithModules entity, AllowedEffects def) {
+        if (table.Get("allowed_effects", out object? obj)) {
+            if (obj is string s) {
+                entity.allowedEffects = (AllowedEffects)Enum.Parse(typeof(AllowedEffects), s, true);
+            }
+            else if (obj is LuaTable t) {
+                entity.allowedEffects = AllowedEffects.None;
+                foreach (string str in t.ArrayElements<string>()) {
+                    entity.allowedEffects |= (AllowedEffects)Enum.Parse(typeof(AllowedEffects), str, true);
                 }
             }
-
-            return count;
+        }
+        else {
+            entity.allowedEffects = def;
         }
 
-        private void ReadFluidEnergySource(LuaTable energySource, Entity entity) {
-            var energy = entity.energy;
-            _ = energySource.Get("burns_fluid", out bool burns, false);
-            energy.type = burns ? EntityEnergyType.FluidFuel : EntityEnergyType.FluidHeat;
+        if (table.Get("module_specification", out LuaTable? moduleSpec)) {
+            entity.moduleSlots = moduleSpec.Get("module_slots", 0);
+        }
+    }
 
-            energy.workingTemperature = TemperatureRange.Any;
-            if (energySource.Get("fluid_usage_per_tick", out float fuelLimit)) {
-                energy.fuelConsumptionLimit = fuelLimit * 60f;
+    private Recipe CreateLaunchRecipe(EntityCrafter entity, Recipe recipe, int partsRequired, int outputCount) {
+        string launchCategory = SpecialNames.RocketCraft + entity.name;
+        var launchRecipe = CreateSpecialRecipe(recipe, launchCategory, "launch");
+        recipeCrafters.Add(entity, launchCategory);
+        launchRecipe.ingredients = recipe.products.Select(x => new Ingredient(x.goods, x.amount * partsRequired)).ToArray();
+        launchRecipe.products = new Product(rocketLaunch, outputCount).SingleElementArray();
+        launchRecipe.time = 40.33f / outputCount;
+        recipeCrafters.Add(entity, SpecialNames.RocketLaunch);
+        return launchRecipe;
+    }
+
+    private void DeserializeRocketEntities(LuaTable? data) {
+        if (data == null) {
+            return;
+        }
+
+        foreach (var entry in data.ObjectElements) {
+            if (entry.Value is LuaTable rocket && rocket.Get("inventory_size", out int size, 1)) {
+                rocketInventorySizes[rocket.Get("name", "")] = size;
             }
+        }
+    }
 
-            if (GetFluidBoxFilter(energySource, "fluid_box", 0, out var fluid, out var filterTemperature)) {
-                string fuelCategory = SpecialNames.SpecificFluid + fluid.name;
-                fuelUsers.Add(entity, fuelCategory);
-                if (!burns) {
-                    var temperature = fluid.temperatureRange;
-                    int maxT = energySource.Get("maximum_temperature", int.MaxValue);
-                    temperature.max = Math.Min(temperature.max, maxT);
-                    energy.workingTemperature = temperature;
-                    energy.acceptedTemperature = filterTemperature;
+    private void DeserializeEntity(LuaTable table, ErrorCollector errorCollector) {
+        string factorioType = table.Get("type", "");
+        string name = table.Get("name", "");
+        string? usesPower;
+        float defaultDrain = 0f;
+
+        if (table.Get("placeable_by", out LuaTable? placeableBy) && placeableBy.Get("item", out string? itemName)) {
+            var item = GetObject<Item>(itemName);
+            if (!placeResults.TryGetValue(item, out var resultNames)) {
+                resultNames = placeResults[item] = [];
+            }
+            resultNames.Add(name);
+        }
+
+        switch (factorioType) {
+            case "transport-belt":
+                GetObject<Entity, EntityBelt>(name).beltItemsPerSecond = table.Get("speed", 0f) * 480f; ;
+                break;
+            case "inserter":
+                var inserter = GetObject<Entity, EntityInserter>(name);
+                inserter.inserterSwingTime = 1f / (table.Get("rotation_speed", 1f) * 60);
+                inserter.isStackInserter = table.Get("stack", false);
+                break;
+            case "accumulator":
+                var accumulator = GetObject<Entity, EntityAccumulator>(name);
+                if (table.Get("energy_source", out LuaTable? accumulatorEnergy) && accumulatorEnergy.Get("buffer_capacity", out string? capacity)) {
+                    accumulator.accumulatorCapacity = ParseEnergy(capacity);
                 }
-            }
-            else if (burns) {
-                fuelUsers.Add(entity, SpecialNames.BurnableFluid);
-            }
-            else {
-                fuelUsers.Add(entity, SpecialNames.HotFluid);
-            }
-        }
 
-        private void ReadEnergySource(LuaTable energySource, Entity entity, float defaultDrain = 0f) {
-            _ = energySource.Get("type", out string type, "burner");
-            if (type == "void") {
-                entity.energy = voidEntityEnergy;
-                return;
-            }
-            EntityEnergy energy = new EntityEnergy();
-            entity.energy = energy;
-            energy.emissions = energySource.Get("emissions_per_minute", 0f);
-            energy.effectivity = energySource.Get("effectivity", 1f);
-            switch (type) {
-                case "electric":
-                    fuelUsers.Add(entity, SpecialNames.Electricity);
-                    energy.type = EntityEnergyType.Electric;
-                    string? drainS = energySource.Get<string>("drain");
-                    energy.drain = drainS == null ? defaultDrain : ParseEnergy(drainS);
+                break;
+            case "reactor":
+                var reactor = GetObject<Entity, EntityReactor>(name);
+                reactor.reactorNeighborBonus = table.Get("neighbour_bonus", 1f); // Keep UK spelling for Factorio/LUA data objects
+                _ = table.Get("consumption", out usesPower);
+                reactor.power = ParseEnergy(usesPower);
+                reactor.craftingSpeed = reactor.power;
+                recipeCrafters.Add(reactor, SpecialNames.ReactorRecipe);
+                break;
+            case "beacon":
+                var beacon = GetObject<Entity, EntityBeacon>(name);
+                beacon.beaconEfficiency = table.Get("distribution_effectivity", 0f);
+                _ = table.Get("energy_usage", out usesPower);
+                ParseModules(table, beacon, AllowedEffects.All ^ AllowedEffects.Productivity);
+                beacon.power = ParseEnergy(usesPower);
+                break;
+            case "logistic-container":
+            case "container":
+                var container = GetObject<Entity, EntityContainer>(name);
+                container.inventorySize = table.Get("inventory_size", 0);
+                if (factorioType == "logistic-container") {
+                    container.logisticMode = table.Get("logistic_mode", "");
+                    container.logisticSlotsCount = table.Get("logistic_slots_count", 0);
+                    if (container.logisticSlotsCount == 0) {
+                        container.logisticSlotsCount = table.Get("max_logistic_slots", 1000);
+                    }
+                }
+                break;
+            case "character":
+                var character = GetObject<Entity, EntityCrafter>(name);
+                character.itemInputs = 255;
+                if (table.Get("mining_categories", out LuaTable? resourceCategories)) {
+                    foreach (string playerMining in resourceCategories.ArrayElements<string>()) {
+                        recipeCrafters.Add(character, SpecialNames.MiningRecipe + playerMining);
+                    }
+                }
+
+                if (table.Get("crafting_categories", out LuaTable? craftingCategories)) {
+                    foreach (string playerCrafting in craftingCategories.ArrayElements<string>()) {
+                        recipeCrafters.Add(character, playerCrafting);
+                    }
+                }
+
+                character.energy = laborEntityEnergy;
+                if (character.name == "character") {
+                    this.character = character;
+                    character.mapGenerated = true;
+                    rootAccessible.Insert(0, character);
+                }
+                break;
+            case "boiler":
+                var boiler = GetObject<Entity, EntityCrafter>(name);
+                _ = table.Get("energy_consumption", out usesPower);
+                boiler.power = ParseEnergy(usesPower);
+                boiler.fluidInputs = 1;
+                bool hasOutput = table.Get("mode", out string? mode) && mode == "output-to-separate-pipe";
+                _ = GetFluidBoxFilter(table, "fluid_box", 0, out Fluid? input, out var acceptTemperature);
+                _ = table.Get("target_temperature", out int targetTemp);
+                Fluid? output = hasOutput ? GetFluidBoxFilter(table, "output_fluid_box", targetTemp, out var fluid, out _) ? fluid : null : input;
+                if (input == null || output == null) { // TODO - boiler works with any fluid - not supported
                     break;
-                case "burner":
-                    energy.type = EntityEnergyType.SolidFuel;
-                    if (energySource.Get("fuel_categories", out LuaTable? categories)) {
-                        foreach (string cat in categories.ArrayElements<string>()) {
-                            fuelUsers.Add(entity, cat);
+                }
+                // otherwise convert boiler production to a recipe
+                string category = SpecialNames.BoilerRecipe + boiler.name;
+                var recipe = CreateSpecialRecipe(output, category, "boiling to " + targetTemp + "°");
+                recipeCrafters.Add(boiler, category);
+                recipe.flags |= RecipeFlags.UsesFluidTemperature;
+                recipe.ingredients = new Ingredient(input, 60) { temperature = acceptTemperature }.SingleElementArray();
+                recipe.products = new Product(output, 60).SingleElementArray();
+                // This doesn't mean anything as RecipeFlags.UsesFluidTemperature overrides recipe time, but looks nice in the tooltip
+                recipe.time = input.heatCapacity * 60 * (output.temperature - Math.Max(input.temperature, input.temperatureRange.min)) / boiler.power;
+                boiler.craftingSpeed = 1f / boiler.power;
+                break;
+            case "assembling-machine":
+            case "rocket-silo":
+            case "furnace":
+                var crafter = GetObject<Entity, EntityCrafter>(name);
+                _ = table.Get("energy_usage", out usesPower);
+                ParseModules(table, crafter, AllowedEffects.None);
+                crafter.power = ParseEnergy(usesPower);
+                defaultDrain = crafter.power / 30f;
+                crafter.craftingSpeed = table.Get("crafting_speed", 1f);
+                crafter.itemInputs = factorioType == "furnace" ? table.Get("source_inventory_size", 1) : table.Get("ingredient_count", 255);
+                if (table.Get("fluid_boxes", out LuaTable? fluidBoxes)) {
+                    crafter.fluidInputs = CountFluidBoxes(fluidBoxes, true);
+                }
+
+                Recipe? fixedRecipe = null;
+                if (table.Get("fixed_recipe", out string? fixedRecipeName)) {
+                    string fixedRecipeCategoryName = SpecialNames.FixedRecipe + fixedRecipeName;
+                    fixedRecipe = GetObject<Recipe>(fixedRecipeName);
+                    recipeCrafters.Add(crafter, fixedRecipeCategoryName);
+                    recipeCategories.Add(fixedRecipeCategoryName, fixedRecipe);
+                }
+                else {
+                    _ = table.Get("crafting_categories", out craftingCategories);
+                    foreach (string categoryName in craftingCategories.ArrayElements<string>()) {
+                        recipeCrafters.Add(crafter, categoryName);
+                    }
+                }
+
+                if (factorioType == "rocket-silo") {
+                    int resultInventorySize = table.Get("rocket_result_inventory_size", 1);
+                    if (resultInventorySize > 0) {
+                        int outputCount = table.Get("rocket_entity", out string? rocketEntity) && rocketInventorySizes.TryGetValue(rocketEntity, out int value) ? value : 1;
+                        _ = table.Get("rocket_parts_required", out int partsRequired, 100);
+                        if (fixedRecipe != null) {
+                            var launchRecipe = CreateLaunchRecipe(crafter, fixedRecipe, partsRequired, outputCount);
+                            formerAliases["Mechanics.launch" + crafter.name + "." + crafter.name] = launchRecipe;
                         }
-                    }
-                    else {
-                        fuelUsers.Add(entity, energySource.Get("fuel_category", "chemical"));
-                    }
-
-                    break;
-                case "heat":
-                    energy.type = EntityEnergyType.Heat;
-                    fuelUsers.Add(entity, SpecialNames.Heat);
-                    energy.workingTemperature = new TemperatureRange(energySource.Get("min_working_temperature", 15), energySource.Get("max_temperature", 15));
-                    break;
-                case "fluid":
-                    ReadFluidEnergySource(energySource, entity);
-                    break;
-            }
-        }
-
-        private int GetSize(LuaTable box) {
-            _ = box.Get(1, out LuaTable? topLeft);
-            _ = box.Get(2, out LuaTable? bottomRight);
-            _ = topLeft.Get(1, out float x0);
-            _ = topLeft.Get(2, out float y0);
-            _ = bottomRight.Get(1, out float x1);
-            _ = bottomRight.Get(2, out float y1);
-            return Math.Max(MathUtils.Round(x1 - x0), MathUtils.Round(y1 - y0));
-        }
-
-        private void ParseModules(LuaTable table, EntityWithModules entity, AllowedEffects def) {
-            if (table.Get("allowed_effects", out object? obj)) {
-                if (obj is string s) {
-                    entity.allowedEffects = (AllowedEffects)Enum.Parse(typeof(AllowedEffects), s, true);
-                }
-                else if (obj is LuaTable t) {
-                    entity.allowedEffects = AllowedEffects.None;
-                    foreach (string str in t.ArrayElements<string>()) {
-                        entity.allowedEffects |= (AllowedEffects)Enum.Parse(typeof(AllowedEffects), str, true);
-                    }
-                }
-            }
-            else {
-                entity.allowedEffects = def;
-            }
-
-            if (table.Get("module_specification", out LuaTable? moduleSpec)) {
-                entity.moduleSlots = moduleSpec.Get("module_slots", 0);
-            }
-        }
-
-        private Recipe CreateLaunchRecipe(EntityCrafter entity, Recipe recipe, int partsRequired, int outputCount) {
-            string launchCategory = SpecialNames.RocketCraft + entity.name;
-            var launchRecipe = CreateSpecialRecipe(recipe, launchCategory, "launch");
-            recipeCrafters.Add(entity, launchCategory);
-            launchRecipe.ingredients = recipe.products.Select(x => new Ingredient(x.goods, x.amount * partsRequired)).ToArray();
-            launchRecipe.products = new Product(rocketLaunch, outputCount).SingleElementArray();
-            launchRecipe.time = 40.33f / outputCount;
-            recipeCrafters.Add(entity, SpecialNames.RocketLaunch);
-            return launchRecipe;
-        }
-
-        private void DeserializeRocketEntities(LuaTable? data) {
-            if (data == null) {
-                return;
-            }
-
-            foreach (var entry in data.ObjectElements) {
-                if (entry.Value is LuaTable rocket && rocket.Get("inventory_size", out int size, 1)) {
-                    rocketInventorySizes[rocket.Get("name", "")] = size;
-                }
-            }
-        }
-
-        private void DeserializeEntity(LuaTable table, ErrorCollector errorCollector) {
-            string factorioType = table.Get("type", "");
-            string name = table.Get("name", "");
-            string? usesPower;
-            float defaultDrain = 0f;
-
-            if (table.Get("placeable_by", out LuaTable? placeableBy) && placeableBy.Get("item", out string? itemName)) {
-                var item = GetObject<Item>(itemName);
-                if (!placeResults.TryGetValue(item, out var resultNames)) {
-                    resultNames = placeResults[item] = [];
-                }
-                resultNames.Add(name);
-            }
-
-            switch (factorioType) {
-                case "transport-belt":
-                    GetObject<Entity, EntityBelt>(name).beltItemsPerSecond = table.Get("speed", 0f) * 480f; ;
-                    break;
-                case "inserter":
-                    var inserter = GetObject<Entity, EntityInserter>(name);
-                    inserter.inserterSwingTime = 1f / (table.Get("rotation_speed", 1f) * 60);
-                    inserter.isStackInserter = table.Get("stack", false);
-                    break;
-                case "accumulator":
-                    var accumulator = GetObject<Entity, EntityAccumulator>(name);
-                    if (table.Get("energy_source", out LuaTable? accumulatorEnergy) && accumulatorEnergy.Get("buffer_capacity", out string? capacity)) {
-                        accumulator.accumulatorCapacity = ParseEnergy(capacity);
-                    }
-
-                    break;
-                case "reactor":
-                    var reactor = GetObject<Entity, EntityReactor>(name);
-                    reactor.reactorNeighborBonus = table.Get("neighbour_bonus", 1f); // Keep UK spelling for Factorio/LUA data objects
-                    _ = table.Get("consumption", out usesPower);
-                    reactor.power = ParseEnergy(usesPower);
-                    reactor.craftingSpeed = reactor.power;
-                    recipeCrafters.Add(reactor, SpecialNames.ReactorRecipe);
-                    break;
-                case "beacon":
-                    var beacon = GetObject<Entity, EntityBeacon>(name);
-                    beacon.beaconEfficiency = table.Get("distribution_effectivity", 0f);
-                    _ = table.Get("energy_usage", out usesPower);
-                    ParseModules(table, beacon, AllowedEffects.All ^ AllowedEffects.Productivity);
-                    beacon.power = ParseEnergy(usesPower);
-                    break;
-                case "logistic-container":
-                case "container":
-                    var container = GetObject<Entity, EntityContainer>(name);
-                    container.inventorySize = table.Get("inventory_size", 0);
-                    if (factorioType == "logistic-container") {
-                        container.logisticMode = table.Get("logistic_mode", "");
-                        container.logisticSlotsCount = table.Get("logistic_slots_count", 0);
-                        if (container.logisticSlotsCount == 0) {
-                            container.logisticSlotsCount = table.Get("max_logistic_slots", 1000);
-                        }
-                    }
-                    break;
-                case "character":
-                    var character = GetObject<Entity, EntityCrafter>(name);
-                    character.itemInputs = 255;
-                    if (table.Get("mining_categories", out LuaTable? resourceCategories)) {
-                        foreach (string playerMining in resourceCategories.ArrayElements<string>()) {
-                            recipeCrafters.Add(character, SpecialNames.MiningRecipe + playerMining);
-                        }
-                    }
-
-                    if (table.Get("crafting_categories", out LuaTable? craftingCategories)) {
-                        foreach (string playerCrafting in craftingCategories.ArrayElements<string>()) {
-                            recipeCrafters.Add(character, playerCrafting);
-                        }
-                    }
-
-                    character.energy = laborEntityEnergy;
-                    if (character.name == "character") {
-                        this.character = character;
-                        character.mapGenerated = true;
-                        rootAccessible.Insert(0, character);
-                    }
-                    break;
-                case "boiler":
-                    var boiler = GetObject<Entity, EntityCrafter>(name);
-                    _ = table.Get("energy_consumption", out usesPower);
-                    boiler.power = ParseEnergy(usesPower);
-                    boiler.fluidInputs = 1;
-                    bool hasOutput = table.Get("mode", out string? mode) && mode == "output-to-separate-pipe";
-                    _ = GetFluidBoxFilter(table, "fluid_box", 0, out Fluid? input, out var acceptTemperature);
-                    _ = table.Get("target_temperature", out int targetTemp);
-                    Fluid? output = hasOutput ? GetFluidBoxFilter(table, "output_fluid_box", targetTemp, out var fluid, out _) ? fluid : null : input;
-                    if (input == null || output == null) { // TODO - boiler works with any fluid - not supported
-                        break;
-                    }
-                    // otherwise convert boiler production to a recipe
-                    string category = SpecialNames.BoilerRecipe + boiler.name;
-                    var recipe = CreateSpecialRecipe(output, category, "boiling to " + targetTemp + "°");
-                    recipeCrafters.Add(boiler, category);
-                    recipe.flags |= RecipeFlags.UsesFluidTemperature;
-                    recipe.ingredients = new Ingredient(input, 60) { temperature = acceptTemperature }.SingleElementArray();
-                    recipe.products = new Product(output, 60).SingleElementArray();
-                    // This doesn't mean anything as RecipeFlags.UsesFluidTemperature overrides recipe time, but looks nice in the tooltip
-                    recipe.time = input.heatCapacity * 60 * (output.temperature - Math.Max(input.temperature, input.temperatureRange.min)) / boiler.power;
-                    boiler.craftingSpeed = 1f / boiler.power;
-                    break;
-                case "assembling-machine":
-                case "rocket-silo":
-                case "furnace":
-                    var crafter = GetObject<Entity, EntityCrafter>(name);
-                    _ = table.Get("energy_usage", out usesPower);
-                    ParseModules(table, crafter, AllowedEffects.None);
-                    crafter.power = ParseEnergy(usesPower);
-                    defaultDrain = crafter.power / 30f;
-                    crafter.craftingSpeed = table.Get("crafting_speed", 1f);
-                    crafter.itemInputs = factorioType == "furnace" ? table.Get("source_inventory_size", 1) : table.Get("ingredient_count", 255);
-                    if (table.Get("fluid_boxes", out LuaTable? fluidBoxes)) {
-                        crafter.fluidInputs = CountFluidBoxes(fluidBoxes, true);
-                    }
-
-                    Recipe? fixedRecipe = null;
-                    if (table.Get("fixed_recipe", out string? fixedRecipeName)) {
-                        string fixedRecipeCategoryName = SpecialNames.FixedRecipe + fixedRecipeName;
-                        fixedRecipe = GetObject<Recipe>(fixedRecipeName);
-                        recipeCrafters.Add(crafter, fixedRecipeCategoryName);
-                        recipeCategories.Add(fixedRecipeCategoryName, fixedRecipe);
-                    }
-                    else {
-                        _ = table.Get("crafting_categories", out craftingCategories);
-                        foreach (string categoryName in craftingCategories.ArrayElements<string>()) {
-                            recipeCrafters.Add(crafter, categoryName);
-                        }
-                    }
-
-                    if (factorioType == "rocket-silo") {
-                        int resultInventorySize = table.Get("rocket_result_inventory_size", 1);
-                        if (resultInventorySize > 0) {
-                            int outputCount = table.Get("rocket_entity", out string? rocketEntity) && rocketInventorySizes.TryGetValue(rocketEntity, out int value) ? value : 1;
-                            _ = table.Get("rocket_parts_required", out int partsRequired, 100);
-                            if (fixedRecipe != null) {
-                                var launchRecipe = CreateLaunchRecipe(crafter, fixedRecipe, partsRequired, outputCount);
-                                formerAliases["Mechanics.launch" + crafter.name + "." + crafter.name] = launchRecipe;
-                            }
-                            else {
-                                foreach (string categoryName in recipeCrafters.GetRaw(crafter).ToArray()) {
-                                    foreach (var possibleRecipe in recipeCategories.GetRaw(categoryName)) {
-                                        if (possibleRecipe is Recipe rec) {
-                                            _ = CreateLaunchRecipe(crafter, rec, partsRequired, outputCount);
-                                        }
+                        else {
+                            foreach (string categoryName in recipeCrafters.GetRaw(crafter).ToArray()) {
+                                foreach (var possibleRecipe in recipeCategories.GetRaw(categoryName)) {
+                                    if (possibleRecipe is Recipe rec) {
+                                        _ = CreateLaunchRecipe(crafter, rec, partsRequired, outputCount);
                                     }
                                 }
                             }
                         }
                     }
-                    break;
-                case "generator":
-                case "burner-generator":
-                    var generator = GetObject<Entity, EntityCrafter>(name);
-                    // generator energy input config is strange
-                    if (table.Get("max_power_output", out string? maxPowerOutput)) {
-                        generator.power = ParseEnergy(maxPowerOutput);
-                    }
+                }
+                break;
+            case "generator":
+            case "burner-generator":
+                var generator = GetObject<Entity, EntityCrafter>(name);
+                // generator energy input config is strange
+                if (table.Get("max_power_output", out string? maxPowerOutput)) {
+                    generator.power = ParseEnergy(maxPowerOutput);
+                }
 
-                    if ((factorioVersion < v0_18 || factorioType == "burner-generator") && table.Get("burner", out LuaTable? burnerSource)) {
-                        ReadEnergySource(burnerSource, generator);
-                    }
-                    else {
-                        generator.energy = new EntityEnergy { effectivity = table.Get("effectivity", 1f) };
-                        ReadFluidEnergySource(table, generator);
-                    }
-                    recipeCrafters.Add(generator, SpecialNames.GeneratorRecipe);
-                    break;
-                case "mining-drill":
-                    var drill = GetObject<Entity, EntityCrafter>(name);
-                    _ = table.Get("energy_usage", out usesPower);
-                    drill.power = ParseEnergy(usesPower);
-                    ParseModules(table, drill, AllowedEffects.All);
-                    drill.craftingSpeed = table.Get("mining_speed", 1f);
-                    _ = table.Get("resource_categories", out resourceCategories);
-                    if (table.Get("input_fluid_box", out LuaTable? _)) {
-                        drill.fluidInputs = 1;
-                    }
+                if ((factorioVersion < v0_18 || factorioType == "burner-generator") && table.Get("burner", out LuaTable? burnerSource)) {
+                    ReadEnergySource(burnerSource, generator);
+                }
+                else {
+                    generator.energy = new EntityEnergy { effectivity = table.Get("effectivity", 1f) };
+                    ReadFluidEnergySource(table, generator);
+                }
+                recipeCrafters.Add(generator, SpecialNames.GeneratorRecipe);
+                break;
+            case "mining-drill":
+                var drill = GetObject<Entity, EntityCrafter>(name);
+                _ = table.Get("energy_usage", out usesPower);
+                drill.power = ParseEnergy(usesPower);
+                ParseModules(table, drill, AllowedEffects.All);
+                drill.craftingSpeed = table.Get("mining_speed", 1f);
+                _ = table.Get("resource_categories", out resourceCategories);
+                if (table.Get("input_fluid_box", out LuaTable? _)) {
+                    drill.fluidInputs = 1;
+                }
 
-                    foreach (string resource in resourceCategories.ArrayElements<string>()) {
-                        recipeCrafters.Add(drill, SpecialNames.MiningRecipe + resource);
-                    }
+                foreach (string resource in resourceCategories.ArrayElements<string>()) {
+                    recipeCrafters.Add(drill, SpecialNames.MiningRecipe + resource);
+                }
 
-                    break;
-                case "offshore-pump":
-                    var pump = GetObject<Entity, EntityCrafter>(name);
-                    pump.craftingSpeed = table.Get("pumping_speed", 20f) / 20f;
-                    if (table.Get("fluid", out string? fluidName)) {
-                        var pumpingFluid = GetFluidFixedTemp(fluidName, 0);
-                        string recipeCategory = SpecialNames.PumpingRecipe + pumpingFluid.name;
-                        recipe = CreateSpecialRecipe(pumpingFluid, recipeCategory, "pumping");
-                        recipeCrafters.Add(pump, recipeCategory);
-                        pump.energy = voidEntityEnergy;
-                        if (recipe.products == null) {
-                            recipe.products = new Product(pumpingFluid, 1200f).SingleElementArray(); // set to Factorio default pump amounts - looks nice in tooltip
-                            recipe.ingredients = [];
-                            recipe.time = 1f;
-                        }
-                    }
-                    else {
-                        errorCollector.Error($"Could not load offshore pump {name}, because it does not pump anything.", ErrorSeverity.AnalysisWarning);
-                    }
-                    break;
-                case "lab":
-                    var lab = GetObject<Entity, EntityCrafter>(name);
-                    _ = table.Get("energy_usage", out usesPower);
-                    ParseModules(table, lab, AllowedEffects.All);
-                    lab.power = ParseEnergy(usesPower);
-                    lab.craftingSpeed = table.Get("researching_speed", 1f);
-                    recipeCrafters.Add(lab, SpecialNames.Labs);
-                    _ = table.Get("inputs", out LuaTable? inputs);
-                    lab.inputs = inputs.ArrayElements<string>().Select(GetObject<Item>).ToArray();
-                    sciencePacks.UnionWith(lab.inputs.Select(x => (Item)x));
-                    lab.itemInputs = lab.inputs.Length;
-                    break;
-                case "solar-panel":
-                    var solarPanel = GetObject<Entity, EntityCrafter>(name);
-                    solarPanel.energy = voidEntityEnergy;
-                    _ = table.Get("production", out string? powerProduction);
-                    recipeCrafters.Add(solarPanel, SpecialNames.GeneratorRecipe);
-                    solarPanel.craftingSpeed = ParseEnergy(powerProduction) * 0.7f; // 0.7f is a solar panel ratio on nauvis
-                    break;
-                case "electric-energy-interface":
-                    var eei = GetObject<Entity, EntityCrafter>(name);
-                    eei.energy = voidEntityEnergy;
-                    if (table.Get("energy_production", out string? interfaceProduction)) {
-                        eei.craftingSpeed = ParseEnergy(interfaceProduction);
-                        if (eei.craftingSpeed > 0) {
-                            recipeCrafters.Add(eei, SpecialNames.GeneratorRecipe);
-                        }
-                    }
-                    break;
-                case "constant-combinator":
-                    if (name == "constant-combinator") {
-                        Database.constantCombinatorCapacity = table.Get("item_slot_count", 18);
-                    }
-
-                    break;
-            }
-
-            var entity = DeserializeCommon<Entity>(table, "entity");
-
-            if (table.Get("loot", out LuaTable? lootList)) {
-                entity.loot = lootList.ArrayElements<LuaTable>().Select(x => {
-                    Product product = new Product(GetObject<Item>(x.Get("item", "")), x.Get("count_min", 1f), x.Get("count_max", 1f), x.Get("probability", 1f));
-                    return product;
-                }).ToArray();
-            }
-
-            if (table.Get("minable", out LuaTable? minable)) {
-                var products = LoadProductList(minable, "minable");
-                if (factorioType == "resource") {
-                    // mining resource is processed as a recipe
-                    _ = table.Get("category", out string category, "basic-solid");
-                    var recipe = CreateSpecialRecipe(entity, SpecialNames.MiningRecipe + category, "mining");
-                    recipe.flags = RecipeFlags.UsesMiningProductivity | RecipeFlags.LimitedByTickRate;
-                    recipe.time = minable.Get("mining_time", 1f);
-                    recipe.products = products;
-                    recipe.modules = [.. allModules];
-                    recipe.sourceEntity = entity;
-                    if (minable.Get("required_fluid", out string? requiredFluid)) {
-                        _ = minable.Get("fluid_amount", out float amount);
-                        recipe.ingredients = new Ingredient(GetObject<Fluid>(requiredFluid), amount / 10f).SingleElementArray(); // 10x difference is correct but why?
-                    }
-                    else {
+                break;
+            case "offshore-pump":
+                var pump = GetObject<Entity, EntityCrafter>(name);
+                pump.craftingSpeed = table.Get("pumping_speed", 20f) / 20f;
+                if (table.Get("fluid", out string? fluidName)) {
+                    var pumpingFluid = GetFluidFixedTemp(fluidName, 0);
+                    string recipeCategory = SpecialNames.PumpingRecipe + pumpingFluid.name;
+                    recipe = CreateSpecialRecipe(pumpingFluid, recipeCategory, "pumping");
+                    recipeCrafters.Add(pump, recipeCategory);
+                    pump.energy = voidEntityEnergy;
+                    if (recipe.products == null) {
+                        recipe.products = new Product(pumpingFluid, 1200f).SingleElementArray(); // set to Factorio default pump amounts - looks nice in tooltip
                         recipe.ingredients = [];
+                        recipe.time = 1f;
                     }
                 }
                 else {
-                    // otherwise it is processed as loot
-                    entity.loot = products;
+                    errorCollector.Error($"Could not load offshore pump {name}, because it does not pump anything.", ErrorSeverity.AnalysisWarning);
+                }
+                break;
+            case "lab":
+                var lab = GetObject<Entity, EntityCrafter>(name);
+                _ = table.Get("energy_usage", out usesPower);
+                ParseModules(table, lab, AllowedEffects.All);
+                lab.power = ParseEnergy(usesPower);
+                lab.craftingSpeed = table.Get("researching_speed", 1f);
+                recipeCrafters.Add(lab, SpecialNames.Labs);
+                _ = table.Get("inputs", out LuaTable? inputs);
+                lab.inputs = inputs.ArrayElements<string>().Select(GetObject<Item>).ToArray();
+                sciencePacks.UnionWith(lab.inputs.Select(x => (Item)x));
+                lab.itemInputs = lab.inputs.Length;
+                break;
+            case "solar-panel":
+                var solarPanel = GetObject<Entity, EntityCrafter>(name);
+                solarPanel.energy = voidEntityEnergy;
+                _ = table.Get("production", out string? powerProduction);
+                recipeCrafters.Add(solarPanel, SpecialNames.GeneratorRecipe);
+                solarPanel.craftingSpeed = ParseEnergy(powerProduction) * 0.7f; // 0.7f is a solar panel ratio on nauvis
+                break;
+            case "electric-energy-interface":
+                var eei = GetObject<Entity, EntityCrafter>(name);
+                eei.energy = voidEntityEnergy;
+                if (table.Get("energy_production", out string? interfaceProduction)) {
+                    eei.craftingSpeed = ParseEnergy(interfaceProduction);
+                    if (eei.craftingSpeed > 0) {
+                        recipeCrafters.Add(eei, SpecialNames.GeneratorRecipe);
+                    }
+                }
+                break;
+            case "constant-combinator":
+                if (name == "constant-combinator") {
+                    Database.constantCombinatorCapacity = table.Get("item_slot_count", 18);
+                }
+
+                break;
+        }
+
+        var entity = DeserializeCommon<Entity>(table, "entity");
+
+        if (table.Get("loot", out LuaTable? lootList)) {
+            entity.loot = lootList.ArrayElements<LuaTable>().Select(x => {
+                Product product = new Product(GetObject<Item>(x.Get("item", "")), x.Get("count_min", 1f), x.Get("count_max", 1f), x.Get("probability", 1f));
+                return product;
+            }).ToArray();
+        }
+
+        if (table.Get("minable", out LuaTable? minable)) {
+            var products = LoadProductList(minable, "minable");
+            if (factorioType == "resource") {
+                // mining resource is processed as a recipe
+                _ = table.Get("category", out string category, "basic-solid");
+                var recipe = CreateSpecialRecipe(entity, SpecialNames.MiningRecipe + category, "mining");
+                recipe.flags = RecipeFlags.UsesMiningProductivity | RecipeFlags.LimitedByTickRate;
+                recipe.time = minable.Get("mining_time", 1f);
+                recipe.products = products;
+                recipe.modules = [.. allModules];
+                recipe.sourceEntity = entity;
+                if (minable.Get("required_fluid", out string? requiredFluid)) {
+                    _ = minable.Get("fluid_amount", out float amount);
+                    recipe.ingredients = new Ingredient(GetObject<Fluid>(requiredFluid), amount / 10f).SingleElementArray(); // 10x difference is correct but why?
+                }
+                else {
+                    recipe.ingredients = [];
                 }
             }
-
-            entity.size = table.Get("selection_box", out LuaTable? box) ? GetSize(box) : 3;
-
-            _ = table.Get("energy_source", out LuaTable? energySource);
-            // These types have already called ReadEnergySource/ReadFluidEnergySource (generator, burner generator) or don't consume energy from YAFC's point of view (pump to EII).
-            // TODO: Work with AAI-I to support offshore pumps that consume energy.
-            if (factorioType is not "generator" and not "burner-generator" and not "offshore-pump" and not "solar-panel" and not "accumulator" and not "electric-energy-interface" && energySource != null) {
-                ReadEnergySource(energySource, entity, defaultDrain);
-            }
-
-            if (entity is EntityCrafter entityCrafter) {
-                entityCrafter.productivity = table.Get("base_productivity", 0f);
-            }
-
-            if (table.Get("autoplace", out LuaTable? generation)) {
-                entity.mapGenerated = true;
-                rootAccessible.Add(entity);
-                if (generation.Get("probability_expression", out LuaTable? prob)) {
-                    float probability = EstimateNoiseExpression(prob);
-                    float richness = generation.Get("richness_expression", out LuaTable? rich) ? EstimateNoiseExpression(rich) : probability;
-                    entity.mapGenDensity = richness * probability;
-                }
-                else if (generation.Get("coverage", out float coverage)) {
-                    float richBase = generation.Get("richness_base", 0f);
-                    float richMultiplier = generation.Get("richness_multiplier", 0f);
-                    float richMultiplierDist = generation.Get("richness_multiplier_distance_bonus", 0f);
-                    float estimatedAmount = coverage * (richBase + richMultiplier + (richMultiplierDist * EstimationDistanceFromCenter));
-                    entity.mapGenDensity = estimatedAmount;
-                }
-            }
-
-            entity.loot ??= [];
-
-            if (entity.energy == voidEntityEnergy || entity.energy == laborEntityEnergy) {
-                fuelUsers.Add(entity, SpecialNames.Void);
+            else {
+                // otherwise it is processed as loot
+                entity.loot = products;
             }
         }
 
-        private float EstimateArgument(LuaTable args, string name, float def = 0) {
-            return args.Get(name, out LuaTable? res) ? EstimateNoiseExpression(res) : def;
+        entity.size = table.Get("selection_box", out LuaTable? box) ? GetSize(box) : 3;
+
+        _ = table.Get("energy_source", out LuaTable? energySource);
+        // These types have already called ReadEnergySource/ReadFluidEnergySource (generator, burner generator) or don't consume energy from YAFC's point of view (pump to EII).
+        // TODO: Work with AAI-I to support offshore pumps that consume energy.
+        if (factorioType is not "generator" and not "burner-generator" and not "offshore-pump" and not "solar-panel" and not "accumulator" and not "electric-energy-interface" && energySource != null) {
+            ReadEnergySource(energySource, entity, defaultDrain);
         }
 
-        private float EstimateArgument(LuaTable args, int index, float def = 0) {
-            return args.Get(index, out LuaTable? res) ? EstimateNoiseExpression(res) : def;
+        if (entity is EntityCrafter entityCrafter) {
+            entityCrafter.productivity = table.Get("base_productivity", 0f);
         }
 
-        private float EstimateNoiseExpression(LuaTable expression) {
-            string type = expression.Get("type", "typed");
-            switch (type) {
-                case "variable":
-                    string varname = expression.Get("variable_name", "");
-                    if (varname is "x" or "y" or "distance") {
-                        return EstimationDistanceFromCenter;
-                    }
-
-                    if (((LuaTable?)raw["noise-expression"]).Get(varname, out LuaTable? noiseExpr)) {
-                        return EstimateArgument(noiseExpr, "expression");
-                    }
-
-                    return 1f;
-                case "function-application":
-                    string funName = expression.Get("function_name", "");
-                    var args = expression.Get<LuaTable>("arguments");
-                    if (args is null) {
-                        return 0;
-                    }
-                    switch (funName) {
-                        case "add":
-                            float res = 0f;
-                            foreach (var el in args.ArrayElements<LuaTable>()) {
-                                res += EstimateNoiseExpression(el);
-                            }
-
-                            return res;
-                        case "multiply":
-                            res = 1f;
-                            foreach (var el in args.ArrayElements<LuaTable>()) {
-                                res *= EstimateNoiseExpression(el);
-                            }
-
-                            return res;
-                        case "subtract":
-                            return EstimateArgument(args, 1) - EstimateArgument(args, 2);
-                        case "divide":
-                            return EstimateArgument(args, 1) / EstimateArgument(args, 2);
-                        case "exponentiate":
-                            return MathF.Pow(EstimateArgument(args, 1), EstimateArgument(args, 2));
-                        case "absolute-value":
-                            return MathF.Abs(EstimateArgument(args, 1));
-                        case "clamp":
-                            return MathUtils.Clamp(EstimateArgument(args, 1), EstimateArgument(args, 2), EstimateArgument(args, 3));
-                        case "log2":
-                            return MathF.Log(EstimateArgument(args, 1), 2f);
-                        case "distance-from-nearest-point":
-                            return EstimateArgument(args, "maximum_distance");
-                        case "ridge":
-                            return (EstimateArgument(args, 2) + EstimateArgument(args, 3)) * 0.5f; // TODO
-                        case "terrace":
-                            return EstimateArgument(args, "value"); // TODO what terrace does
-                        case "random-penalty":
-                            float source = EstimateArgument(args, "source");
-                            float penalty = EstimateArgument(args, "amplitude");
-                            if (penalty > source) {
-                                return source / penalty;
-                            }
-
-                            return (source + source - penalty) / 2;
-                        case "spot-noise":
-                            float quantity = EstimateArgument(args, "spot_quantity_expression");
-                            float spotCount;
-                            if (args.Get("candidate_spot_count", out LuaTable? spots)) {
-                                spotCount = EstimateNoiseExpression(spots);
-                            }
-                            else {
-                                spotCount = EstimateArgument(args, "candidate_point_count", 256) / EstimateArgument(args, "skip_span", 1);
-                            }
-
-                            float regionSize = EstimateArgument(args, "region_size", 512);
-                            regionSize *= regionSize;
-                            float count = spotCount * quantity / regionSize;
-                            return count;
-                        case "factorio-basis-noise":
-                        case "factorio-quick-multioctave-noise":
-                        case "factorio-multioctave-noise":
-                            float outputScale = EstimateArgument(args, "output_scale", 1f);
-                            return 0.1f * outputScale;
-                        default:
-                            return 0f;
-                    }
-                case "procedure-delimiter":
-                    return EstimateArgument(expression, "expression");
-                case "literal-number":
-                    return expression.Get("literal_value", 0f);
-                case "literal-expression":
-                    return EstimateArgument(expression, "literal_value");
-                default:
-                    return 0f;
+        if (table.Get("autoplace", out LuaTable? generation)) {
+            entity.mapGenerated = true;
+            rootAccessible.Add(entity);
+            if (generation.Get("probability_expression", out LuaTable? prob)) {
+                float probability = EstimateNoiseExpression(prob);
+                float richness = generation.Get("richness_expression", out LuaTable? rich) ? EstimateNoiseExpression(rich) : probability;
+                entity.mapGenDensity = richness * probability;
             }
+            else if (generation.Get("coverage", out float coverage)) {
+                float richBase = generation.Get("richness_base", 0f);
+                float richMultiplier = generation.Get("richness_multiplier", 0f);
+                float richMultiplierDist = generation.Get("richness_multiplier_distance_bonus", 0f);
+                float estimatedAmount = coverage * (richBase + richMultiplier + (richMultiplierDist * EstimationDistanceFromCenter));
+                entity.mapGenDensity = estimatedAmount;
+            }
+        }
+
+        entity.loot ??= [];
+
+        if (entity.energy == voidEntityEnergy || entity.energy == laborEntityEnergy) {
+            fuelUsers.Add(entity, SpecialNames.Void);
+        }
+    }
+
+    private float EstimateArgument(LuaTable args, string name, float def = 0) {
+        return args.Get(name, out LuaTable? res) ? EstimateNoiseExpression(res) : def;
+    }
+
+    private float EstimateArgument(LuaTable args, int index, float def = 0) {
+        return args.Get(index, out LuaTable? res) ? EstimateNoiseExpression(res) : def;
+    }
+
+    private float EstimateNoiseExpression(LuaTable expression) {
+        string type = expression.Get("type", "typed");
+        switch (type) {
+            case "variable":
+                string varname = expression.Get("variable_name", "");
+                if (varname is "x" or "y" or "distance") {
+                    return EstimationDistanceFromCenter;
+                }
+
+                if (((LuaTable?)raw["noise-expression"]).Get(varname, out LuaTable? noiseExpr)) {
+                    return EstimateArgument(noiseExpr, "expression");
+                }
+
+                return 1f;
+            case "function-application":
+                string funName = expression.Get("function_name", "");
+                var args = expression.Get<LuaTable>("arguments");
+                if (args is null) {
+                    return 0;
+                }
+                switch (funName) {
+                    case "add":
+                        float res = 0f;
+                        foreach (var el in args.ArrayElements<LuaTable>()) {
+                            res += EstimateNoiseExpression(el);
+                        }
+
+                        return res;
+                    case "multiply":
+                        res = 1f;
+                        foreach (var el in args.ArrayElements<LuaTable>()) {
+                            res *= EstimateNoiseExpression(el);
+                        }
+
+                        return res;
+                    case "subtract":
+                        return EstimateArgument(args, 1) - EstimateArgument(args, 2);
+                    case "divide":
+                        return EstimateArgument(args, 1) / EstimateArgument(args, 2);
+                    case "exponentiate":
+                        return MathF.Pow(EstimateArgument(args, 1), EstimateArgument(args, 2));
+                    case "absolute-value":
+                        return MathF.Abs(EstimateArgument(args, 1));
+                    case "clamp":
+                        return MathUtils.Clamp(EstimateArgument(args, 1), EstimateArgument(args, 2), EstimateArgument(args, 3));
+                    case "log2":
+                        return MathF.Log(EstimateArgument(args, 1), 2f);
+                    case "distance-from-nearest-point":
+                        return EstimateArgument(args, "maximum_distance");
+                    case "ridge":
+                        return (EstimateArgument(args, 2) + EstimateArgument(args, 3)) * 0.5f; // TODO
+                    case "terrace":
+                        return EstimateArgument(args, "value"); // TODO what terrace does
+                    case "random-penalty":
+                        float source = EstimateArgument(args, "source");
+                        float penalty = EstimateArgument(args, "amplitude");
+                        if (penalty > source) {
+                            return source / penalty;
+                        }
+
+                        return (source + source - penalty) / 2;
+                    case "spot-noise":
+                        float quantity = EstimateArgument(args, "spot_quantity_expression");
+                        float spotCount;
+                        if (args.Get("candidate_spot_count", out LuaTable? spots)) {
+                            spotCount = EstimateNoiseExpression(spots);
+                        }
+                        else {
+                            spotCount = EstimateArgument(args, "candidate_point_count", 256) / EstimateArgument(args, "skip_span", 1);
+                        }
+
+                        float regionSize = EstimateArgument(args, "region_size", 512);
+                        regionSize *= regionSize;
+                        float count = spotCount * quantity / regionSize;
+                        return count;
+                    case "factorio-basis-noise":
+                    case "factorio-quick-multioctave-noise":
+                    case "factorio-multioctave-noise":
+                        float outputScale = EstimateArgument(args, "output_scale", 1f);
+                        return 0.1f * outputScale;
+                    default:
+                        return 0f;
+                }
+            case "procedure-delimiter":
+                return EstimateArgument(expression, "expression");
+            case "literal-number":
+                return expression.Get("literal_value", 0f);
+            case "literal-expression":
+                return EstimateArgument(expression, "literal_value");
+            default:
+                return 0f;
         }
     }
 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -2,186 +2,185 @@
 using System.Linq;
 using Yafc.Model;
 
-namespace Yafc.Parser {
-    internal partial class FactorioDataDeserializer {
-        private T DeserializeWithDifficulty<T>(LuaTable table, string prototypeType, Action<T, LuaTable, bool, ErrorCollector> loader, ErrorCollector errorCollector) where T : FactorioObject, new() {
-            var obj = DeserializeCommon<T>(table, prototypeType);
-            object? current = expensiveRecipes ? table["expensive"] : table["normal"];
-            object? fallback = expensiveRecipes ? table["normal"] : table["expensive"];
-            if (current is LuaTable c) {
-                loader(obj, c, false, errorCollector);
-            }
-            else if (fallback is LuaTable f) {
-                loader(obj, f, current is bool b && !b, errorCollector);
-            }
-            else {
-                loader(obj, table, false, errorCollector);
-            }
-
-            return obj;
+namespace Yafc.Parser;
+internal partial class FactorioDataDeserializer {
+    private T DeserializeWithDifficulty<T>(LuaTable table, string prototypeType, Action<T, LuaTable, bool, ErrorCollector> loader, ErrorCollector errorCollector) where T : FactorioObject, new() {
+        var obj = DeserializeCommon<T>(table, prototypeType);
+        object? current = expensiveRecipes ? table["expensive"] : table["normal"];
+        object? fallback = expensiveRecipes ? table["normal"] : table["expensive"];
+        if (current is LuaTable c) {
+            loader(obj, c, false, errorCollector);
+        }
+        else if (fallback is LuaTable f) {
+            loader(obj, f, current is bool b && !b, errorCollector);
+        }
+        else {
+            loader(obj, table, false, errorCollector);
         }
 
-        private void DeserializeRecipe(LuaTable table, ErrorCollector errorCollector) {
-            var recipe = DeserializeWithDifficulty<Recipe>(table, "recipe", LoadRecipeData, errorCollector);
-            _ = table.Get("category", out string recipeCategory, "crafting");
-            recipeCategories.Add(recipeCategory, recipe);
-            recipe.modules = recipeModules.GetArray(recipe);
-            recipe.flags |= RecipeFlags.LimitedByTickRate;
-        }
+        return obj;
+    }
 
-        private static void DeserializeFlags(LuaTable table, RecipeOrTechnology recipe, bool forceDisable) {
-            recipe.hidden = table.Get("hidden", true);
-            if (forceDisable) {
-                recipe.enabled = false;
+    private void DeserializeRecipe(LuaTable table, ErrorCollector errorCollector) {
+        var recipe = DeserializeWithDifficulty<Recipe>(table, "recipe", LoadRecipeData, errorCollector);
+        _ = table.Get("category", out string recipeCategory, "crafting");
+        recipeCategories.Add(recipeCategory, recipe);
+        recipe.modules = recipeModules.GetArray(recipe);
+        recipe.flags |= RecipeFlags.LimitedByTickRate;
+    }
+
+    private static void DeserializeFlags(LuaTable table, RecipeOrTechnology recipe, bool forceDisable) {
+        recipe.hidden = table.Get("hidden", true);
+        if (forceDisable) {
+            recipe.enabled = false;
+        }
+        else {
+            recipe.enabled = table.Get("enabled", true);
+        }
+    }
+
+    private void DeserializeTechnology(LuaTable table, ErrorCollector errorCollector) {
+        var technology = DeserializeWithDifficulty<Technology>(table, "technology", LoadTechnologyData, errorCollector);
+        recipeCategories.Add(SpecialNames.Labs, technology);
+        technology.modules = [.. allModules];
+        technology.products = [new(researchUnit, 1)];
+    }
+
+    private void UpdateRecipeCatalysts() {
+        foreach (var recipe in allObjects.OfType<Recipe>()) {
+            foreach (var product in recipe.products) {
+                if (product.productivityAmount == product.amount) {
+                    float catalyst = recipe.GetConsumptionPerRecipe(product.goods);
+                    if (catalyst > 0f) {
+                        product.SetCatalyst(catalyst);
+                    }
+                }
             }
-            else {
-                recipe.enabled = table.Get("enabled", true);
-            }
         }
+    }
 
-        private void DeserializeTechnology(LuaTable table, ErrorCollector errorCollector) {
-            var technology = DeserializeWithDifficulty<Technology>(table, "technology", LoadTechnologyData, errorCollector);
-            recipeCategories.Add(SpecialNames.Labs, technology);
-            technology.modules = [.. allModules];
-            technology.products = [new(researchUnit, 1)];
-        }
+    private void UpdateRecipeIngredientFluids() {
+        foreach (var recipe in allObjects.OfType<Recipe>()) {
+            foreach (var ingredient in recipe.ingredients) {
+                if (ingredient.goods is Fluid fluid && fluid.variants != null) {
+                    int min = -1, max = fluid.variants.Count - 1;
+                    for (int i = 0; i < fluid.variants.Count; i++) {
+                        var variant = fluid.variants[i];
+                        if (variant.temperature < ingredient.temperature.min) {
+                            continue;
+                        }
 
-        private void UpdateRecipeCatalysts() {
-            foreach (var recipe in allObjects.OfType<Recipe>()) {
-                foreach (var product in recipe.products) {
-                    if (product.productivityAmount == product.amount) {
-                        float catalyst = recipe.GetConsumptionPerRecipe(product.goods);
-                        if (catalyst > 0f) {
-                            product.SetCatalyst(catalyst);
+                        if (min == -1) {
+                            min = i;
+                        }
+
+                        if (variant.temperature > ingredient.temperature.max) {
+                            max = i - 1;
+                            break;
+                        }
+                    }
+
+                    if (min >= 0 && max >= 0) {
+                        ingredient.goods = fluid.variants[min];
+                        if (max > min) {
+                            Fluid[] fluidVariants = new Fluid[max - min + 1];
+                            ingredient.variants = fluidVariants;
+                            fluid.variants.CopyTo(min, fluidVariants, 0, max - min + 1);
                         }
                     }
                 }
             }
         }
+    }
 
-        private void UpdateRecipeIngredientFluids() {
-            foreach (var recipe in allObjects.OfType<Recipe>()) {
-                foreach (var ingredient in recipe.ingredients) {
-                    if (ingredient.goods is Fluid fluid && fluid.variants != null) {
-                        int min = -1, max = fluid.variants.Count - 1;
-                        for (int i = 0; i < fluid.variants.Count; i++) {
-                            var variant = fluid.variants[i];
-                            if (variant.temperature < ingredient.temperature.min) {
-                                continue;
-                            }
-
-                            if (min == -1) {
-                                min = i;
-                            }
-
-                            if (variant.temperature > ingredient.temperature.max) {
-                                max = i - 1;
-                                break;
-                            }
-                        }
-
-                        if (min >= 0 && max >= 0) {
-                            ingredient.goods = fluid.variants[min];
-                            if (max > min) {
-                                Fluid[] fluidVariants = new Fluid[max - min + 1];
-                                ingredient.variants = fluidVariants;
-                                fluid.variants.CopyTo(min, fluidVariants, 0, max - min + 1);
-                            }
-                        }
-                    }
-                }
-            }
+    private void LoadTechnologyData(Technology technology, LuaTable table, bool forceDisable, ErrorCollector errorCollector) {
+        if (table.Get("unit", out LuaTable? unit)) {
+            technology.ingredients = LoadIngredientList(unit, technology.typeDotName, errorCollector);
+        }
+        else {
+            errorCollector.Error($"Could not get science packs for {technology.name}.", ErrorSeverity.AnalysisWarning);
+        }
+        DeserializeFlags(table, technology, forceDisable);
+        technology.time = unit.Get("time", 1f);
+        technology.count = unit.Get("count", 1000f);
+        if (table.Get("prerequisites", out LuaTable? prerequisitesList)) {
+            technology.prerequisites = prerequisitesList.ArrayElements<string>().Select(GetObject<Technology>).ToArray();
         }
 
-        private void LoadTechnologyData(Technology technology, LuaTable table, bool forceDisable, ErrorCollector errorCollector) {
-            if (table.Get("unit", out LuaTable? unit)) {
-                technology.ingredients = LoadIngredientList(unit, technology.typeDotName, errorCollector);
-            }
-            else {
-                errorCollector.Error($"Could not get science packs for {technology.name}.", ErrorSeverity.AnalysisWarning);
-            }
-            DeserializeFlags(table, technology, forceDisable);
-            technology.time = unit.Get("time", 1f);
-            technology.count = unit.Get("count", 1000f);
-            if (table.Get("prerequisites", out LuaTable? prerequisitesList)) {
-                technology.prerequisites = prerequisitesList.ArrayElements<string>().Select(GetObject<Technology>).ToArray();
+        if (table.Get("effects", out LuaTable? modifiers)) {
+            technology.unlockRecipes = modifiers.ArrayElements<LuaTable>()
+            .Select(x => x.Get("type", out string? type) && type == "unlock-recipe" && GetRef<Recipe>(x, "recipe", out var recipe) ? recipe : null).WhereNotNull()
+            .ToArray();
+        }
+    }
+
+    private Func<LuaTable, Product> LoadProduct(string typeDotName, int multiplier = 1) {
+        return table => {
+            bool haveExtraData = LoadItemData(table, true, typeDotName, out var goods, out float amount);
+            amount *= multiplier;
+            float min = amount, max = amount;
+            if (haveExtraData && amount == 0) {
+                _ = table.Get("amount_min", out min);
+                _ = table.Get("amount_max", out max);
+                min *= multiplier;
+                max *= multiplier;
             }
 
-            if (table.Get("effects", out LuaTable? modifiers)) {
-                technology.unlockRecipes = modifiers.ArrayElements<LuaTable>()
-                .Select(x => x.Get("type", out string? type) && type == "unlock-recipe" && GetRef<Recipe>(x, "recipe", out var recipe) ? recipe : null).WhereNotNull()
-                .ToArray();
+            Product product = new Product(goods, min, max, table.Get("probability", 1f));
+            float catalyst = table.Get("catalyst_amount", 0f);
+            if (catalyst > 0f) {
+                product.SetCatalyst(catalyst);
             }
+
+            return product;
+        };
+    }
+
+    private Product[] LoadProductList(LuaTable table, string typeDotName) {
+        if (table.Get("results", out LuaTable? resultList)) {
+            return resultList.ArrayElements<LuaTable>().Select(LoadProduct(typeDotName)).Where(x => x.amount != 0).ToArray();
         }
 
-        private Func<LuaTable, Product> LoadProduct(string typeDotName, int multiplier = 1) {
-            return table => {
-                bool haveExtraData = LoadItemData(table, true, typeDotName, out var goods, out float amount);
-                amount *= multiplier;
-                float min = amount, max = amount;
-                if (haveExtraData && amount == 0) {
-                    _ = table.Get("amount_min", out min);
-                    _ = table.Get("amount_max", out max);
-                    min *= multiplier;
-                    max *= multiplier;
-                }
-
-                Product product = new Product(goods, min, max, table.Get("probability", 1f));
-                float catalyst = table.Get("catalyst_amount", 0f);
-                if (catalyst > 0f) {
-                    product.SetCatalyst(catalyst);
-                }
-
-                return product;
-            };
+        _ = table.Get("result", out string? name);
+        if (name == null) {
+            return [];
         }
 
-        private Product[] LoadProductList(LuaTable table, string typeDotName) {
-            if (table.Get("results", out LuaTable? resultList)) {
-                return resultList.ArrayElements<LuaTable>().Select(LoadProduct(typeDotName)).Where(x => x.amount != 0).ToArray();
-            }
+        Product singleProduct = new Product(GetObject<Item>(name), table.Get("result_count", out float amount) ? amount : table.Get("count", 1));
+        return singleProduct.SingleElementArray();
+    }
 
-            _ = table.Get("result", out string? name);
-            if (name == null) {
-                return [];
+    private Ingredient[] LoadIngredientList(LuaTable table, string typeDotName, ErrorCollector errorCollector) {
+        _ = table.Get("ingredients", out LuaTable? ingredientsList);
+        return ingredientsList?.ArrayElements<LuaTable>().Select(table => {
+            bool haveExtraData = LoadItemData(table, false, typeDotName, out var goods, out float amount);
+            if (goods is null) {
+                errorCollector.Error($"Failed to load at least one ingredient for {typeDotName}.", ErrorSeverity.AnalysisWarning);
+                return null!;
             }
+            Ingredient ingredient = new Ingredient(goods, amount);
+            if (haveExtraData && goods is Fluid f) {
+                ingredient.temperature = table.Get("temperature", out int temp)
+                    ? new TemperatureRange(temp)
+                    : new TemperatureRange(table.Get("minimum_temperature", f.temperatureRange.min), table.Get("maximum_temperature", f.temperatureRange.max));
+            }
+            return ingredient;
+        }).Where(x => x is not null).ToArray() ?? [];
+    }
 
-            Product singleProduct = new Product(GetObject<Item>(name), table.Get("result_count", out float amount) ? amount : table.Get("count", 1));
-            return singleProduct.SingleElementArray();
+    private void LoadRecipeData(Recipe recipe, LuaTable table, bool forceDisable, ErrorCollector errorCollector) {
+        recipe.ingredients = LoadIngredientList(table, recipe.typeDotName, errorCollector);
+        recipe.products = LoadProductList(table, recipe.typeDotName);
+
+        recipe.time = table.Get("energy_required", 0.5f);
+
+        if (table.Get("main_product", out string? mainProductName) && mainProductName != "") {
+            recipe.mainProduct = recipe.products.FirstOrDefault(x => x.goods.name == mainProductName)?.goods;
+        }
+        else if (recipe.products.Length == 1) {
+            recipe.mainProduct = recipe.products[0]?.goods;
         }
 
-        private Ingredient[] LoadIngredientList(LuaTable table, string typeDotName, ErrorCollector errorCollector) {
-            _ = table.Get("ingredients", out LuaTable? ingredientsList);
-            return ingredientsList?.ArrayElements<LuaTable>().Select(table => {
-                bool haveExtraData = LoadItemData(table, false, typeDotName, out var goods, out float amount);
-                if (goods is null) {
-                    errorCollector.Error($"Failed to load at least one ingredient for {typeDotName}.", ErrorSeverity.AnalysisWarning);
-                    return null!;
-                }
-                Ingredient ingredient = new Ingredient(goods, amount);
-                if (haveExtraData && goods is Fluid f) {
-                    ingredient.temperature = table.Get("temperature", out int temp)
-                        ? new TemperatureRange(temp)
-                        : new TemperatureRange(table.Get("minimum_temperature", f.temperatureRange.min), table.Get("maximum_temperature", f.temperatureRange.max));
-                }
-                return ingredient;
-            }).Where(x => x is not null).ToArray() ?? [];
-        }
-
-        private void LoadRecipeData(Recipe recipe, LuaTable table, bool forceDisable, ErrorCollector errorCollector) {
-            recipe.ingredients = LoadIngredientList(table, recipe.typeDotName, errorCollector);
-            recipe.products = LoadProductList(table, recipe.typeDotName);
-
-            recipe.time = table.Get("energy_required", 0.5f);
-
-            if (table.Get("main_product", out string? mainProductName) && mainProductName != "") {
-                recipe.mainProduct = recipe.products.FirstOrDefault(x => x.goods.name == mainProductName)?.goods;
-            }
-            else if (recipe.products.Length == 1) {
-                recipe.mainProduct = recipe.products[0]?.goods;
-            }
-
-            DeserializeFlags(table, recipe, forceDisable);
-        }
+        DeserializeFlags(table, recipe, forceDisable);
     }
 }

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -9,440 +9,439 @@ using Serilog;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc.Parser {
-    public static partial class FactorioDataSource {
-        /* If you're wondering why this class is partial, 
-         * please check the implementation comment of ModInfo. 
-         */
+namespace Yafc.Parser;
+public static partial class FactorioDataSource {
+    /* If you're wondering why this class is partial,
+     * please check the implementation comment of ModInfo.
+     */
 
-        private static readonly ILogger logger = Logging.GetLogger(typeof(FactorioDataSource));
-        internal static Dictionary<string, ModInfo> allMods = [];
-        public static readonly Version defaultFactorioVersion = new Version(1, 1);
-        private static byte[] ReadAllBytes(this Stream stream, int length) {
-            BinaryReader reader = new BinaryReader(stream);
-            byte[] bytes = reader.ReadBytes(length);
-            stream.Dispose();
-            return bytes;
-        }
+    private static readonly ILogger logger = Logging.GetLogger(typeof(FactorioDataSource));
+    internal static Dictionary<string, ModInfo> allMods = [];
+    public static readonly Version defaultFactorioVersion = new Version(1, 1);
+    private static byte[] ReadAllBytes(this Stream stream, int length) {
+        BinaryReader reader = new BinaryReader(stream);
+        byte[] bytes = reader.ReadBytes(length);
+        stream.Dispose();
+        return bytes;
+    }
 
-        private static readonly byte[] bom = [0xEF, 0xBB, 0xBF];
+    private static readonly byte[] bom = [0xEF, 0xBB, 0xBF];
 
-        public static ReadOnlySpan<byte> CleanupBom(this ReadOnlySpan<byte> span) {
-            return span.StartsWith(bom) ? span[bom.Length..] : span;
-        }
+    public static ReadOnlySpan<byte> CleanupBom(this ReadOnlySpan<byte> span) {
+        return span.StartsWith(bom) ? span[bom.Length..] : span;
+    }
 
-        private static readonly char[] fileSplittersLua = ['.', '/', '\\'];
-        private static readonly char[] fileSplittersNormal = ['/', '\\'];
+    private static readonly char[] fileSplittersLua = ['.', '/', '\\'];
+    private static readonly char[] fileSplittersNormal = ['/', '\\'];
 #pragma warning disable CA2211 // Non-constant fields should not be visible.
-        // Suppressed because the only place where it's read is when there is an exception.
-        public static string? currentLoadingMod;
+    // Suppressed because the only place where it's read is when there is an exception.
+    public static string? currentLoadingMod;
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
-        public static (string mod, string path) ResolveModPath(string currentMod, string fullPath, bool isLuaRequire = false) {
-            string mod = currentMod;
-            char[] splitters = fileSplittersNormal;
-            if (isLuaRequire && !fullPath.Contains('/')) {
-                splitters = fileSplittersLua;
-            }
-
-            string[] path = fullPath.Split(splitters, StringSplitOptions.RemoveEmptyEntries);
-            if (Array.IndexOf(path, "..") >= 0) {
-                throw new InvalidOperationException("Attempt to traverse to parent directory");
-            }
-
-            IEnumerable<string> pathEnumerable = path;
-            if (path[0].StartsWith("__") && path[0].EndsWith("__")) {
-                mod = path[0][2..^2];
-                pathEnumerable = pathEnumerable.Skip(1);
-            }
-
-            string resolved = string.Join("/", pathEnumerable);
-            if (isLuaRequire) {
-                resolved += ".lua";
-            }
-
-            return (mod, resolved);
+    public static (string mod, string path) ResolveModPath(string currentMod, string fullPath, bool isLuaRequire = false) {
+        string mod = currentMod;
+        char[] splitters = fileSplittersNormal;
+        if (isLuaRequire && !fullPath.Contains('/')) {
+            splitters = fileSplittersLua;
         }
 
-        public static bool ModPathExists(string modName, string path) {
-            var info = allMods[modName];
-            if (info.zipArchive != null) {
-                return info.zipArchive.GetEntry(info.folder + path) != null;
-            }
-
-            string fileName = Path.Combine(info.folder, path);
-            return File.Exists(fileName);
+        string[] path = fullPath.Split(splitters, StringSplitOptions.RemoveEmptyEntries);
+        if (Array.IndexOf(path, "..") >= 0) {
+            throw new InvalidOperationException("Attempt to traverse to parent directory");
         }
 
-        public static byte[] ReadModFile(string modName, string path) {
-            var info = allMods[modName];
-            if (info.zipArchive != null) {
-                var entry = info.zipArchive.GetEntry(info.folder + path);
-                if (entry == null) {
-                    return [];
+        IEnumerable<string> pathEnumerable = path;
+        if (path[0].StartsWith("__") && path[0].EndsWith("__")) {
+            mod = path[0][2..^2];
+            pathEnumerable = pathEnumerable.Skip(1);
+        }
+
+        string resolved = string.Join("/", pathEnumerable);
+        if (isLuaRequire) {
+            resolved += ".lua";
+        }
+
+        return (mod, resolved);
+    }
+
+    public static bool ModPathExists(string modName, string path) {
+        var info = allMods[modName];
+        if (info.zipArchive != null) {
+            return info.zipArchive.GetEntry(info.folder + path) != null;
+        }
+
+        string fileName = Path.Combine(info.folder, path);
+        return File.Exists(fileName);
+    }
+
+    public static byte[] ReadModFile(string modName, string path) {
+        var info = allMods[modName];
+        if (info.zipArchive != null) {
+            var entry = info.zipArchive.GetEntry(info.folder + path);
+            if (entry == null) {
+                return [];
+            }
+
+            byte[] bytearr = new byte[entry.Length];
+            using (var stream = entry.Open()) {
+                int read = 0;
+                while (read < bytearr.Length) {
+                    read += stream.Read(bytearr, read, bytearr.Length - read);
                 }
-
-                byte[] bytearr = new byte[entry.Length];
-                using (var stream = entry.Open()) {
-                    int read = 0;
-                    while (read < bytearr.Length) {
-                        read += stream.Read(bytearr, read, bytearr.Length - read);
-                    }
-                }
-
-                return bytearr;
             }
 
-            string fileName = Path.Combine(info.folder, path);
-            return File.Exists(fileName) ? File.ReadAllBytes(fileName) : [];
+            return bytearr;
         }
 
-        private static void LoadModLocale(string modName, string locale) {
-            foreach (string localeName in GetAllModFiles(modName, "locale/" + locale + "/")) {
-                byte[] loaded = ReadModFile(modName, localeName);
-                using MemoryStream ms = new MemoryStream(loaded);
-                FactorioLocalization.Parse(ms);
+        string fileName = Path.Combine(info.folder, path);
+        return File.Exists(fileName) ? File.ReadAllBytes(fileName) : [];
+    }
+
+    private static void LoadModLocale(string modName, string locale) {
+        foreach (string localeName in GetAllModFiles(modName, "locale/" + locale + "/")) {
+            byte[] loaded = ReadModFile(modName, localeName);
+            using MemoryStream ms = new MemoryStream(loaded);
+            FactorioLocalization.Parse(ms);
+        }
+    }
+
+    private static void FindMods(string directory, IProgress<(string, string)> progress, List<ModInfo> mods) {
+        foreach (string entry in Directory.EnumerateDirectories(directory)) {
+            string infoFile = Path.Combine(entry, "info.json");
+            if (File.Exists(infoFile)) {
+                progress.Report(("Initializing", entry));
+                ModInfo info = new(entry, File.ReadAllBytes(infoFile));
+                mods.Add(info);
             }
         }
 
-        private static void FindMods(string directory, IProgress<(string, string)> progress, List<ModInfo> mods) {
-            foreach (string entry in Directory.EnumerateDirectories(directory)) {
-                string infoFile = Path.Combine(entry, "info.json");
-                if (File.Exists(infoFile)) {
-                    progress.Report(("Initializing", entry));
-                    ModInfo info = new(entry, File.ReadAllBytes(infoFile));
+        foreach (string fileName in Directory.EnumerateFiles(directory)) {
+            if (fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
+                FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+                ZipArchive zipArchive = new ZipArchive(fileStream);
+                var infoEntry = zipArchive.Entries.FirstOrDefault(x =>
+                    x.Name.Equals("info.json", StringComparison.OrdinalIgnoreCase) &&
+                    x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);
+                if (infoEntry != null) {
+                    ModInfo info = new(infoEntry.FullName[..^"info.json".Length], infoEntry.Open().ReadAllBytes((int)infoEntry.Length)) {
+                        zipArchive = zipArchive
+                    };
                     mods.Add(info);
                 }
             }
-
-            foreach (string fileName in Directory.EnumerateFiles(directory)) {
-                if (fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
-                    FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-                    ZipArchive zipArchive = new ZipArchive(fileStream);
-                    var infoEntry = zipArchive.Entries.FirstOrDefault(x =>
-                        x.Name.Equals("info.json", StringComparison.OrdinalIgnoreCase) &&
-                        x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);
-                    if (infoEntry != null) {
-                        ModInfo info = new(infoEntry.FullName[..^"info.json".Length], infoEntry.Open().ReadAllBytes((int)infoEntry.Length)) {
-                            zipArchive = zipArchive
-                        };
-                        mods.Add(info);
-                    }
-                }
-            }
         }
+    }
 
-        /// <summary>
-        /// Create or load the file <paramref name="projectPath"/> (if specified), with the Factorio data at <paramref name="factorioPath"/> and <paramref name="modPath"/>.
-        /// </summary>
-        /// <param name="factorioPath">The path to the data/ folder, containing the base and core folders.</param>
-        /// <param name="modPath">The path to the mods/ folder, containing mod-list.json and the mods. Both zipped and unzipped mods are supported. May be empty (but not <see langword="null"/>)
-        /// to load only vanilla Factorio data.</param>
-        /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
-        /// <param name="expensive">Whether to use expensive recipes.</param>
-        /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
-        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
-        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
-        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
-        /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
-        /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
-        /// <param name="locale">One of the languages supported by Factorio. Typically just the two-letter language code, e.g. en, but occasionally also includes the region code, e.g. pt-PT.</param>
-        /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
-        /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
-        /// <exception cref="NotSupportedException">Thrown if a mod enabled in mod-list.json could not be found in <paramref name="modPath"/>.</exception>
-        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, bool netProduction, IProgress<(string MajorState, string MinorState)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
-            LuaContext? dataContext = null;
-            try {
-                currentLoadingMod = null;
-                string modSettingsPath = Path.Combine(modPath, "mod-settings.dat");
-                progress.Report(("Initializing", "Loading mod list"));
-                string modListPath = Path.Combine(modPath, "mod-list.json");
-                Dictionary<string, Version> versionSpecifiers = [];
-                if (File.Exists(modListPath)) {
-                    var mods = JsonSerializer.Deserialize<ModList>(File.ReadAllText(modListPath)) ?? throw new($"Could not read mod list from {modListPath}");
-                    allMods = mods.mods.Where(x => x.enabled).Select(x => x.name).ToDictionary(x => x, x => (ModInfo)null!);
-                    versionSpecifiers = mods.mods.Where(x => x.enabled && !string.IsNullOrEmpty(x.version)).ToDictionary(x => x.name, x => Version.Parse(x.version!)); // null-forgiving: null version strings are filtered by the Where.
-                }
-                else {
-                    allMods = new Dictionary<string, ModInfo> { { "base", null! } };
-                }
-
-                allMods["core"] = null!;
-                logger.Information("Mod list parsed");
-
-                List<ModInfo> allFoundMods = [];
-                FindMods(factorioPath, progress, allFoundMods);
-                if (modPath != factorioPath && modPath != "") {
-                    FindMods(modPath, progress, allFoundMods);
-                }
-
-                Version? factorioVersion = null;
-                foreach (var mod in allFoundMods) {
-                    currentLoadingMod = mod.name;
-                    if (mod.name == "base") {
-                        mod.parsedFactorioVersion = mod.parsedVersion;
-                        if (factorioVersion == null || mod.parsedVersion > factorioVersion) {
-                            factorioVersion = mod.parsedVersion;
-                        }
-                    }
-                }
-
-                foreach (var mod in allFoundMods) {
-                    currentLoadingMod = mod.name;
-                    if (mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out var existing) && (existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null)) && (!versionSpecifiers.TryGetValue(mod.name, out var version) || mod.parsedVersion == version)) {
-                        existing?.Dispose();
-                        allMods[mod.name] = mod;
-                    }
-                    else {
-                        mod.Dispose();
-                    }
-                }
-
-                string? missingMod = null;
-
-                foreach (var (name, mod) in allMods) {
-                    currentLoadingMod = name;
-                    if (mod == null) {
-                        missingMod ??= name;
-                        logger.Error("Mod not found: {ModName}.", name);
-                    }
-
-                    mod?.ParseDependencies();
-                }
-
-                if (missingMod != null) {
-                    throw new NotSupportedException("Mod not found: " + missingMod + ". Try loading this pack in Factorio first.");
-                }
-
-
-                List<string> modsToDisable = [];
-                do {
-                    modsToDisable.Clear();
-                    foreach (var (name, mod) in allMods) {
-                        currentLoadingMod = name;
-                        if (!mod.CheckDependencies(allMods, modsToDisable)) {
-                            modsToDisable.Add(name);
-                        }
-                    }
-
-                    currentLoadingMod = null;
-
-                    foreach (string mod in modsToDisable) {
-                        _ = allMods.Remove(mod, out var disabled);
-                        disabled?.Dispose();
-                    }
-                } while (modsToDisable.Count > 0);
-
-                currentLoadingMod = null;
-                progress.Report(("Initializing", "Creating Lua context"));
-
-                HashSet<string> modsToLoad = [.. allMods.Keys];
-                string[] modLoadOrder = new string[modsToLoad.Count];
-                modLoadOrder[0] = "core";
-                _ = modsToLoad.Remove("core");
-                int index = 1;
-                List<string> sortedMods = [.. modsToLoad];
-                sortedMods.Sort((a, b) => string.Compare(a, b, StringComparison.OrdinalIgnoreCase));
-                List<string> currentLoadBatch = [];
-                while (modsToLoad.Count > 0) {
-                    currentLoadBatch.Clear();
-                    foreach (string mod in sortedMods) {
-                        if (allMods[mod].CanLoad(modsToLoad)) {
-                            currentLoadBatch.Add(mod);
-                        }
-                    }
-                    if (currentLoadBatch.Count == 0) {
-                        throw new NotSupportedException("Mods dependencies are circular. Unable to load mods: " + string.Join(", ", modsToLoad));
-                    }
-
-                    foreach (string mod in currentLoadBatch) {
-                        modLoadOrder[index++] = mod;
-                        _ = modsToLoad.Remove(mod);
-                    }
-
-                    _ = sortedMods.RemoveAll(x => !modsToLoad.Contains(x));
-                }
-
-                logger.Information("All mods found! Loading order: {LoadOrder}", string.Join(", ", modLoadOrder));
-
-                if (locale != "en") {
-                    foreach (string mod in modLoadOrder) {
-                        currentLoadingMod = mod;
-                        LoadModLocale(mod, "en");
-                    }
-                }
-                if (locale != null) {
-                    foreach (string mod in modLoadOrder) {
-                        currentLoadingMod = mod;
-                        LoadModLocale(mod, locale);
-                    }
-                }
-
-                byte[] preProcess = File.ReadAllBytes("Data/Sandbox.lua");
-                byte[] postProcess = File.ReadAllBytes("Data/Postprocess.lua");
-                DataUtils.dataPath = factorioPath;
-                DataUtils.modsPath = modPath;
-                DataUtils.expensiveRecipes = expensive;
-                DataUtils.netProduction = netProduction;
-
-
-                dataContext = new LuaContext();
-                object? settings = null;
-                if (File.Exists(modSettingsPath)) {
-                    using (FileStream fs = new FileStream(Path.Combine(modPath, "mod-settings.dat"), FileMode.Open, FileAccess.Read)) {
-                        settings = FactorioPropertyTree.ReadModSettings(new BinaryReader(fs), dataContext);
-                    }
-
-                    logger.Information("Mod settings parsed");
-                }
-                settings ??= dataContext.NewTable();
-
-                // TODO default mod settings
-                dataContext.SetGlobal("settings", settings);
-
-                _ = dataContext.Exec(preProcess, "*", "pre");
-                dataContext.DoModFiles(modLoadOrder, "data.lua", progress);
-                dataContext.DoModFiles(modLoadOrder, "data-updates.lua", progress);
-                dataContext.DoModFiles(modLoadOrder, "data-final-fixes.lua", progress);
-                _ = dataContext.Exec(postProcess, "*", "post");
-                currentLoadingMod = null;
-
-                FactorioDataDeserializer deserializer = new FactorioDataDeserializer(expensive, factorioVersion ?? defaultFactorioVersion);
-                var project = deserializer.LoadData(projectPath, dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
-                logger.Information("Completed!");
-                progress.Report(("Completed!", ""));
-                return project;
-            }
-            finally {
-                dataContext?.Dispose();
-                foreach (var mod in allMods) {
-                    mod.Value?.Dispose();
-                }
-
-                allMods.Clear();
-            }
-        }
-
-        internal class ModEntry {
-            public string name { get; set; } = null!; // null-forgiving: Initialized by the Json reader.
-            public bool enabled { get; set; }
-            public string? version { get; set; }
-        }
-
-        internal class ModList {
-            public ModEntry[] mods { get; set; } = null!; // null-forgiving: Initialized by the Json reader.
-        }
-
-        internal partial class ModInfo : IDisposable {
-            /* This class is partial because we want to generate a Regex at compile time.
-             * For that, we use a GeneratedRegex annotation that can be applied only to partial, parameterless, 
-             * non-generic methods that are typed to return Regex. 
-             * Due to the Regex method being partial, so is the ModInfo class, so is the FactorioDataSource class.
-             */
-
-            private static readonly string[] defaultDependencies = ["base"];
-            public string name { get; set; } = null!; // null-forgiving: Set by JsonSerializer.Populate
-            public string version { get; set; } = null!; // null-forgiving: Set by JsonSerializer.Populate
-            public string? factorio_version { get; set; }
-            public Version parsedVersion { get; set; }
-            public Version parsedFactorioVersion { get; set; }
-            public string[] dependencies { get; set; } = defaultDependencies;
-            private readonly List<(string mod, bool optional)> parsedDependencies = [];
-            private readonly List<string> incompatibilities = [];
-
-            public ZipArchive? zipArchive;
-            public string folder;
-
-            public ModInfo(string folder, byte[] json, ZipArchive? zipArchive = null) {
-                this.folder = folder;
-                this.zipArchive = zipArchive;
-                Newtonsoft.Json.JsonSerializer.Create().Populate(new StreamReader(new MemoryStream(json)), this);
-                _ = Version.TryParse(version, out var parsedV);
-                parsedVersion = parsedV ?? new Version();
-                _ = Version.TryParse(factorio_version, out parsedV);
-                parsedFactorioVersion = parsedV ?? defaultFactorioVersion;
-            }
-
-            public void ParseDependencies() {
-                foreach (string dependency in dependencies) {
-                    var match = DependencyRegex().Match(dependency);
-                    if (match.Success) {
-                        string modifier = match.Groups[1].Value;
-                        if (modifier == "!") {
-                            incompatibilities.Add(match.Groups[2].Value);
-                            continue;
-                        }
-                        if (modifier == "~") {
-                            continue;
-                        }
-
-                        parsedDependencies.Add((match.Groups[2].Value, modifier == "?"));
-                    }
-                }
-            }
-
-            private bool MajorMinorEquals(Version a, Version b) {
-                return a.Major == b.Major && a.Minor == b.Minor;
-            }
-
-            public bool ValidForFactorioVersion(Version? factorioVersion) {
-                return factorioVersion == null || MajorMinorEquals(factorioVersion, parsedFactorioVersion) ||
-                       (MajorMinorEquals(factorioVersion, new Version(1, 0)) && MajorMinorEquals(parsedFactorioVersion, new Version(0, 18))) || name == "core";
-            }
-
-            public bool CheckDependencies(Dictionary<string, ModInfo> allMods, List<string> modsToDisable) {
-                foreach (var (mod, optional) in parsedDependencies) {
-                    if (!optional && !allMods.ContainsKey(mod)) {
-                        return false;
-                    }
-                }
-
-                foreach (string incompatibility in incompatibilities) {
-                    if (allMods.ContainsKey(incompatibility) && !modsToDisable.Contains(incompatibility)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            public bool CanLoad(HashSet<string> notLoadedMods) {
-                foreach (var (mod, _) in parsedDependencies) {
-                    if (notLoadedMods.Contains(mod)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            public void Dispose() {
-                if (zipArchive != null) {
-                    zipArchive.Dispose();
-                    zipArchive = null;
-                }
-            }
-
-            [GeneratedRegex("^\\(?([?!~]?)\\)?\\s*([\\w- ]+?)(?:\\s*[><=]+\\s*[\\d.]*)?\\s*$")]
-            private static partial Regex DependencyRegex();
-        }
-
-        public static IEnumerable<string> GetAllModFiles(string mod, string prefix) {
-            var info = allMods[mod];
-            if (info.zipArchive != null) {
-                prefix = info.folder + prefix;
-                foreach (var entry in info.zipArchive.Entries) {
-                    if (entry.FullName.StartsWith(prefix, StringComparison.Ordinal)) {
-                        yield return entry.FullName[info.folder.Length..];
-                    }
-                }
+    /// <summary>
+    /// Create or load the file <paramref name="projectPath"/> (if specified), with the Factorio data at <paramref name="factorioPath"/> and <paramref name="modPath"/>.
+    /// </summary>
+    /// <param name="factorioPath">The path to the data/ folder, containing the base and core folders.</param>
+    /// <param name="modPath">The path to the mods/ folder, containing mod-list.json and the mods. Both zipped and unzipped mods are supported. May be empty (but not <see langword="null"/>)
+    /// to load only vanilla Factorio data.</param>
+    /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
+    /// <param name="expensive">Whether to use expensive recipes.</param>
+    /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+    /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+    /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+    /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
+    /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+    /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
+    /// <param name="locale">One of the languages supported by Factorio. Typically just the two-letter language code, e.g. en, but occasionally also includes the region code, e.g. pt-PT.</param>
+    /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
+    /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
+    /// <exception cref="NotSupportedException">Thrown if a mod enabled in mod-list.json could not be found in <paramref name="modPath"/>.</exception>
+    public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, bool netProduction, IProgress<(string MajorState, string MinorState)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
+        LuaContext? dataContext = null;
+        try {
+            currentLoadingMod = null;
+            string modSettingsPath = Path.Combine(modPath, "mod-settings.dat");
+            progress.Report(("Initializing", "Loading mod list"));
+            string modListPath = Path.Combine(modPath, "mod-list.json");
+            Dictionary<string, Version> versionSpecifiers = [];
+            if (File.Exists(modListPath)) {
+                var mods = JsonSerializer.Deserialize<ModList>(File.ReadAllText(modListPath)) ?? throw new($"Could not read mod list from {modListPath}");
+                allMods = mods.mods.Where(x => x.enabled).Select(x => x.name).ToDictionary(x => x, x => (ModInfo)null!);
+                versionSpecifiers = mods.mods.Where(x => x.enabled && !string.IsNullOrEmpty(x.version)).ToDictionary(x => x.name, x => Version.Parse(x.version!)); // null-forgiving: null version strings are filtered by the Where.
             }
             else {
-                string dirFrom = Path.Combine(info.folder, prefix);
-                if (Directory.Exists(dirFrom)) {
-                    foreach (string file in Directory.EnumerateFiles(dirFrom, "*", SearchOption.AllDirectories)) {
-                        yield return file[(info.folder.Length + 1)..];
+                allMods = new Dictionary<string, ModInfo> { { "base", null! } };
+            }
+
+            allMods["core"] = null!;
+            logger.Information("Mod list parsed");
+
+            List<ModInfo> allFoundMods = [];
+            FindMods(factorioPath, progress, allFoundMods);
+            if (modPath != factorioPath && modPath != "") {
+                FindMods(modPath, progress, allFoundMods);
+            }
+
+            Version? factorioVersion = null;
+            foreach (var mod in allFoundMods) {
+                currentLoadingMod = mod.name;
+                if (mod.name == "base") {
+                    mod.parsedFactorioVersion = mod.parsedVersion;
+                    if (factorioVersion == null || mod.parsedVersion > factorioVersion) {
+                        factorioVersion = mod.parsedVersion;
                     }
+                }
+            }
+
+            foreach (var mod in allFoundMods) {
+                currentLoadingMod = mod.name;
+                if (mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out var existing) && (existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null)) && (!versionSpecifiers.TryGetValue(mod.name, out var version) || mod.parsedVersion == version)) {
+                    existing?.Dispose();
+                    allMods[mod.name] = mod;
+                }
+                else {
+                    mod.Dispose();
+                }
+            }
+
+            string? missingMod = null;
+
+            foreach (var (name, mod) in allMods) {
+                currentLoadingMod = name;
+                if (mod == null) {
+                    missingMod ??= name;
+                    logger.Error("Mod not found: {ModName}.", name);
+                }
+
+                mod?.ParseDependencies();
+            }
+
+            if (missingMod != null) {
+                throw new NotSupportedException("Mod not found: " + missingMod + ". Try loading this pack in Factorio first.");
+            }
+
+
+            List<string> modsToDisable = [];
+            do {
+                modsToDisable.Clear();
+                foreach (var (name, mod) in allMods) {
+                    currentLoadingMod = name;
+                    if (!mod.CheckDependencies(allMods, modsToDisable)) {
+                        modsToDisable.Add(name);
+                    }
+                }
+
+                currentLoadingMod = null;
+
+                foreach (string mod in modsToDisable) {
+                    _ = allMods.Remove(mod, out var disabled);
+                    disabled?.Dispose();
+                }
+            } while (modsToDisable.Count > 0);
+
+            currentLoadingMod = null;
+            progress.Report(("Initializing", "Creating Lua context"));
+
+            HashSet<string> modsToLoad = [.. allMods.Keys];
+            string[] modLoadOrder = new string[modsToLoad.Count];
+            modLoadOrder[0] = "core";
+            _ = modsToLoad.Remove("core");
+            int index = 1;
+            List<string> sortedMods = [.. modsToLoad];
+            sortedMods.Sort((a, b) => string.Compare(a, b, StringComparison.OrdinalIgnoreCase));
+            List<string> currentLoadBatch = [];
+            while (modsToLoad.Count > 0) {
+                currentLoadBatch.Clear();
+                foreach (string mod in sortedMods) {
+                    if (allMods[mod].CanLoad(modsToLoad)) {
+                        currentLoadBatch.Add(mod);
+                    }
+                }
+                if (currentLoadBatch.Count == 0) {
+                    throw new NotSupportedException("Mods dependencies are circular. Unable to load mods: " + string.Join(", ", modsToLoad));
+                }
+
+                foreach (string mod in currentLoadBatch) {
+                    modLoadOrder[index++] = mod;
+                    _ = modsToLoad.Remove(mod);
+                }
+
+                _ = sortedMods.RemoveAll(x => !modsToLoad.Contains(x));
+            }
+
+            logger.Information("All mods found! Loading order: {LoadOrder}", string.Join(", ", modLoadOrder));
+
+            if (locale != "en") {
+                foreach (string mod in modLoadOrder) {
+                    currentLoadingMod = mod;
+                    LoadModLocale(mod, "en");
+                }
+            }
+            if (locale != null) {
+                foreach (string mod in modLoadOrder) {
+                    currentLoadingMod = mod;
+                    LoadModLocale(mod, locale);
+                }
+            }
+
+            byte[] preProcess = File.ReadAllBytes("Data/Sandbox.lua");
+            byte[] postProcess = File.ReadAllBytes("Data/Postprocess.lua");
+            DataUtils.dataPath = factorioPath;
+            DataUtils.modsPath = modPath;
+            DataUtils.expensiveRecipes = expensive;
+            DataUtils.netProduction = netProduction;
+
+
+            dataContext = new LuaContext();
+            object? settings = null;
+            if (File.Exists(modSettingsPath)) {
+                using (FileStream fs = new FileStream(Path.Combine(modPath, "mod-settings.dat"), FileMode.Open, FileAccess.Read)) {
+                    settings = FactorioPropertyTree.ReadModSettings(new BinaryReader(fs), dataContext);
+                }
+
+                logger.Information("Mod settings parsed");
+            }
+            settings ??= dataContext.NewTable();
+
+            // TODO default mod settings
+            dataContext.SetGlobal("settings", settings);
+
+            _ = dataContext.Exec(preProcess, "*", "pre");
+            dataContext.DoModFiles(modLoadOrder, "data.lua", progress);
+            dataContext.DoModFiles(modLoadOrder, "data-updates.lua", progress);
+            dataContext.DoModFiles(modLoadOrder, "data-final-fixes.lua", progress);
+            _ = dataContext.Exec(postProcess, "*", "post");
+            currentLoadingMod = null;
+
+            FactorioDataDeserializer deserializer = new FactorioDataDeserializer(expensive, factorioVersion ?? defaultFactorioVersion);
+            var project = deserializer.LoadData(projectPath, dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
+            logger.Information("Completed!");
+            progress.Report(("Completed!", ""));
+            return project;
+        }
+        finally {
+            dataContext?.Dispose();
+            foreach (var mod in allMods) {
+                mod.Value?.Dispose();
+            }
+
+            allMods.Clear();
+        }
+    }
+
+    internal class ModEntry {
+        public string name { get; set; } = null!; // null-forgiving: Initialized by the Json reader.
+        public bool enabled { get; set; }
+        public string? version { get; set; }
+    }
+
+    internal class ModList {
+        public ModEntry[] mods { get; set; } = null!; // null-forgiving: Initialized by the Json reader.
+    }
+
+    internal partial class ModInfo : IDisposable {
+        /* This class is partial because we want to generate a Regex at compile time.
+         * For that, we use a GeneratedRegex annotation that can be applied only to partial, parameterless,
+         * non-generic methods that are typed to return Regex.
+         * Due to the Regex method being partial, so is the ModInfo class, so is the FactorioDataSource class.
+         */
+
+        private static readonly string[] defaultDependencies = ["base"];
+        public string name { get; set; } = null!; // null-forgiving: Set by JsonSerializer.Populate
+        public string version { get; set; } = null!; // null-forgiving: Set by JsonSerializer.Populate
+        public string? factorio_version { get; set; }
+        public Version parsedVersion { get; set; }
+        public Version parsedFactorioVersion { get; set; }
+        public string[] dependencies { get; set; } = defaultDependencies;
+        private readonly List<(string mod, bool optional)> parsedDependencies = [];
+        private readonly List<string> incompatibilities = [];
+
+        public ZipArchive? zipArchive;
+        public string folder;
+
+        public ModInfo(string folder, byte[] json, ZipArchive? zipArchive = null) {
+            this.folder = folder;
+            this.zipArchive = zipArchive;
+            Newtonsoft.Json.JsonSerializer.Create().Populate(new StreamReader(new MemoryStream(json)), this);
+            _ = Version.TryParse(version, out var parsedV);
+            parsedVersion = parsedV ?? new Version();
+            _ = Version.TryParse(factorio_version, out parsedV);
+            parsedFactorioVersion = parsedV ?? defaultFactorioVersion;
+        }
+
+        public void ParseDependencies() {
+            foreach (string dependency in dependencies) {
+                var match = DependencyRegex().Match(dependency);
+                if (match.Success) {
+                    string modifier = match.Groups[1].Value;
+                    if (modifier == "!") {
+                        incompatibilities.Add(match.Groups[2].Value);
+                        continue;
+                    }
+                    if (modifier == "~") {
+                        continue;
+                    }
+
+                    parsedDependencies.Add((match.Groups[2].Value, modifier == "?"));
+                }
+            }
+        }
+
+        private bool MajorMinorEquals(Version a, Version b) {
+            return a.Major == b.Major && a.Minor == b.Minor;
+        }
+
+        public bool ValidForFactorioVersion(Version? factorioVersion) {
+            return factorioVersion == null || MajorMinorEquals(factorioVersion, parsedFactorioVersion) ||
+                   (MajorMinorEquals(factorioVersion, new Version(1, 0)) && MajorMinorEquals(parsedFactorioVersion, new Version(0, 18))) || name == "core";
+        }
+
+        public bool CheckDependencies(Dictionary<string, ModInfo> allMods, List<string> modsToDisable) {
+            foreach (var (mod, optional) in parsedDependencies) {
+                if (!optional && !allMods.ContainsKey(mod)) {
+                    return false;
+                }
+            }
+
+            foreach (string incompatibility in incompatibilities) {
+                if (allMods.ContainsKey(incompatibility) && !modsToDisable.Contains(incompatibility)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool CanLoad(HashSet<string> notLoadedMods) {
+            foreach (var (mod, _) in parsedDependencies) {
+                if (notLoadedMods.Contains(mod)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public void Dispose() {
+            if (zipArchive != null) {
+                zipArchive.Dispose();
+                zipArchive = null;
+            }
+        }
+
+        [GeneratedRegex("^\\(?([?!~]?)\\)?\\s*([\\w- ]+?)(?:\\s*[><=]+\\s*[\\d.]*)?\\s*$")]
+        private static partial Regex DependencyRegex();
+    }
+
+    public static IEnumerable<string> GetAllModFiles(string mod, string prefix) {
+        var info = allMods[mod];
+        if (info.zipArchive != null) {
+            prefix = info.folder + prefix;
+            foreach (var entry in info.zipArchive.Entries) {
+                if (entry.FullName.StartsWith(prefix, StringComparison.Ordinal)) {
+                    yield return entry.FullName[info.folder.Length..];
+                }
+            }
+        }
+        else {
+            string dirFrom = Path.Combine(info.folder, prefix);
+            if (Directory.Exists(dirFrom)) {
+                foreach (string file in Directory.EnumerateFiles(dirFrom, "*", SearchOption.AllDirectories)) {
+                    yield return file[(info.folder.Length + 1)..];
                 }
             }
         }

--- a/Yafc.Parser/FactorioLocalization.cs
+++ b/Yafc.Parser/FactorioLocalization.cs
@@ -1,64 +1,63 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 
-namespace Yafc.Parser {
-    internal static class FactorioLocalization {
-        private static readonly Dictionary<string, string> keys = [];
+namespace Yafc.Parser;
+internal static class FactorioLocalization {
+    private static readonly Dictionary<string, string> keys = [];
 
-        public static void Parse(Stream stream) {
-            using StreamReader reader = new StreamReader(stream);
-            string category = "";
-            while (true) {
-                string? line = reader.ReadLine();
-                if (line == null) {
-                    return;
-                }
-
-                line = line.Trim();
-                if (line.StartsWith("[") && line.EndsWith("]")) {
-                    category = line[1..^1];
-                }
-                else {
-                    int idx = line.IndexOf('=');
-                    if (idx < 0) {
-                        continue;
-                    }
-
-                    string key = line[..idx];
-                    string val = line.Substring(idx + 1, line.Length - idx - 1);
-                    keys[category + "." + key] = CleanupTags(val);
-                }
-
+    public static void Parse(Stream stream) {
+        using StreamReader reader = new StreamReader(stream);
+        string category = "";
+        while (true) {
+            string? line = reader.ReadLine();
+            if (line == null) {
+                return;
             }
+
+            line = line.Trim();
+            if (line.StartsWith("[") && line.EndsWith("]")) {
+                category = line[1..^1];
+            }
+            else {
+                int idx = line.IndexOf('=');
+                if (idx < 0) {
+                    continue;
+                }
+
+                string key = line[..idx];
+                string val = line.Substring(idx + 1, line.Length - idx - 1);
+                keys[category + "." + key] = CleanupTags(val);
+            }
+
+        }
+    }
+
+    private static string CleanupTags(string source) {
+        while (true) {
+            int tagStart = source.IndexOf('[');
+            if (tagStart < 0) {
+                return source;
+            }
+
+            int tagEnd = source.IndexOf(']', tagStart);
+            if (tagEnd < 0) {
+                return source;
+            }
+
+            source = source.Remove(tagStart, tagEnd - tagStart + 1);
+        }
+    }
+
+    public static string? Localize(string key) {
+        if (keys.TryGetValue(key, out string? val)) {
+            return val;
         }
 
-        private static string CleanupTags(string source) {
-            while (true) {
-                int tagStart = source.IndexOf('[');
-                if (tagStart < 0) {
-                    return source;
-                }
-
-                int tagEnd = source.IndexOf(']', tagStart);
-                if (tagEnd < 0) {
-                    return source;
-                }
-
-                source = source.Remove(tagStart, tagEnd - tagStart + 1);
-            }
+        int lastDash = key.LastIndexOf('-');
+        if (lastDash > 0 && int.TryParse(key[(lastDash + 1)..], out int level) && keys.TryGetValue(key[..lastDash], out val)) {
+            return val + " " + level;
         }
 
-        public static string? Localize(string key) {
-            if (keys.TryGetValue(key, out string? val)) {
-                return val;
-            }
-
-            int lastDash = key.LastIndexOf('-');
-            if (lastDash > 0 && int.TryParse(key[(lastDash + 1)..], out int level) && keys.TryGetValue(key[..lastDash], out val)) {
-                return val + " " + level;
-            }
-
-            return null;
-        }
+        return null;
     }
 }

--- a/Yafc.Parser/FactorioPropertyTree.cs
+++ b/Yafc.Parser/FactorioPropertyTree.cs
@@ -2,64 +2,63 @@
 using System.IO;
 using System.Text;
 
-namespace Yafc.Parser {
-    internal static class FactorioPropertyTree {
-        private static int ReadSpaceOptimizedUint(BinaryReader reader) {
-            byte b = reader.ReadByte();
-            if (b < 255) {
-                return b;
-            }
-
-            return reader.ReadInt32();
+namespace Yafc.Parser;
+internal static class FactorioPropertyTree {
+    private static int ReadSpaceOptimizedUint(BinaryReader reader) {
+        byte b = reader.ReadByte();
+        if (b < 255) {
+            return b;
         }
 
-        private static string ReadString(BinaryReader reader) {
-            if (reader.ReadBoolean()) {
-                return "";
-            }
+        return reader.ReadInt32();
+    }
 
-            int len = ReadSpaceOptimizedUint(reader);
-            byte[] bytes = reader.ReadBytes(len);
-            return Encoding.UTF8.GetString(bytes);
+    private static string ReadString(BinaryReader reader) {
+        if (reader.ReadBoolean()) {
+            return "";
         }
 
-        public static object? ReadModSettings(BinaryReader reader, LuaContext context) {
-            _ = reader.ReadInt64();
-            _ = reader.ReadBoolean();
-            return ReadAny(reader, context);
-        }
+        int len = ReadSpaceOptimizedUint(reader);
+        byte[] bytes = reader.ReadBytes(len);
+        return Encoding.UTF8.GetString(bytes);
+    }
 
-        private static object? ReadAny(BinaryReader reader, LuaContext context) {
-            byte type = reader.ReadByte();
-            _ = reader.ReadByte();
-            switch (type) {
-                case 0:
-                    return null;
-                case 1:
-                    return reader.ReadBoolean();
-                case 2:
-                    return reader.ReadDouble();
-                case 3:
-                    return ReadString(reader);
-                case 4:
-                    int count = reader.ReadInt32();
-                    var arr = context.NewTable();
-                    for (int i = 0; i < count; i++) {
-                        _ = ReadString(reader);
-                        arr[i + 1] = ReadAny(reader, context);
-                    }
-                    return arr;
-                case 5:
-                    count = reader.ReadInt32();
-                    var table = context.NewTable();
-                    for (int i = 0; i < count; i++) {
-                        table[ReadString(reader)] = ReadAny(reader, context);
-                    }
+    public static object? ReadModSettings(BinaryReader reader, LuaContext context) {
+        _ = reader.ReadInt64();
+        _ = reader.ReadBoolean();
+        return ReadAny(reader, context);
+    }
 
-                    return table;
-                default:
-                    throw new NotSupportedException("Unknown type");
-            }
+    private static object? ReadAny(BinaryReader reader, LuaContext context) {
+        byte type = reader.ReadByte();
+        _ = reader.ReadByte();
+        switch (type) {
+            case 0:
+                return null;
+            case 1:
+                return reader.ReadBoolean();
+            case 2:
+                return reader.ReadDouble();
+            case 3:
+                return ReadString(reader);
+            case 4:
+                int count = reader.ReadInt32();
+                var arr = context.NewTable();
+                for (int i = 0; i < count; i++) {
+                    _ = ReadString(reader);
+                    arr[i + 1] = ReadAny(reader, context);
+                }
+                return arr;
+            case 5:
+                count = reader.ReadInt32();
+                var table = context.NewTable();
+                for (int i = 0; i < count; i++) {
+                    table[ReadString(reader)] = ReadAny(reader, context);
+                }
+
+                return table;
+            default:
+                throw new NotSupportedException("Unknown type");
         }
     }
 }

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -9,513 +9,512 @@ using Yafc.Model;
 using Yafc.UI;
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Yafc.Model.Tests")]
 
-namespace Yafc.Parser {
-    public class LuaException(string luaMessage) : Exception(luaMessage) {
+namespace Yafc.Parser;
+public class LuaException(string luaMessage) : Exception(luaMessage) {
+}
+internal partial class LuaContext : IDisposable {
+    private enum Result {
+        LUA_OK = 0,
+        LUA_YIELD = 1,
+        LUA_ERRRUN = 2,
+        LUA_ERRSYNTAX = 3,
+        LUA_ERRMEM = 4,
+        LUA_ERRGCMM = 5,
+        LUA_ERRERR = 6
     }
-    internal partial class LuaContext : IDisposable {
-        private enum Result {
-            LUA_OK = 0,
-            LUA_YIELD = 1,
-            LUA_ERRRUN = 2,
-            LUA_ERRSYNTAX = 3,
-            LUA_ERRMEM = 4,
-            LUA_ERRGCMM = 5,
-            LUA_ERRERR = 6
+
+    private enum Type {
+        LUA_TNONE = -1,
+        LUA_TNIL = 0,
+        LUA_TBOOLEAN = 1,
+        LUA_TLIGHTUSERDATA = 2,
+        LUA_TNUMBER = 3,
+        LUA_TSTRING = 4,
+        LUA_TTABLE = 5,
+        LUA_TFUNCTION = 6,
+        LUA_TUSERDATA = 7,
+        LUA_TTHREAD = 8,
+    }
+
+
+    private const int LUA_REFNIL = -1;
+    private const int REGISTRY = -1001000;
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] private delegate int LuaCFunction(IntPtr lua);
+    private const string LUA = "lua52";
+
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial IntPtr luaL_newstate();
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial IntPtr luaL_openlibs(IntPtr state);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_close(IntPtr state);
+
+    [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial Result luaL_loadbufferx(IntPtr state, in byte buf, IntPtr sz, string name, string? mode);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial Result lua_pcallk(IntPtr state, int nargs, int nresults, int msgh, IntPtr ctx, IntPtr k);
+    [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial void luaL_traceback(IntPtr state, IntPtr state2, string? msg, int level);
+
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial Type lua_type(IntPtr state, int idx);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial IntPtr lua_tolstring(IntPtr state, int idx, out IntPtr len);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int lua_toboolean(IntPtr state, int idx);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial double lua_tonumberx(IntPtr state, int idx, [MarshalAs(UnmanagedType.Bool)] out bool isnum);
+
+    [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial int lua_getglobal(IntPtr state, string var);
+    [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial void lua_setglobal(IntPtr state, string name);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int luaL_ref(IntPtr state, int t);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int lua_checkstack(IntPtr state, int n);
+
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_pushnil(IntPtr state);
+    [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static partial IntPtr lua_pushstring(IntPtr state, string s);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_pushnumber(IntPtr state, double d);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_pushboolean(IntPtr state, int b);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_pushcclosure(IntPtr state, IntPtr callback, int n);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_createtable(IntPtr state, int narr, int nrec);
+
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_rawgeti(IntPtr state, int idx, long n);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_rawget(IntPtr state, int idx);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_rawset(IntPtr state, int idx);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_rawseti(IntPtr state, int idx, long n);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_len(IntPtr state, int index);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int lua_next(IntPtr state, int idx);
+
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial int lua_gettop(IntPtr state);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_settop(IntPtr state, int idx);
+
+
+    private IntPtr L;
+    private readonly int tracebackReg;
+    private readonly List<(string mod, string name)> fullChunkNames = [];
+    private readonly Dictionary<string, int> required = [];
+    private readonly Dictionary<(string mod, string name), byte[]> modFixes = [];
+
+    private static readonly ILogger logger = Logging.GetLogger<LuaContext>();
+
+    public LuaContext() {
+        L = luaL_newstate();
+        _ = luaL_openlibs(L);
+        RegisterApi(Log, "raw_log");
+        RegisterApi(Require, "require");
+        _ = lua_pushstring(L, Project.currentYafcVersion.ToString());
+        lua_setglobal(L, "yafc_version");
+        var mods = NewTable();
+        foreach (var mod in FactorioDataSource.allMods) {
+            mods[mod.Key] = mod.Value.version;
         }
 
-        private enum Type {
-            LUA_TNONE = -1,
-            LUA_TNIL = 0,
-            LUA_TBOOLEAN = 1,
-            LUA_TLIGHTUSERDATA = 2,
-            LUA_TNUMBER = 3,
-            LUA_TSTRING = 4,
-            LUA_TTABLE = 5,
-            LUA_TFUNCTION = 6,
-            LUA_TUSERDATA = 7,
-            LUA_TTHREAD = 8,
-        }
+        SetGlobal("mods", mods);
 
-
-        private const int LUA_REFNIL = -1;
-        private const int REGISTRY = -1001000;
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)] private delegate int LuaCFunction(IntPtr lua);
-        private const string LUA = "lua52";
-
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial IntPtr luaL_newstate();
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial IntPtr luaL_openlibs(IntPtr state);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_close(IntPtr state);
-
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial Result luaL_loadbufferx(IntPtr state, in byte buf, IntPtr sz, string name, string? mode);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial Result lua_pcallk(IntPtr state, int nargs, int nresults, int msgh, IntPtr ctx, IntPtr k);
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial void luaL_traceback(IntPtr state, IntPtr state2, string? msg, int level);
-
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial Type lua_type(IntPtr state, int idx);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial IntPtr lua_tolstring(IntPtr state, int idx, out IntPtr len);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial int lua_toboolean(IntPtr state, int idx);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial double lua_tonumberx(IntPtr state, int idx, [MarshalAs(UnmanagedType.Bool)] out bool isnum);
-
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial int lua_getglobal(IntPtr state, string var);
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial void lua_setglobal(IntPtr state, string name);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial int luaL_ref(IntPtr state, int t);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial int lua_checkstack(IntPtr state, int n);
-
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_pushnil(IntPtr state);
-        [LibraryImport(LUA, StringMarshalling = StringMarshalling.Utf8)]
-        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-        private static partial IntPtr lua_pushstring(IntPtr state, string s);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_pushnumber(IntPtr state, double d);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_pushboolean(IntPtr state, int b);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_pushcclosure(IntPtr state, IntPtr callback, int n);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_createtable(IntPtr state, int narr, int nrec);
-
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_rawgeti(IntPtr state, int idx, long n);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_rawget(IntPtr state, int idx);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_rawset(IntPtr state, int idx);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_rawseti(IntPtr state, int idx, long n);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_len(IntPtr state, int index);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial int lua_next(IntPtr state, int idx);
-
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial int lua_gettop(IntPtr state);
-        [LibraryImport(LUA)]
-        [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-        private static partial void lua_settop(IntPtr state, int idx);
-
-
-        private IntPtr L;
-        private readonly int tracebackReg;
-        private readonly List<(string mod, string name)> fullChunkNames = [];
-        private readonly Dictionary<string, int> required = [];
-        private readonly Dictionary<(string mod, string name), byte[]> modFixes = [];
-
-        private static readonly ILogger logger = Logging.GetLogger<LuaContext>();
-
-        public LuaContext() {
-            L = luaL_newstate();
-            _ = luaL_openlibs(L);
-            RegisterApi(Log, "raw_log");
-            RegisterApi(Require, "require");
-            _ = lua_pushstring(L, Project.currentYafcVersion.ToString());
-            lua_setglobal(L, "yafc_version");
-            var mods = NewTable();
-            foreach (var mod in FactorioDataSource.allMods) {
-                mods[mod.Key] = mod.Value.version;
-            }
-
-            SetGlobal("mods", mods);
-
-            LuaCFunction traceback = CreateErrorTraceback;
-            neverCollect.Add(traceback);
-            lua_pushcclosure(L, Marshal.GetFunctionPointerForDelegate(traceback), 0);
-            tracebackReg = luaL_ref(L, REGISTRY);
-            if (Directory.Exists("Data/Mod-fixes/")) {
-                foreach (string file in Directory.EnumerateFiles("Data/Mod-fixes/", "*.lua")) {
-                    string fileName = Path.GetFileName(file);
-                    string[] modAndFile = fileName.Split('.');
-                    string assemble = string.Join('/', modAndFile.Skip(1).SkipLast(1));
-                    modFixes[(modAndFile[0], assemble + ".lua")] = File.ReadAllBytes(file);
-                }
+        LuaCFunction traceback = CreateErrorTraceback;
+        neverCollect.Add(traceback);
+        lua_pushcclosure(L, Marshal.GetFunctionPointerForDelegate(traceback), 0);
+        tracebackReg = luaL_ref(L, REGISTRY);
+        if (Directory.Exists("Data/Mod-fixes/")) {
+            foreach (string file in Directory.EnumerateFiles("Data/Mod-fixes/", "*.lua")) {
+                string fileName = Path.GetFileName(file);
+                string[] modAndFile = fileName.Split('.');
+                string assemble = string.Join('/', modAndFile.Skip(1).SkipLast(1));
+                modFixes[(modAndFile[0], assemble + ".lua")] = File.ReadAllBytes(file);
             }
         }
+    }
 
-        private static int ParseTracebackEntry(string s, out int endOfName) {
-            endOfName = 0;
-            if (s.StartsWith("[string \"", StringComparison.Ordinal)) {
-                int endOfNum = s.IndexOf(' ', 9);
-                endOfName = s.IndexOf("\"]:", 9, StringComparison.Ordinal) + 2;
-                if (endOfNum >= 0 && endOfName >= 0) {
-                    return int.Parse(s[9..endOfNum]);
-                }
+    private static int ParseTracebackEntry(string s, out int endOfName) {
+        endOfName = 0;
+        if (s.StartsWith("[string \"", StringComparison.Ordinal)) {
+            int endOfNum = s.IndexOf(' ', 9);
+            endOfName = s.IndexOf("\"]:", 9, StringComparison.Ordinal) + 2;
+            if (endOfNum >= 0 && endOfName >= 0) {
+                return int.Parse(s[9..endOfNum]);
             }
-
-            return -1;
         }
 
-        private int CreateErrorTraceback(IntPtr lua) {
-            string message = GetString(1);
-            luaL_traceback(L, L, message, 0);
-            string actualTraceback = GetString(-1);
-            string[] split = [.. actualTraceback.Split("\n\t")];
-            for (int i = 0; i < split.Length; i++) {
-                int chunkId = ParseTracebackEntry(split[i], out int endOfName);
-                if (chunkId >= 0) {
-                    split[i] = fullChunkNames[chunkId] + split[i][endOfName..];
-                }
+        return -1;
+    }
+
+    private int CreateErrorTraceback(IntPtr lua) {
+        string message = GetString(1);
+        luaL_traceback(L, L, message, 0);
+        string actualTraceback = GetString(-1);
+        string[] split = [.. actualTraceback.Split("\n\t")];
+        for (int i = 0; i < split.Length; i++) {
+            int chunkId = ParseTracebackEntry(split[i], out int endOfName);
+            if (chunkId >= 0) {
+                split[i] = fullChunkNames[chunkId] + split[i][endOfName..];
             }
-
-            string reassemble = string.Join("\n", split);
-            _ = lua_pushstring(L, reassemble);
-            return 1;
         }
 
-        private int Log(IntPtr lua) {
-            logger.Information(GetString(1));
-            return 0;
-        }
-        private void GetReg(int refId) {
-            lua_rawgeti(L, REGISTRY, refId);
-        }
+        string reassemble = string.Join("\n", split);
+        _ = lua_pushstring(L, reassemble);
+        return 1;
+    }
 
-        private void Pop(int popc) {
-            lua_settop(L, lua_gettop(L) - popc);
-        }
+    private int Log(IntPtr lua) {
+        logger.Information(GetString(1));
+        return 0;
+    }
+    private void GetReg(int refId) {
+        lua_rawgeti(L, REGISTRY, refId);
+    }
 
-        public List<object?> ArrayElements(int refId) {
-            GetReg(refId); // 1
-            lua_pushnil(L);
-            List<object?> list = [];
-            while (lua_next(L, -2) != 0) {
-                object? value = PopManagedValue(1);
-                object? key = PopManagedValue(0);
-                if (key is double) {
-                    list.Add(value);
+    private void Pop(int popc) {
+        lua_settop(L, lua_gettop(L) - popc);
+    }
+
+    public List<object?> ArrayElements(int refId) {
+        GetReg(refId); // 1
+        lua_pushnil(L);
+        List<object?> list = [];
+        while (lua_next(L, -2) != 0) {
+            object? value = PopManagedValue(1);
+            object? key = PopManagedValue(0);
+            if (key is double) {
+                list.Add(value);
+            }
+            else {
+                break;
+            }
+        }
+        Pop(1);
+        return list;
+    }
+
+    public Dictionary<object, object?> ObjectElements(int refId) {
+        GetReg(refId); // 1
+        lua_pushnil(L);
+        Dictionary<object, object?> dict = [];
+        while (lua_next(L, -2) != 0) {
+            object? value = PopManagedValue(1);
+            object? key = PopManagedValue(0);
+            if (key != null) {
+                dict[key] = value;
+            }
+        }
+        Pop(1);
+        return dict;
+    }
+
+    public LuaTable NewTable() {
+        lua_createtable(L, 0, 0);
+        return new LuaTable(this, luaL_ref(L, REGISTRY));
+    }
+
+    public object? GetGlobal(string name) {
+        _ = lua_getglobal(L, name); // 1
+        return PopManagedValue(1);
+    }
+
+    public void SetGlobal(string name, object value) {
+        PushManagedObject(value);
+        lua_setglobal(L, name);
+    }
+    public object? GetValue(int refId, int idx) {
+        GetReg(refId); // 1
+        lua_rawgeti(L, -1, idx); // 2
+        return PopManagedValue(2);
+    }
+
+    public object? GetValue(int refId, string idx) {
+        GetReg(refId); // 1
+        _ = lua_pushstring(L, idx); // 2
+        lua_rawget(L, -2); // 3
+        return PopManagedValue(3);
+    }
+
+    private object? PopManagedValue(int popc) {
+        object? result = null;
+        switch (lua_type(L, -1)) {
+            case Type.LUA_TBOOLEAN:
+                result = lua_toboolean(L, -1) != 0;
+                break;
+            case Type.LUA_TNUMBER:
+                result = lua_tonumberx(L, -1, out _);
+                break;
+            case Type.LUA_TSTRING:
+                result = GetString(-1);
+                break;
+            case Type.LUA_TTABLE:
+                int refId = luaL_ref(L, REGISTRY);
+                LuaTable table = new LuaTable(this, refId);
+                if (popc == 0) {
+                    GetReg(table.refId);
                 }
                 else {
-                    break;
+                    popc--;
                 }
-            }
-            Pop(1);
-            return list;
+
+                result = table;
+                break;
+        }
+        if (popc > 0) {
+            Pop(popc);
         }
 
-        public Dictionary<object, object?> ObjectElements(int refId) {
-            GetReg(refId); // 1
+        return result;
+    }
+
+    private void PushManagedObject(object? value) {
+        if (value is double d) {
+            lua_pushnumber(L, d);
+        }
+        else if (value is int i) {
+            lua_pushnumber(L, i);
+        }
+        else if (value is string s) {
+            _ = lua_pushstring(L, s);
+        }
+        else if (value is LuaTable t) {
+            GetReg(t.refId);
+        }
+        else if (value is bool b) {
+            lua_pushboolean(L, b ? 1 : 0);
+        }
+        else {
             lua_pushnil(L);
-            Dictionary<object, object?> dict = [];
-            while (lua_next(L, -2) != 0) {
-                object? value = PopManagedValue(1);
-                object? key = PopManagedValue(0);
-                if (key != null) {
-                    dict[key] = value;
-                }
-            }
-            Pop(1);
-            return dict;
+        }
+    }
+
+    public void SetValue(int refId, string idx, object? value) {
+        GetReg(refId); // 1;
+        _ = lua_pushstring(L, idx); // 2
+        PushManagedObject(value); // 3;
+        lua_rawset(L, -3);
+        Pop(3);
+    }
+
+    public void SetValue(int refId, int idx, object? value) {
+        GetReg(refId); // 1;
+        PushManagedObject(value); // 2;
+        lua_rawseti(L, -2, idx);
+        Pop(2);
+    }
+
+    private static string GetDirectoryName(string s) {
+        int lastSlash = s.LastIndexOf('/');
+        return lastSlash >= 0 ? s[..(lastSlash + 1)] : "";
+    }
+
+    private int Require(IntPtr lua) {
+        string file = GetString(1); // 1
+        string argument = file;
+        if (file.Contains("..")) {
+            throw new NotSupportedException("Attempt to traverse to parent directory");
         }
 
-        public LuaTable NewTable() {
-            lua_createtable(L, 0, 0);
-            return new LuaTable(this, luaL_ref(L, REGISTRY));
+        if (file.EndsWith(".lua", StringComparison.OrdinalIgnoreCase)) {
+            file = file[..^4];
         }
 
-        public object? GetGlobal(string name) {
-            _ = lua_getglobal(L, name); // 1
-            return PopManagedValue(1);
-        }
-
-        public void SetGlobal(string name, object value) {
-            PushManagedObject(value);
-            lua_setglobal(L, name);
-        }
-        public object? GetValue(int refId, int idx) {
-            GetReg(refId); // 1
-            lua_rawgeti(L, -1, idx); // 2
-            return PopManagedValue(2);
-        }
-
-        public object? GetValue(int refId, string idx) {
-            GetReg(refId); // 1
-            _ = lua_pushstring(L, idx); // 2
-            lua_rawget(L, -2); // 3
-            return PopManagedValue(3);
-        }
-
-        private object? PopManagedValue(int popc) {
-            object? result = null;
-            switch (lua_type(L, -1)) {
-                case Type.LUA_TBOOLEAN:
-                    result = lua_toboolean(L, -1) != 0;
-                    break;
-                case Type.LUA_TNUMBER:
-                    result = lua_tonumberx(L, -1, out _);
-                    break;
-                case Type.LUA_TSTRING:
-                    result = GetString(-1);
-                    break;
-                case Type.LUA_TTABLE:
-                    int refId = luaL_ref(L, REGISTRY);
-                    LuaTable table = new LuaTable(this, refId);
-                    if (popc == 0) {
-                        GetReg(table.refId);
-                    }
-                    else {
-                        popc--;
-                    }
-
-                    result = table;
-                    break;
-            }
-            if (popc > 0) {
-                Pop(popc);
-            }
-
-            return result;
-        }
-
-        private void PushManagedObject(object? value) {
-            if (value is double d) {
-                lua_pushnumber(L, d);
-            }
-            else if (value is int i) {
-                lua_pushnumber(L, i);
-            }
-            else if (value is string s) {
-                _ = lua_pushstring(L, s);
-            }
-            else if (value is LuaTable t) {
-                GetReg(t.refId);
-            }
-            else if (value is bool b) {
-                lua_pushboolean(L, b ? 1 : 0);
-            }
-            else {
-                lua_pushnil(L);
+        file = file.Replace('\\', '/');
+        string origFile = file;
+        file = file.Replace('.', '/');
+        string fileExt = file + ".lua";
+        Pop(1);
+        luaL_traceback(L, L, null, 1); //2
+        // TODO how to determine where to start require search? Parsing lua traceback output for now
+        string tracebackS = GetString(-1);
+        string[] tracebackVal = tracebackS.Split("\n\t");
+        int traceId = -1;
+        foreach (string traceLine in tracebackVal) // TODO slightly hacky
+        {
+            traceId = ParseTracebackEntry(traceLine, out _);
+            if (traceId >= 0) {
+                break;
             }
         }
+        var (mod, source) = fullChunkNames[traceId];
 
-        public void SetValue(int refId, string idx, object? value) {
-            GetReg(refId); // 1;
-            _ = lua_pushstring(L, idx); // 2
-            PushManagedObject(value); // 3;
-            lua_rawset(L, -3);
-            Pop(3);
+        (string mod, string path) requiredFile = (mod, fileExt);
+        if (file.StartsWith("__")) {
+            requiredFile = FactorioDataSource.ResolveModPath(mod, origFile, true);
         }
-
-        public void SetValue(int refId, int idx, object? value) {
-            GetReg(refId); // 1;
-            PushManagedObject(value); // 2;
-            lua_rawseti(L, -2, idx);
-            Pop(2);
-        }
-
-        private static string GetDirectoryName(string s) {
-            int lastSlash = s.LastIndexOf('/');
-            return lastSlash >= 0 ? s[..(lastSlash + 1)] : "";
-        }
-
-        private int Require(IntPtr lua) {
-            string file = GetString(1); // 1
-            string argument = file;
-            if (file.Contains("..")) {
-                throw new NotSupportedException("Attempt to traverse to parent directory");
-            }
-
-            if (file.EndsWith(".lua", StringComparison.OrdinalIgnoreCase)) {
-                file = file[..^4];
-            }
-
-            file = file.Replace('\\', '/');
-            string origFile = file;
-            file = file.Replace('.', '/');
-            string fileExt = file + ".lua";
-            Pop(1);
-            luaL_traceback(L, L, null, 1); //2
-            // TODO how to determine where to start require search? Parsing lua traceback output for now
-            string tracebackS = GetString(-1);
-            string[] tracebackVal = tracebackS.Split("\n\t");
-            int traceId = -1;
-            foreach (string traceLine in tracebackVal) // TODO slightly hacky
-            {
-                traceId = ParseTracebackEntry(traceLine, out _);
-                if (traceId >= 0) {
-                    break;
-                }
-            }
-            var (mod, source) = fullChunkNames[traceId];
-
-            (string mod, string path) requiredFile = (mod, fileExt);
-            if (file.StartsWith("__")) {
-                requiredFile = FactorioDataSource.ResolveModPath(mod, origFile, true);
-            }
-            else if (mod == "*") {
-                byte[] localFile = File.ReadAllBytes("Data/" + fileExt);
-                int result = Exec(localFile, "*", file);
-                GetReg(result);
-                return 1;
-            }
-            else if (FactorioDataSource.ModPathExists(requiredFile.mod, fileExt)) { }
-            else if (FactorioDataSource.ModPathExists(requiredFile.mod, GetDirectoryName(source) + fileExt)) {
-                requiredFile.path = GetDirectoryName(source) + fileExt;
-            }
-            else if (FactorioDataSource.ModPathExists("core", "lualib/" + fileExt)) {
-                requiredFile.mod = "core";
-                requiredFile.path = "lualib/" + fileExt;
-            }
-            else { // Just find anything ffs
-                foreach (string path in FactorioDataSource.GetAllModFiles(requiredFile.mod, GetDirectoryName(source))) {
-                    if (path.EndsWith(fileExt, StringComparison.OrdinalIgnoreCase)) {
-                        requiredFile.path = path;
-                        break;
-                    }
-                }
-            }
-
-            if (required.TryGetValue(argument, out int value)) {
-                GetReg(value);
-                return 1;
-            }
-            logger.Information("Require {RequiredFile}", requiredFile.mod + "/" + requiredFile.path);
-            byte[] bytes = FactorioDataSource.ReadModFile(requiredFile.mod, requiredFile.path);
-            if (bytes != null) {
-                _ = lua_pushstring(L, argument);
-                int argumentReg = luaL_ref(L, REGISTRY);
-                int result = Exec(bytes, requiredFile.mod, requiredFile.path, argumentReg);
-                if (modFixes.TryGetValue(requiredFile, out byte[]? fix)) {
-                    string modFixName = "mod-fix-" + requiredFile.mod + "." + requiredFile.path;
-                    logger.Information("Running mod-fix {ModFix}", modFixName);
-                    result = Exec(fix, "*", modFixName, result);
-                }
-                required[argument] = result;
-                GetReg(result);
-            }
-            else {
-                logger.Error("LUA require failed: mod {mod}, file {file}", mod, file);
-                lua_pushnil(L);
-            }
+        else if (mod == "*") {
+            byte[] localFile = File.ReadAllBytes("Data/" + fileExt);
+            int result = Exec(localFile, "*", file);
+            GetReg(result);
             return 1;
         }
-
-        protected readonly List<object> neverCollect = []; // references callbacks that could be called from native code to not be garbage collected
-        private void RegisterApi(LuaCFunction callback, string name) {
-            neverCollect.Add(callback);
-            lua_pushcclosure(L, Marshal.GetFunctionPointerForDelegate(callback), 0);
-            lua_setglobal(L, name);
+        else if (FactorioDataSource.ModPathExists(requiredFile.mod, fileExt)) { }
+        else if (FactorioDataSource.ModPathExists(requiredFile.mod, GetDirectoryName(source) + fileExt)) {
+            requiredFile.path = GetDirectoryName(source) + fileExt;
         }
-        private byte[] GetData(int index) {
-            nint ptr = lua_tolstring(L, index, out nint len);
-            byte[] buf = new byte[(int)len];
-            Marshal.Copy(ptr, buf, 0, buf.Length);
-            return buf;
+        else if (FactorioDataSource.ModPathExists("core", "lualib/" + fileExt)) {
+            requiredFile.mod = "core";
+            requiredFile.path = "lualib/" + fileExt;
         }
-
-        private string GetString(int index) {
-            return Encoding.UTF8.GetString(GetData(index));
-        }
-
-        public int Exec(ReadOnlySpan<byte> chunk, string mod, string name, int argument = 0) {
-            // since lua cuts file name to a few dozen symbols, add index to start of every name
-            fullChunkNames.Add((mod, name));
-            name = fullChunkNames.Count - 1 + " " + name;
-            GetReg(tracebackReg);
-            chunk = chunk.CleanupBom();
-
-            var result = luaL_loadbufferx(L, in chunk.GetPinnableReference(), chunk.Length, name, null);
-            if (result != Result.LUA_OK) {
-                throw new LuaException("Loading terminated with code " + result + "\n" + GetString(-1));
-            }
-
-            int argcount = 0;
-            if (argument > 0) {
-                GetReg(argument);
-                argcount = 1;
-            }
-            result = lua_pcallk(L, argcount, 1, -2 - argcount, IntPtr.Zero, IntPtr.Zero);
-            if (result != Result.LUA_OK) {
-                if (result == Result.LUA_ERRRUN) {
-                    throw new LuaException(GetString(-1));
+        else { // Just find anything ffs
+            foreach (string path in FactorioDataSource.GetAllModFiles(requiredFile.mod, GetDirectoryName(source))) {
+                if (path.EndsWith(fileExt, StringComparison.OrdinalIgnoreCase)) {
+                    requiredFile.path = path;
+                    break;
                 }
-
-                throw new LuaException("Execution " + mod + "/" + name + " terminated with code " + result + "\n" + GetString(-1));
-            }
-            return luaL_ref(L, REGISTRY);
-        }
-
-        public void Dispose() {
-            lua_close(L);
-            L = IntPtr.Zero;
-        }
-
-        public void DoModFiles(string[] modorder, string fileName, IProgress<(string, string)> progress) {
-            string header = "Executing mods " + fileName;
-            foreach (string mod in modorder) {
-                required.Clear();
-                FactorioDataSource.currentLoadingMod = mod;
-                progress.Report((header, mod));
-                byte[] bytes = FactorioDataSource.ReadModFile(mod, fileName);
-                if (bytes == null) {
-                    continue;
-                }
-
-                logger.Information("Executing file {Filename}", mod + "/" + fileName);
-                _ = Exec(bytes, mod, fileName);
             }
         }
 
-        public LuaTable data => (LuaTable)GetGlobal("data")!;
-        public LuaTable defines => (LuaTable)GetGlobal("defines")!;
+        if (required.TryGetValue(argument, out int value)) {
+            GetReg(value);
+            return 1;
+        }
+        logger.Information("Require {RequiredFile}", requiredFile.mod + "/" + requiredFile.path);
+        byte[] bytes = FactorioDataSource.ReadModFile(requiredFile.mod, requiredFile.path);
+        if (bytes != null) {
+            _ = lua_pushstring(L, argument);
+            int argumentReg = luaL_ref(L, REGISTRY);
+            int result = Exec(bytes, requiredFile.mod, requiredFile.path, argumentReg);
+            if (modFixes.TryGetValue(requiredFile, out byte[]? fix)) {
+                string modFixName = "mod-fix-" + requiredFile.mod + "." + requiredFile.path;
+                logger.Information("Running mod-fix {ModFix}", modFixName);
+                result = Exec(fix, "*", modFixName, result);
+            }
+            required[argument] = result;
+            GetReg(result);
+        }
+        else {
+            logger.Error("LUA require failed: mod {mod}, file {file}", mod, file);
+            lua_pushnil(L);
+        }
+        return 1;
     }
 
-    internal class LuaTable {
-        public readonly LuaContext context;
-        public readonly int refId;
-
-        internal LuaTable(LuaContext context, int refId) {
-            this.context = context;
-            this.refId = refId;
-        }
-
-        public object? this[int index] {
-            get => context.GetValue(refId, index);
-            set => context.SetValue(refId, index, value);
-        }
-        public object? this[string index] {
-            get => context.GetValue(refId, index);
-            set => context.SetValue(refId, index, value);
-        }
-
-        public List<object?> ArrayElements => context.ArrayElements(refId);
-        public Dictionary<object, object?> ObjectElements => context.ObjectElements(refId);
+    protected readonly List<object> neverCollect = []; // references callbacks that could be called from native code to not be garbage collected
+    private void RegisterApi(LuaCFunction callback, string name) {
+        neverCollect.Add(callback);
+        lua_pushcclosure(L, Marshal.GetFunctionPointerForDelegate(callback), 0);
+        lua_setglobal(L, name);
     }
+    private byte[] GetData(int index) {
+        nint ptr = lua_tolstring(L, index, out nint len);
+        byte[] buf = new byte[(int)len];
+        Marshal.Copy(ptr, buf, 0, buf.Length);
+        return buf;
+    }
+
+    private string GetString(int index) {
+        return Encoding.UTF8.GetString(GetData(index));
+    }
+
+    public int Exec(ReadOnlySpan<byte> chunk, string mod, string name, int argument = 0) {
+        // since lua cuts file name to a few dozen symbols, add index to start of every name
+        fullChunkNames.Add((mod, name));
+        name = fullChunkNames.Count - 1 + " " + name;
+        GetReg(tracebackReg);
+        chunk = chunk.CleanupBom();
+
+        var result = luaL_loadbufferx(L, in chunk.GetPinnableReference(), chunk.Length, name, null);
+        if (result != Result.LUA_OK) {
+            throw new LuaException("Loading terminated with code " + result + "\n" + GetString(-1));
+        }
+
+        int argcount = 0;
+        if (argument > 0) {
+            GetReg(argument);
+            argcount = 1;
+        }
+        result = lua_pcallk(L, argcount, 1, -2 - argcount, IntPtr.Zero, IntPtr.Zero);
+        if (result != Result.LUA_OK) {
+            if (result == Result.LUA_ERRRUN) {
+                throw new LuaException(GetString(-1));
+            }
+
+            throw new LuaException("Execution " + mod + "/" + name + " terminated with code " + result + "\n" + GetString(-1));
+        }
+        return luaL_ref(L, REGISTRY);
+    }
+
+    public void Dispose() {
+        lua_close(L);
+        L = IntPtr.Zero;
+    }
+
+    public void DoModFiles(string[] modorder, string fileName, IProgress<(string, string)> progress) {
+        string header = "Executing mods " + fileName;
+        foreach (string mod in modorder) {
+            required.Clear();
+            FactorioDataSource.currentLoadingMod = mod;
+            progress.Report((header, mod));
+            byte[] bytes = FactorioDataSource.ReadModFile(mod, fileName);
+            if (bytes == null) {
+                continue;
+            }
+
+            logger.Information("Executing file {Filename}", mod + "/" + fileName);
+            _ = Exec(bytes, mod, fileName);
+        }
+    }
+
+    public LuaTable data => (LuaTable)GetGlobal("data")!;
+    public LuaTable defines => (LuaTable)GetGlobal("defines")!;
+}
+
+internal class LuaTable {
+    public readonly LuaContext context;
+    public readonly int refId;
+
+    internal LuaTable(LuaContext context, int refId) {
+        this.context = context;
+        this.refId = refId;
+    }
+
+    public object? this[int index] {
+        get => context.GetValue(refId, index);
+        set => context.SetValue(refId, index, value);
+    }
+    public object? this[string index] {
+        get => context.GetValue(refId, index);
+        set => context.SetValue(refId, index, value);
+    }
+
+    public List<object?> ArrayElements => context.ArrayElements(refId);
+    public Dictionary<object, object?> ObjectElements => context.ObjectElements(refId);
 }

--- a/Yafc.Parser/SoftwareScaler.cs
+++ b/Yafc.Parser/SoftwareScaler.cs
@@ -3,53 +3,52 @@ using System.Runtime.CompilerServices;
 using SDL2;
 using Yafc.UI;
 
-namespace Yafc.Parser {
-    internal static class SoftwareScaler {
-        public static unsafe IntPtr DownscaleIcon(IntPtr surface, int targetSize) {
-            ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface);
-            uint format = Unsafe.AsRef<SDL.SDL_PixelFormat>((void*)surfaceData.format).format;
+namespace Yafc.Parser;
+internal static class SoftwareScaler {
+    public static unsafe IntPtr DownscaleIcon(IntPtr surface, int targetSize) {
+        ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface);
+        uint format = Unsafe.AsRef<SDL.SDL_PixelFormat>((void*)surfaceData.format).format;
 
-            nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, targetSize, targetSize, 0, format);
-            ref var targetSurfaceData = ref RenderingUtils.AsSdlSurface(targetSurface);
-            int sourceSize = Math.Min(surfaceData.h, surfaceData.w);
+        nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, targetSize, targetSize, 0, format);
+        ref var targetSurfaceData = ref RenderingUtils.AsSdlSurface(targetSurface);
+        int sourceSize = Math.Min(surfaceData.h, surfaceData.w);
 
-            int pitch = surfaceData.pitch;
-            int bpp = Math.Min(pitch / surfaceData.w, targetSurfaceData.pitch / targetSurfaceData.w);
-            int fromY = 0;
-            int* buf = stackalloc int[bpp];
-            for (int y = 0; y < targetSize; y++) {
-                int toY = (y + 1) * sourceSize / targetSize;
-                int fromX = 0;
-                for (int x = 0; x < targetSize; x++) {
-                    int toX = (x + 1) * sourceSize / targetSize;
-                    int c = 0;
-                    for (int sy = fromY; sy < toY; sy++) {
-                        byte* pixels = (byte*)(surfaceData.pixels + (sy * pitch) + (fromX * bpp));
-                        for (int sx = fromX; sx < toX; sx++) {
-                            ++c;
-                            for (int p = 0; p < bpp; p++) {
-                                buf[p] += *pixels;
-                                pixels++;
-                            }
+        int pitch = surfaceData.pitch;
+        int bpp = Math.Min(pitch / surfaceData.w, targetSurfaceData.pitch / targetSurfaceData.w);
+        int fromY = 0;
+        int* buf = stackalloc int[bpp];
+        for (int y = 0; y < targetSize; y++) {
+            int toY = (y + 1) * sourceSize / targetSize;
+            int fromX = 0;
+            for (int x = 0; x < targetSize; x++) {
+                int toX = (x + 1) * sourceSize / targetSize;
+                int c = 0;
+                for (int sy = fromY; sy < toY; sy++) {
+                    byte* pixels = (byte*)(surfaceData.pixels + (sy * pitch) + (fromX * bpp));
+                    for (int sx = fromX; sx < toX; sx++) {
+                        ++c;
+                        for (int p = 0; p < bpp; p++) {
+                            buf[p] += *pixels;
+                            pixels++;
                         }
                     }
-
-                    byte* targetPixels = (byte*)(targetSurfaceData.pixels + (y * targetSurfaceData.pitch) + (x * bpp));
-                    for (int p = 0; p < bpp; p++) {
-                        int sum = buf[p];
-                        *targetPixels = (byte)MathUtils.Clamp((float)sum / c, 0, 255);
-                        targetPixels++;
-                        buf[p] = 0;
-                    }
-
-                    fromX = toX;
                 }
 
-                fromY = toY;
+                byte* targetPixels = (byte*)(targetSurfaceData.pixels + (y * targetSurfaceData.pitch) + (x * bpp));
+                for (int p = 0; p < bpp; p++) {
+                    int sum = buf[p];
+                    *targetPixels = (byte)MathUtils.Clamp((float)sum / c, 0, 255);
+                    targetPixels++;
+                    buf[p] = 0;
+                }
+
+                fromX = toX;
             }
 
-            SDL.SDL_FreeSurface(surface);
-            return targetSurface;
+            fromY = toY;
         }
+
+        SDL.SDL_FreeSurface(surface);
+        return targetSurface;
     }
 }

--- a/Yafc.UI/Core/DrawingSurface.cs
+++ b/Yafc.UI/Core/DrawingSurface.cs
@@ -2,167 +2,166 @@
 using System.Numerics;
 using SDL2;
 
-namespace Yafc.UI {
-    public readonly struct TextureHandle(DrawingSurface surface, IntPtr handle) {
-        public readonly IntPtr handle = handle;
-        public readonly DrawingSurface surface = surface;
-        public readonly int version = surface.rendererVersion;
-        public bool valid => surface != null && surface.rendererVersion == version;
+namespace Yafc.UI;
+public readonly struct TextureHandle(DrawingSurface surface, IntPtr handle) {
+    public readonly IntPtr handle = handle;
+    public readonly DrawingSurface surface = surface;
+    public readonly int version = surface.rendererVersion;
+    public bool valid => surface != null && surface.rendererVersion == version;
 
-        public TextureHandle Destroy() {
-            if (valid) {
-                var capturedHandle = handle;
-                Ui.DispatchInMainThread(_ => SDL.SDL_DestroyTexture(capturedHandle), null);
-            }
-            return default;
+    public TextureHandle Destroy() {
+        if (valid) {
+            var capturedHandle = handle;
+            Ui.DispatchInMainThread(_ => SDL.SDL_DestroyTexture(capturedHandle), null);
+        }
+        return default;
+    }
+}
+
+public abstract class DrawingSurface(float pixelsPerUnit) : IDisposable {
+    private IntPtr rendererHandle;
+
+    public IntPtr renderer {
+        get => rendererHandle;
+        protected set {
+            rendererHandle = value;
+            rendererVersion++;
         }
     }
 
-    public abstract class DrawingSurface(float pixelsPerUnit) : IDisposable {
-        private IntPtr rendererHandle;
+    public int rendererVersion { get; private set; }
 
-        public IntPtr renderer {
-            get => rendererHandle;
-            protected set {
-                rendererHandle = value;
-                rendererVersion++;
+    public float pixelsPerUnit { get; set; } = pixelsPerUnit;
+
+    internal static RenderingUtils.BlitMapping[]? blitMapping;
+
+    private SDL.SDL_Rect clipRect;
+    private bool disposedValue;
+
+    internal abstract void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color);
+    internal abstract void DrawBorder(SDL.SDL_Rect position, RectangleBorder type);
+
+    public abstract Window? window { get; }
+
+    public TextureHandle BeginRenderToTexture(out SDL.SDL_Rect textureSize) {
+        _ = SDL.SDL_GetRendererOutputSize(renderer, out int w, out int h);
+        textureSize = new SDL.SDL_Rect { w = w, h = h };
+        nint texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, textureSize.w, textureSize.h);
+        _ = SDL.SDL_SetRenderTarget(renderer, texture);
+        return new TextureHandle(this, texture);
+    }
+
+    public void EndRenderToTexture() => _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
+
+    public virtual SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
+        var prev = clipRect;
+        clipRect = clip;
+        _ = SDL.SDL_RenderSetClipRect(renderer, ref clip);
+        return prev;
+    }
+
+    public virtual void Present() => SDL.SDL_RenderPresent(renderer);
+
+    public void Clear(SDL.SDL_Rect clipRect) {
+        this.clipRect = clipRect;
+        {
+            // TODO work-around sdl bug
+            _ = SDL.SDL_RenderSetClipRect(renderer, ref clipRect);
+        }
+        _ = SDL.SDL_RenderClear(renderer);
+    }
+
+    public TextureHandle CreateTextureFromSurface(IntPtr surface) => new TextureHandle(this, SDL.SDL_CreateTextureFromSurface(renderer, surface));
+
+    public TextureHandle CreateTexture(uint format, int access, int w, int h) {
+        return new TextureHandle(this, SDL.SDL_CreateTexture(renderer, format, access, w, h));
+    }
+
+    protected virtual void Dispose(bool disposing) {
+        if (!disposedValue) {
+            if (disposing) {
+                // dispose managed state (managed objects)
             }
-        }
 
-        public int rendererVersion { get; private set; }
+            // free unmanaged resources (unmanaged objects) and override finalizer
+            SDL.SDL_DestroyRenderer(renderer);
+            renderer = IntPtr.Zero;
+            // set large fields to null
 
-        public float pixelsPerUnit { get; set; } = pixelsPerUnit;
-
-        internal static RenderingUtils.BlitMapping[]? blitMapping;
-
-        private SDL.SDL_Rect clipRect;
-        private bool disposedValue;
-
-        internal abstract void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color);
-        internal abstract void DrawBorder(SDL.SDL_Rect position, RectangleBorder type);
-
-        public abstract Window? window { get; }
-
-        public TextureHandle BeginRenderToTexture(out SDL.SDL_Rect textureSize) {
-            _ = SDL.SDL_GetRendererOutputSize(renderer, out int w, out int h);
-            textureSize = new SDL.SDL_Rect { w = w, h = h };
-            nint texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, textureSize.w, textureSize.h);
-            _ = SDL.SDL_SetRenderTarget(renderer, texture);
-            return new TextureHandle(this, texture);
-        }
-
-        public void EndRenderToTexture() => _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
-
-        public virtual SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
-            var prev = clipRect;
-            clipRect = clip;
-            _ = SDL.SDL_RenderSetClipRect(renderer, ref clip);
-            return prev;
-        }
-
-        public virtual void Present() => SDL.SDL_RenderPresent(renderer);
-
-        public void Clear(SDL.SDL_Rect clipRect) {
-            this.clipRect = clipRect;
-            {
-                // TODO work-around sdl bug
-                _ = SDL.SDL_RenderSetClipRect(renderer, ref clipRect);
-            }
-            _ = SDL.SDL_RenderClear(renderer);
-        }
-
-        public TextureHandle CreateTextureFromSurface(IntPtr surface) => new TextureHandle(this, SDL.SDL_CreateTextureFromSurface(renderer, surface));
-
-        public TextureHandle CreateTexture(uint format, int access, int w, int h) {
-            return new TextureHandle(this, SDL.SDL_CreateTexture(renderer, format, access, w, h));
-        }
-
-        protected virtual void Dispose(bool disposing) {
-            if (!disposedValue) {
-                if (disposing) {
-                    // dispose managed state (managed objects)
-                }
-
-                // free unmanaged resources (unmanaged objects) and override finalizer
-                SDL.SDL_DestroyRenderer(renderer);
-                renderer = IntPtr.Zero;
-                // set large fields to null
-
-                disposedValue = true;
-            }
-        }
-
-        ~DrawingSurface() {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: false);
-        }
-
-        public virtual void Dispose() {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            disposedValue = true;
         }
     }
 
-    public abstract class SoftwareDrawingSurface(IntPtr surface, float pixelsPerUnit) : DrawingSurface(pixelsPerUnit) {
-        public IntPtr surface { get; protected set; } = surface;
-
-        public override SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
-            _ = SDL.SDL_SetClipRect(surface, ref clip);
-            return base.SetClip(clip);
-        }
-
-        internal override void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color) {
-            var sdlColor = color.ToSdlColor();
-            nint iconSurface = IconCollection.GetIconSurface(icon);
-            _ = SDL.SDL_SetSurfaceColorMod(iconSurface, sdlColor.r, sdlColor.g, sdlColor.b);
-            _ = SDL.SDL_SetSurfaceAlphaMod(iconSurface, sdlColor.a);
-            _ = SDL.SDL_BlitScaled(iconSurface, ref IconCollection.IconRect, surface, ref position);
-        }
-
-        internal override void DrawBorder(SDL.SDL_Rect position, RectangleBorder border) {
-            RenderingUtils.GetBorderParameters(pixelsPerUnit, border, out int top, out int side, out int bottom);
-            RenderingUtils.GetBorderBatch(position, top, side, bottom, ref blitMapping);
-            var bm = blitMapping;
-            for (int i = 0; i < bm.Length; i++) {
-                ref var cur = ref bm[i];
-                _ = SDL.SDL_BlitScaled(RenderingUtils.CircleSurface, ref cur.texture, surface, ref cur.position);
-            }
-        }
+    ~DrawingSurface() {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: false);
     }
 
-    public class MemoryDrawingSurface : SoftwareDrawingSurface {
-        public MemoryDrawingSurface(Vector2 size, float pixelsPerUnit) : this(size, ClampPixelsPerUnit(size, pixelsPerUnit), true) { }
-
-        private MemoryDrawingSurface(Vector2 size, float pixelsPerUnit, bool __) :
-            base(SDL.SDL_CreateRGBSurfaceWithFormat(0, MathUtils.Round(size.X * pixelsPerUnit), MathUtils.Round(size.Y * pixelsPerUnit), 0, SDL.SDL_PIXELFORMAT_RGB888), pixelsPerUnit) {
-            renderer = SDL.SDL_CreateSoftwareRenderer(surface);
-            _ = SDL.SDL_SetRenderDrawBlendMode(renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
-        }
-
-        public static float ClampPixelsPerUnit(Vector2 size, float pixelsPerUnit) {
-            float maxPPU = MathF.Min(65535 / size.X, 65535 / size.Y);
-            return MathF.Min(maxPPU, pixelsPerUnit);
-        }
-
-        public void Clear(SDL.SDL_Color bgColor) {
-            _ = SDL.SDL_SetRenderDrawColor(renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
-            _ = SDL.SDL_RenderClear(renderer);
-        }
-
-        public override void Dispose() {
-            if (surface == IntPtr.Zero) {
-                return;
-            }
-
-            base.Dispose();
-            SDL.SDL_FreeSurface(surface);
-            surface = IntPtr.Zero;
-            GC.SuppressFinalize(this);
-        }
-
-        public override Window? window => null;
-
-        public void SavePng(string filename) => _ = SDL_image.IMG_SavePNG(surface, filename);
+    public virtual void Dispose() {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
+}
+
+public abstract class SoftwareDrawingSurface(IntPtr surface, float pixelsPerUnit) : DrawingSurface(pixelsPerUnit) {
+    public IntPtr surface { get; protected set; } = surface;
+
+    public override SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
+        _ = SDL.SDL_SetClipRect(surface, ref clip);
+        return base.SetClip(clip);
+    }
+
+    internal override void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color) {
+        var sdlColor = color.ToSdlColor();
+        nint iconSurface = IconCollection.GetIconSurface(icon);
+        _ = SDL.SDL_SetSurfaceColorMod(iconSurface, sdlColor.r, sdlColor.g, sdlColor.b);
+        _ = SDL.SDL_SetSurfaceAlphaMod(iconSurface, sdlColor.a);
+        _ = SDL.SDL_BlitScaled(iconSurface, ref IconCollection.IconRect, surface, ref position);
+    }
+
+    internal override void DrawBorder(SDL.SDL_Rect position, RectangleBorder border) {
+        RenderingUtils.GetBorderParameters(pixelsPerUnit, border, out int top, out int side, out int bottom);
+        RenderingUtils.GetBorderBatch(position, top, side, bottom, ref blitMapping);
+        var bm = blitMapping;
+        for (int i = 0; i < bm.Length; i++) {
+            ref var cur = ref bm[i];
+            _ = SDL.SDL_BlitScaled(RenderingUtils.CircleSurface, ref cur.texture, surface, ref cur.position);
+        }
+    }
+}
+
+public class MemoryDrawingSurface : SoftwareDrawingSurface {
+    public MemoryDrawingSurface(Vector2 size, float pixelsPerUnit) : this(size, ClampPixelsPerUnit(size, pixelsPerUnit), true) { }
+
+    private MemoryDrawingSurface(Vector2 size, float pixelsPerUnit, bool __) :
+        base(SDL.SDL_CreateRGBSurfaceWithFormat(0, MathUtils.Round(size.X * pixelsPerUnit), MathUtils.Round(size.Y * pixelsPerUnit), 0, SDL.SDL_PIXELFORMAT_RGB888), pixelsPerUnit) {
+        renderer = SDL.SDL_CreateSoftwareRenderer(surface);
+        _ = SDL.SDL_SetRenderDrawBlendMode(renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+    }
+
+    public static float ClampPixelsPerUnit(Vector2 size, float pixelsPerUnit) {
+        float maxPPU = MathF.Min(65535 / size.X, 65535 / size.Y);
+        return MathF.Min(maxPPU, pixelsPerUnit);
+    }
+
+    public void Clear(SDL.SDL_Color bgColor) {
+        _ = SDL.SDL_SetRenderDrawColor(renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
+        _ = SDL.SDL_RenderClear(renderer);
+    }
+
+    public override void Dispose() {
+        if (surface == IntPtr.Zero) {
+            return;
+        }
+
+        base.Dispose();
+        SDL.SDL_FreeSurface(surface);
+        surface = IntPtr.Zero;
+        GC.SuppressFinalize(this);
+    }
+
+    public override Window? window => null;
+
+    public void SavePng(string filename) => _ = SDL_image.IMG_SavePNG(surface, filename);
 }

--- a/Yafc.UI/Core/ExceptionScreen.cs
+++ b/Yafc.UI/Core/ExceptionScreen.cs
@@ -2,53 +2,52 @@
 using SDL2;
 using Serilog;
 
-namespace Yafc.UI {
-    public class ExceptionScreen : WindowUtility {
-        private static readonly ILogger logger = Logging.GetLogger<ExceptionScreen>();
-        private static bool exists;
-        private static bool ignoreAll;
+namespace Yafc.UI;
+public class ExceptionScreen : WindowUtility {
+    private static readonly ILogger logger = Logging.GetLogger<ExceptionScreen>();
+    private static bool exists;
+    private static bool ignoreAll;
 
-        public static void ShowException(Exception ex) {
-            logger.Error(ex, "Exception encountered");
-            if (!exists && !ignoreAll) {
-                exists = true;
-                Ui.DispatchInMainThread(state => new ExceptionScreen(ex), null);
+    public static void ShowException(Exception ex) {
+        logger.Error(ex, "Exception encountered");
+        if (!exists && !ignoreAll) {
+            exists = true;
+            Ui.DispatchInMainThread(state => new ExceptionScreen(ex), null);
+        }
+    }
+
+    public override SchemeColor backgroundColor => SchemeColor.Error;
+    private readonly Exception ex;
+    public ExceptionScreen(Exception ex) : base(new Padding(1f)) {
+        while (ex.InnerException != null) {
+            ex = ex.InnerException;
+        }
+
+        this.ex = ex;
+        rootGui.initialTextColor = SchemeColor.ErrorText;
+        Create(ex.Message, 80, null);
+    }
+
+    protected internal override void Close() {
+        base.Close();
+        exists = false;
+    }
+
+    protected override void BuildContents(ImGui gui) {
+        gui.BuildText(ex.GetType().Name, Font.header);
+        gui.BuildText(ex.Message, new TextBlockDisplayStyle(Font.subheader, true));
+        gui.BuildText(ex.StackTrace, TextBlockDisplayStyle.WrappedText);
+        using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
+            if (gui.BuildButton("Close")) {
+                Close();
             }
-        }
 
-        public override SchemeColor backgroundColor => SchemeColor.Error;
-        private readonly Exception ex;
-        public ExceptionScreen(Exception ex) : base(new Padding(1f)) {
-            while (ex.InnerException != null) {
-                ex = ex.InnerException;
+            if (gui.BuildButton("Ignore future errors", SchemeColor.Grey)) {
+                ignoreAll = true;
+                Close();
             }
-
-            this.ex = ex;
-            rootGui.initialTextColor = SchemeColor.ErrorText;
-            Create(ex.Message, 80, null);
-        }
-
-        protected internal override void Close() {
-            base.Close();
-            exists = false;
-        }
-
-        protected override void BuildContents(ImGui gui) {
-            gui.BuildText(ex.GetType().Name, Font.header);
-            gui.BuildText(ex.Message, new TextBlockDisplayStyle(Font.subheader, true));
-            gui.BuildText(ex.StackTrace, TextBlockDisplayStyle.WrappedText);
-            using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
-                if (gui.BuildButton("Close")) {
-                    Close();
-                }
-
-                if (gui.BuildButton("Ignore future errors", SchemeColor.Grey)) {
-                    ignoreAll = true;
-                    Close();
-                }
-                if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
-                    _ = SDL.SDL_SetClipboardText(ex.Message + "\n\n" + ex.StackTrace);
-                }
+            if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
+                _ = SDL.SDL_SetClipboardText(ex.Message + "\n\n" + ex.StackTrace);
             }
         }
     }

--- a/Yafc.UI/Core/IconCollection.cs
+++ b/Yafc.UI/Core/IconCollection.cs
@@ -2,54 +2,53 @@
 using System.Collections.Generic;
 using SDL2;
 
-namespace Yafc.UI {
-    public static class IconCollection {
-        public const int IconSize = 32;
-        public static SDL.SDL_Rect IconRect = new SDL.SDL_Rect { w = IconSize, h = IconSize };
+namespace Yafc.UI;
+public static class IconCollection {
+    public const int IconSize = 32;
+    public static SDL.SDL_Rect IconRect = new SDL.SDL_Rect { w = IconSize, h = IconSize };
 
-        private static readonly List<IntPtr> icons = [];
+    private static readonly List<IntPtr> icons = [];
 
-        static IconCollection() {
-            icons.Add(IntPtr.Zero);
-            var iconId = Icon.None + 1;
-            while (iconId != Icon.FirstCustom) {
-                nint surface = SDL_image.IMG_Load("Data/Icons/" + iconId + ".png");
-                nint surfaceRgba = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
-                _ = SDL.SDL_FillRect(surfaceRgba, IntPtr.Zero, 0xFFFFFF00);
-                _ = SDL.SDL_BlitSurface(surface, IntPtr.Zero, surfaceRgba, IntPtr.Zero);
-                SDL.SDL_FreeSurface(surface);
-                icons.Add(surfaceRgba);
-                iconId++;
-            }
+    static IconCollection() {
+        icons.Add(IntPtr.Zero);
+        var iconId = Icon.None + 1;
+        while (iconId != Icon.FirstCustom) {
+            nint surface = SDL_image.IMG_Load("Data/Icons/" + iconId + ".png");
+            nint surfaceRgba = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
+            _ = SDL.SDL_FillRect(surfaceRgba, IntPtr.Zero, 0xFFFFFF00);
+            _ = SDL.SDL_BlitSurface(surface, IntPtr.Zero, surfaceRgba, IntPtr.Zero);
+            SDL.SDL_FreeSurface(surface);
+            icons.Add(surfaceRgba);
+            iconId++;
+        }
+    }
+
+    public static int IconCount => icons.Count;
+
+    public static Icon AddIcon(IntPtr surface) {
+        Icon id = (Icon)icons.Count;
+        ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface);
+        if (surfaceData.w == IconSize && surfaceData.h == IconSize) {
+            icons.Add(surface);
+        }
+        else {
+            nint blit = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
+            SDL.SDL_Rect srcRect = new SDL.SDL_Rect { w = surfaceData.w, h = surfaceData.h };
+            _ = SDL.SDL_LowerBlitScaled(surface, ref srcRect, blit, ref IconRect);
+            icons.Add(blit);
+            SDL.SDL_FreeSurface(surface);
+        }
+        return id;
+    }
+
+    public static IntPtr GetIconSurface(Icon icon) => icons[(int)icon];
+
+    public static void ClearCustomIcons() {
+        int firstCustomIconId = (int)Icon.FirstCustom;
+        for (int i = firstCustomIconId; i < icons.Count; i++) {
+            SDL.SDL_FreeSurface(icons[i]);
         }
 
-        public static int IconCount => icons.Count;
-
-        public static Icon AddIcon(IntPtr surface) {
-            Icon id = (Icon)icons.Count;
-            ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface);
-            if (surfaceData.w == IconSize && surfaceData.h == IconSize) {
-                icons.Add(surface);
-            }
-            else {
-                nint blit = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
-                SDL.SDL_Rect srcRect = new SDL.SDL_Rect { w = surfaceData.w, h = surfaceData.h };
-                _ = SDL.SDL_LowerBlitScaled(surface, ref srcRect, blit, ref IconRect);
-                icons.Add(blit);
-                SDL.SDL_FreeSurface(surface);
-            }
-            return id;
-        }
-
-        public static IntPtr GetIconSurface(Icon icon) => icons[(int)icon];
-
-        public static void ClearCustomIcons() {
-            int firstCustomIconId = (int)Icon.FirstCustom;
-            for (int i = firstCustomIconId; i < icons.Count; i++) {
-                SDL.SDL_FreeSurface(icons[i]);
-            }
-
-            icons.RemoveRange(firstCustomIconId, icons.Count - firstCustomIconId);
-        }
+        icons.RemoveRange(firstCustomIconId, icons.Count - firstCustomIconId);
     }
 }

--- a/Yafc.UI/Core/InputSystem.cs
+++ b/Yafc.UI/Core/InputSystem.cs
@@ -3,172 +3,171 @@ using System.Numerics;
 using System.Threading;
 using SDL2;
 
-namespace Yafc.UI {
-    public interface IKeyboardFocus {
-        bool KeyDown(SDL.SDL_Keysym key);
-        bool TextInput(string input);
-        bool KeyUp(SDL.SDL_Keysym key);
-        void FocusChanged(bool focused);
+namespace Yafc.UI;
+public interface IKeyboardFocus {
+    bool KeyDown(SDL.SDL_Keysym key);
+    bool TextInput(string input);
+    bool KeyUp(SDL.SDL_Keysym key);
+    void FocusChanged(bool focused);
+}
+
+public interface IMouseFocus {
+    bool FilterPanel(IPanel? panel);
+    void FocusChanged(bool focused);
+}
+
+public sealed class InputSystem {
+    public static readonly InputSystem Instance = new InputSystem();
+
+    private InputSystem() { }
+
+    public Window? mouseOverWindow { get; private set; }
+    private IPanel? hoveringPanel;
+    private IPanel? mouseDownPanel;
+    private IMouseFocus? activeMouseFocus;
+    private IKeyboardFocus? activeKeyboardFocus;
+    private IKeyboardFocus? defaultKeyboardFocus;
+    private SDL.SDL_Keymod keyMod;
+    public int mouseDownButton { get; private set; } = -1;
+
+    public IKeyboardFocus? currentKeyboardFocus => activeKeyboardFocus ?? defaultKeyboardFocus;
+    private readonly List<(SendOrPostCallback, object)> mouseUpCallbacks = [];
+
+    public Vector2 mouseDownPosition { get; private set; }
+    public Vector2 mousePosition { get; private set; }
+    public Vector2 mouseDelta { get; private set; }
+
+    public void DispatchOnGestureFinish(SendOrPostCallback callback, object state) {
+        if (mouseDownButton == -1) {
+            Ui.DispatchInMainThread(callback, state);
+        }
+        else {
+            mouseUpCallbacks.Add((callback, state));
+        }
     }
 
-    public interface IMouseFocus {
-        bool FilterPanel(IPanel? panel);
-        void FocusChanged(bool focused);
+    public void SetKeyboardFocus(IKeyboardFocus? focus) {
+        if (focus == activeKeyboardFocus) {
+            return;
+        }
+
+        currentKeyboardFocus?.FocusChanged(false);
+        activeKeyboardFocus = focus;
+        currentKeyboardFocus?.FocusChanged(true);
     }
 
-    public sealed class InputSystem {
-        public static readonly InputSystem Instance = new InputSystem();
+    public void SetMouseFocus(IMouseFocus? mouseFocus) {
+        if (mouseFocus == activeMouseFocus) {
+            return;
+        }
 
-        private InputSystem() { }
+        activeMouseFocus?.FocusChanged(false);
+        activeMouseFocus = mouseFocus;
+        activeMouseFocus?.FocusChanged(true);
+    }
 
-        public Window? mouseOverWindow { get; private set; }
-        private IPanel? hoveringPanel;
-        private IPanel? mouseDownPanel;
-        private IMouseFocus? activeMouseFocus;
-        private IKeyboardFocus? activeKeyboardFocus;
-        private IKeyboardFocus? defaultKeyboardFocus;
-        private SDL.SDL_Keymod keyMod;
-        public int mouseDownButton { get; private set; } = -1;
+    public IKeyboardFocus? SetDefaultKeyboardFocus(IKeyboardFocus? focus) {
+        IKeyboardFocus? previousFocus = defaultKeyboardFocus;
+        defaultKeyboardFocus = focus;
+        return previousFocus;
+    }
 
-        public IKeyboardFocus? currentKeyboardFocus => activeKeyboardFocus ?? defaultKeyboardFocus;
-        private readonly List<(SendOrPostCallback, object)> mouseUpCallbacks = [];
+    public bool control => (keyMod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
+    public bool shift => (keyMod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
 
-        public Vector2 mouseDownPosition { get; private set; }
-        public Vector2 mousePosition { get; private set; }
-        public Vector2 mouseDelta { get; private set; }
+    internal void KeyDown(SDL.SDL_Keysym key) {
+        keyMod = key.mod;
+        if (activeKeyboardFocus == null || !activeKeyboardFocus.KeyDown(key)) {
+            _ = (defaultKeyboardFocus?.KeyDown(key));
+        }
+    }
 
-        public void DispatchOnGestureFinish(SendOrPostCallback callback, object state) {
-            if (mouseDownButton == -1) {
-                Ui.DispatchInMainThread(callback, state);
+    internal void KeyUp(SDL.SDL_Keysym key) {
+        keyMod = key.mod;
+        if (activeKeyboardFocus == null || !activeKeyboardFocus.KeyUp(key)) {
+            _ = (defaultKeyboardFocus?.KeyUp(key));
+        }
+    }
+
+    internal void TextInput(string input) {
+        if (activeKeyboardFocus == null || !activeKeyboardFocus.TextInput(input)) {
+            _ = (defaultKeyboardFocus?.TextInput(input));
+        }
+    }
+
+    internal void MouseScroll(int delta) => HitTest()?.MouseScroll(delta);
+
+    internal void MouseMove(int rawX, int rawY) {
+        if (mouseOverWindow == null || mouseOverWindow.closed) {
+            return;
+        }
+
+        Vector2 newMousePos = new Vector2(rawX / mouseOverWindow.pixelsPerUnit, rawY / mouseOverWindow.pixelsPerUnit);
+        mouseDelta = newMousePos - mousePosition;
+        mousePosition = newMousePos;
+        if (mouseDownButton != -1 && mouseDownPanel != null) {
+            mouseDownPanel.MouseMove(mouseDownButton);
+        }
+        else if (hoveringPanel != null) {
+            hoveringPanel?.MouseMove(-1);
+        }
+    }
+
+    internal void MouseExitWindow(Window window) {
+        if (mouseOverWindow == window) {
+            mouseOverWindow = null;
+        }
+    }
+
+    internal void MouseEnterWindow(Window window) => mouseOverWindow = window;
+
+    public IPanel? HitTest() => mouseOverWindow == null || mouseOverWindow.closed ? null : mouseOverWindow.HitTest(mousePosition);
+
+    internal void Update() {
+        var currentHovering = HitTest();
+        if (currentHovering != hoveringPanel) {
+            hoveringPanel?.MouseExit();
+            hoveringPanel = currentHovering;
+        }
+    }
+
+    internal void MouseDown(int button) {
+        if (mouseDownButton != -1) {
+            return;
+        }
+
+        if (button == SDL.SDL_BUTTON_LEFT) {
+            if (activeKeyboardFocus != null) {
+                SetKeyboardFocus(null);
             }
-            else {
-                mouseUpCallbacks.Add((callback, state));
+
+            if (activeMouseFocus != null && !activeMouseFocus.FilterPanel(hoveringPanel)) {
+                SetMouseFocus(null);
             }
         }
 
-        public void SetKeyboardFocus(IKeyboardFocus? focus) {
-            if (focus == activeKeyboardFocus) {
-                return;
-            }
+        mouseDownPosition = mousePosition;
+        mouseDownPanel = hoveringPanel;
+        mouseDownButton = button;
+        mouseDownPanel?.MouseDown(button);
+    }
 
-            currentKeyboardFocus?.FocusChanged(false);
-            activeKeyboardFocus = focus;
-            currentKeyboardFocus?.FocusChanged(true);
+    internal void MouseUp(int button) {
+        if (button != mouseDownButton) {
+            return;
         }
 
-        public void SetMouseFocus(IMouseFocus? mouseFocus) {
-            if (mouseFocus == activeMouseFocus) {
-                return;
-            }
-
-            activeMouseFocus?.FocusChanged(false);
-            activeMouseFocus = mouseFocus;
-            activeMouseFocus?.FocusChanged(true);
+        if (mouseDownPanel != null && mouseDownPanel.valid) {
+            mouseDownPanel.MouseUp(button);
+            mouseDownPanel = null;
         }
 
-        public IKeyboardFocus? SetDefaultKeyboardFocus(IKeyboardFocus? focus) {
-            IKeyboardFocus? previousFocus = defaultKeyboardFocus;
-            defaultKeyboardFocus = focus;
-            return previousFocus;
+        mouseDownPosition = default;
+        mouseDownButton = -1;
+        foreach (var mouseUp in mouseUpCallbacks) {
+            Ui.DispatchInMainThread(mouseUp.Item1, mouseUp.Item2);
         }
 
-        public bool control => (keyMod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
-        public bool shift => (keyMod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
-
-        internal void KeyDown(SDL.SDL_Keysym key) {
-            keyMod = key.mod;
-            if (activeKeyboardFocus == null || !activeKeyboardFocus.KeyDown(key)) {
-                _ = (defaultKeyboardFocus?.KeyDown(key));
-            }
-        }
-
-        internal void KeyUp(SDL.SDL_Keysym key) {
-            keyMod = key.mod;
-            if (activeKeyboardFocus == null || !activeKeyboardFocus.KeyUp(key)) {
-                _ = (defaultKeyboardFocus?.KeyUp(key));
-            }
-        }
-
-        internal void TextInput(string input) {
-            if (activeKeyboardFocus == null || !activeKeyboardFocus.TextInput(input)) {
-                _ = (defaultKeyboardFocus?.TextInput(input));
-            }
-        }
-
-        internal void MouseScroll(int delta) => HitTest()?.MouseScroll(delta);
-
-        internal void MouseMove(int rawX, int rawY) {
-            if (mouseOverWindow == null || mouseOverWindow.closed) {
-                return;
-            }
-
-            Vector2 newMousePos = new Vector2(rawX / mouseOverWindow.pixelsPerUnit, rawY / mouseOverWindow.pixelsPerUnit);
-            mouseDelta = newMousePos - mousePosition;
-            mousePosition = newMousePos;
-            if (mouseDownButton != -1 && mouseDownPanel != null) {
-                mouseDownPanel.MouseMove(mouseDownButton);
-            }
-            else if (hoveringPanel != null) {
-                hoveringPanel?.MouseMove(-1);
-            }
-        }
-
-        internal void MouseExitWindow(Window window) {
-            if (mouseOverWindow == window) {
-                mouseOverWindow = null;
-            }
-        }
-
-        internal void MouseEnterWindow(Window window) => mouseOverWindow = window;
-
-        public IPanel? HitTest() => mouseOverWindow == null || mouseOverWindow.closed ? null : mouseOverWindow.HitTest(mousePosition);
-
-        internal void Update() {
-            var currentHovering = HitTest();
-            if (currentHovering != hoveringPanel) {
-                hoveringPanel?.MouseExit();
-                hoveringPanel = currentHovering;
-            }
-        }
-
-        internal void MouseDown(int button) {
-            if (mouseDownButton != -1) {
-                return;
-            }
-
-            if (button == SDL.SDL_BUTTON_LEFT) {
-                if (activeKeyboardFocus != null) {
-                    SetKeyboardFocus(null);
-                }
-
-                if (activeMouseFocus != null && !activeMouseFocus.FilterPanel(hoveringPanel)) {
-                    SetMouseFocus(null);
-                }
-            }
-
-            mouseDownPosition = mousePosition;
-            mouseDownPanel = hoveringPanel;
-            mouseDownButton = button;
-            mouseDownPanel?.MouseDown(button);
-        }
-
-        internal void MouseUp(int button) {
-            if (button != mouseDownButton) {
-                return;
-            }
-
-            if (mouseDownPanel != null && mouseDownPanel.valid) {
-                mouseDownPanel.MouseUp(button);
-                mouseDownPanel = null;
-            }
-
-            mouseDownPosition = default;
-            mouseDownButton = -1;
-            foreach (var mouseUp in mouseUpCallbacks) {
-                Ui.DispatchInMainThread(mouseUp.Item1, mouseUp.Item2);
-            }
-
-            mouseUpCallbacks.Clear();
-        }
+        mouseUpCallbacks.Clear();
     }
 }

--- a/Yafc.UI/Core/MathUtils.cs
+++ b/Yafc.UI/Core/MathUtils.cs
@@ -1,77 +1,76 @@
 ﻿using System;
 
-namespace Yafc.UI {
-    public static class MathUtils {
-        public static float Clamp(float value, float min, float max) {
-            if (value < min) {
-                return min;
-            }
-
-            if (value > max) {
-                return max;
-            }
-
-            return value;
+namespace Yafc.UI;
+public static class MathUtils {
+    public static float Clamp(float value, float min, float max) {
+        if (value < min) {
+            return min;
         }
 
-        public static int Clamp(int value, int min, int max) {
-            if (value < min) {
-                return min;
-            }
-
-            if (value > max) {
-                return max;
-            }
-
-            return value;
+        if (value > max) {
+            return max;
         }
 
-        public static int Round(float value) => (int)MathF.Round(value);
+        return value;
+    }
 
-        public static int Floor(float value) => (int)MathF.Floor(value);
-
-        public static int Ceil(float value) => (int)MathF.Ceiling(value);
-
-        public static byte FloatToByte(float f) {
-            if (f <= 0) {
-                return 0;
-            }
-
-            if (f >= 1) {
-                return 255;
-            }
-
-            return (byte)MathF.Round(f * 255);
+    public static int Clamp(int value, int min, int max) {
+        if (value < min) {
+            return min;
         }
 
-        public static float LogarithmicToLinear(float value, float logMin, float logMax) {
-            if (value < 0f) {
-                value = 0f;
-            }
-
-            float cur = MathF.Log(value);
-            if (cur <= logMin) {
-                return 0f;
-            }
-
-            if (cur >= logMax) {
-                return 1f;
-            }
-
-            return (cur - logMin) / (logMax - logMin);
+        if (value > max) {
+            return max;
         }
 
-        public static float LinearToLogarithmic(float value, float logMin, float logMax, float min, float max) {
-            if (value <= 0f) {
-                return min;
-            }
+        return value;
+    }
 
-            if (value >= 1f) {
-                return max;
-            }
+    public static int Round(float value) => (int)MathF.Round(value);
 
-            float logCur = logMin + ((logMax - logMin) * value);
-            return MathF.Exp(logCur);
+    public static int Floor(float value) => (int)MathF.Floor(value);
+
+    public static int Ceil(float value) => (int)MathF.Ceiling(value);
+
+    public static byte FloatToByte(float f) {
+        if (f <= 0) {
+            return 0;
         }
+
+        if (f >= 1) {
+            return 255;
+        }
+
+        return (byte)MathF.Round(f * 255);
+    }
+
+    public static float LogarithmicToLinear(float value, float logMin, float logMax) {
+        if (value < 0f) {
+            value = 0f;
+        }
+
+        float cur = MathF.Log(value);
+        if (cur <= logMin) {
+            return 0f;
+        }
+
+        if (cur >= logMax) {
+            return 1f;
+        }
+
+        return (cur - logMin) / (logMax - logMin);
+    }
+
+    public static float LinearToLogarithmic(float value, float logMin, float logMax, float min, float max) {
+        if (value <= 0f) {
+            return min;
+        }
+
+        if (value >= 1f) {
+            return max;
+        }
+
+        float logCur = logMin + ((logMax - logMin) * value);
+        return MathF.Exp(logCur);
     }
 }

--- a/Yafc.UI/Core/Rect.cs
+++ b/Yafc.UI/Core/Rect.cs
@@ -1,131 +1,130 @@
 ﻿using System;
 using System.Numerics;
 
-namespace Yafc.UI {
-    public struct Rect {
-        public float X, Y;
-        public float Width, Height;
+namespace Yafc.UI;
+public struct Rect {
+    public float X, Y;
+    public float Width, Height;
 
-        public float Right {
-            readonly get => X + Width;
-            set => Width = value - X;
-        }
-
-        public float Bottom {
-            readonly get => Y + Height;
-            set => Height = value - Y;
-        }
-
-        public float Left {
-            readonly get => X;
-            set {
-                Width += (X - value);
-                X = value;
-            }
-        }
-
-        public float Top {
-            readonly get => Y;
-            set {
-                Height += (Y - value);
-                Y = value;
-            }
-        }
-
-        public static readonly Rect VeryBig = new Rect(-float.MaxValue / 2, -float.MaxValue / 2, float.MaxValue, float.MaxValue);
-
-        public Rect(Vector2 position, Vector2 size) : this(position.X, position.Y, size.X, size.Y) { }
-
-        public Rect(float x, float y, float width, float height) {
-            X = x;
-            Y = y;
-            Width = width;
-            Height = height;
-        }
-
-        public static Rect SideRect(float left, float right, float top, float bottom) => new Rect(left, top, right - left, bottom - top);
-
-        public static Rect SideRect(Vector2 topLeft, Vector2 bottomRight) => SideRect(topLeft.X, bottomRight.X, topLeft.Y, bottomRight.Y);
-
-        public static Rect Union(Rect a, Rect b) => SideRect(MathF.Min(a.X, a.X), MathF.Max(a.Right, b.Right), MathF.Min(a.Y, b.Y), MathF.Max(a.Bottom, b.Bottom));
-
-        public Vector2 Size {
-            get => new Vector2(Width, Height);
-            set {
-                Width = value.X;
-                Height = value.Y;
-            }
-        }
-
-        public Vector2 Position {
-            get => new Vector2(X, Y);
-            set {
-                X = value.X;
-                Y = value.Y;
-            }
-        }
-
-        public readonly Rect RightPart(float width) => new Rect(Right - width, Y, width, Height);
-
-        public readonly Rect LeftPart(float width) => new Rect(X, Y, width, Height);
-
-        public Vector2 TopLeft => new Vector2(X, Y);
-        public Vector2 TopRight => new Vector2(Right, Y);
-        public Vector2 BottomRight => new Vector2(Right, Bottom);
-        public Vector2 BottomLeft => new Vector2(X, Bottom);
-        public Vector2 Center => new Vector2(X + (Width * 0.5f), Y + (Height * 0.5f));
-
-        public readonly bool Contains(Vector2 position) => position.X >= X && position.Y >= Y && position.X <= Right && position.Y <= Bottom;
-
-        public readonly bool IntersectsWith(Rect other) => X < other.Right && Right > other.X && Y < other.Bottom && Bottom > other.Y;
-
-        public readonly bool Contains(Rect rect) => X <= rect.X && Y <= rect.Y && Right >= rect.Right && Bottom >= rect.Bottom;
-
-        public static Rect Intersect(Rect a, Rect b) {
-            float left = MathF.Max(a.X, b.X);
-            float right = MathF.Min(a.Right, b.Right);
-            if (right <= left) {
-                return default;
-            }
-
-            float top = MathF.Max(a.Y, b.Y);
-            float bottom = MathF.Min(a.Bottom, b.Bottom);
-            if (bottom <= top) {
-                return default;
-            }
-
-            return SideRect(left, right, top, bottom);
-        }
-
-        public readonly bool Equals(Rect other) => this == other;
-
-        public override bool Equals(object? obj) => obj is Rect other && Equals(other);
-
-        public override int GetHashCode() {
-            unchecked {
-                int hashCode = X.GetHashCode();
-                hashCode = (hashCode * 397) ^ Y.GetHashCode();
-                hashCode = (hashCode * 397) ^ Width.GetHashCode();
-                hashCode = (hashCode * 397) ^ Height.GetHashCode();
-                return hashCode;
-            }
-        }
-
-        public static Rect operator +(in Rect source, Vector2 offset) => new Rect(source.Position + offset, source.Size);
-
-        public static Rect operator -(in Rect source, Vector2 offset) => new Rect(source.Position - offset, source.Size);
-
-        public static Rect operator *(in Rect source, float multiplier) => new Rect(source.Position * multiplier, source.Size * multiplier);
-
-        public static bool operator ==(in Rect a, in Rect b) => a.X == b.X && a.Y == b.Y && a.Width == b.Width && a.Height == b.Height;
-
-        public static bool operator !=(in Rect a, in Rect b) => !(a == b);
-
-        public override string ToString() => "(" + X + "-" + Right + ")-(" + Y + "-" + Bottom + ")";
-
-        public readonly Rect Expand(float amount) => new Rect(X - amount, Y - amount, Width + (2 * amount), Height + (2 * amount));
-
-        public static Rect Square(Vector2 center, float side) => new Rect(center.X - (side * 0.5f), center.Y - (side * 0.5f), side, side);
-        public static Rect Square(float centerX, float centerY, float side) => new Rect(centerX - (side * 0.5f), centerY - (side * 0.5f), side, side);
+    public float Right {
+        readonly get => X + Width;
+        set => Width = value - X;
     }
+
+    public float Bottom {
+        readonly get => Y + Height;
+        set => Height = value - Y;
+    }
+
+    public float Left {
+        readonly get => X;
+        set {
+            Width += (X - value);
+            X = value;
+        }
+    }
+
+    public float Top {
+        readonly get => Y;
+        set {
+            Height += (Y - value);
+            Y = value;
+        }
+    }
+
+    public static readonly Rect VeryBig = new Rect(-float.MaxValue / 2, -float.MaxValue / 2, float.MaxValue, float.MaxValue);
+
+    public Rect(Vector2 position, Vector2 size) : this(position.X, position.Y, size.X, size.Y) { }
+
+    public Rect(float x, float y, float width, float height) {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+
+    public static Rect SideRect(float left, float right, float top, float bottom) => new Rect(left, top, right - left, bottom - top);
+
+    public static Rect SideRect(Vector2 topLeft, Vector2 bottomRight) => SideRect(topLeft.X, bottomRight.X, topLeft.Y, bottomRight.Y);
+
+    public static Rect Union(Rect a, Rect b) => SideRect(MathF.Min(a.X, a.X), MathF.Max(a.Right, b.Right), MathF.Min(a.Y, b.Y), MathF.Max(a.Bottom, b.Bottom));
+
+    public Vector2 Size {
+        get => new Vector2(Width, Height);
+        set {
+            Width = value.X;
+            Height = value.Y;
+        }
+    }
+
+    public Vector2 Position {
+        get => new Vector2(X, Y);
+        set {
+            X = value.X;
+            Y = value.Y;
+        }
+    }
+
+    public readonly Rect RightPart(float width) => new Rect(Right - width, Y, width, Height);
+
+    public readonly Rect LeftPart(float width) => new Rect(X, Y, width, Height);
+
+    public Vector2 TopLeft => new Vector2(X, Y);
+    public Vector2 TopRight => new Vector2(Right, Y);
+    public Vector2 BottomRight => new Vector2(Right, Bottom);
+    public Vector2 BottomLeft => new Vector2(X, Bottom);
+    public Vector2 Center => new Vector2(X + (Width * 0.5f), Y + (Height * 0.5f));
+
+    public readonly bool Contains(Vector2 position) => position.X >= X && position.Y >= Y && position.X <= Right && position.Y <= Bottom;
+
+    public readonly bool IntersectsWith(Rect other) => X < other.Right && Right > other.X && Y < other.Bottom && Bottom > other.Y;
+
+    public readonly bool Contains(Rect rect) => X <= rect.X && Y <= rect.Y && Right >= rect.Right && Bottom >= rect.Bottom;
+
+    public static Rect Intersect(Rect a, Rect b) {
+        float left = MathF.Max(a.X, b.X);
+        float right = MathF.Min(a.Right, b.Right);
+        if (right <= left) {
+            return default;
+        }
+
+        float top = MathF.Max(a.Y, b.Y);
+        float bottom = MathF.Min(a.Bottom, b.Bottom);
+        if (bottom <= top) {
+            return default;
+        }
+
+        return SideRect(left, right, top, bottom);
+    }
+
+    public readonly bool Equals(Rect other) => this == other;
+
+    public override bool Equals(object? obj) => obj is Rect other && Equals(other);
+
+    public override int GetHashCode() {
+        unchecked {
+            int hashCode = X.GetHashCode();
+            hashCode = (hashCode * 397) ^ Y.GetHashCode();
+            hashCode = (hashCode * 397) ^ Width.GetHashCode();
+            hashCode = (hashCode * 397) ^ Height.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    public static Rect operator +(in Rect source, Vector2 offset) => new Rect(source.Position + offset, source.Size);
+
+    public static Rect operator -(in Rect source, Vector2 offset) => new Rect(source.Position - offset, source.Size);
+
+    public static Rect operator *(in Rect source, float multiplier) => new Rect(source.Position * multiplier, source.Size * multiplier);
+
+    public static bool operator ==(in Rect a, in Rect b) => a.X == b.X && a.Y == b.Y && a.Width == b.Width && a.Height == b.Height;
+
+    public static bool operator !=(in Rect a, in Rect b) => !(a == b);
+
+    public override string ToString() => "(" + X + "-" + Right + ")-(" + Y + "-" + Bottom + ")";
+
+    public readonly Rect Expand(float amount) => new Rect(X - amount, Y - amount, Width + (2 * amount), Height + (2 * amount));
+
+    public static Rect Square(Vector2 center, float side) => new Rect(center.X - (side * 0.5f), center.Y - (side * 0.5f), side, side);
+    public static Rect Square(float centerX, float centerY, float side) => new Rect(centerX - (side * 0.5f), centerY - (side * 0.5f), side, side);
 }

--- a/Yafc.UI/Core/SearchQuery.cs
+++ b/Yafc.UI/Core/SearchQuery.cs
@@ -1,23 +1,22 @@
 ﻿using System;
 
-namespace Yafc.UI {
-    public readonly struct SearchQuery(string query) {
-        public readonly string query = query;
-        public readonly string[] tokens = string.IsNullOrWhiteSpace(query) ? [] : query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        public readonly bool empty => tokens == null || tokens.Length == 0;
+namespace Yafc.UI;
+public readonly struct SearchQuery(string query) {
+    public readonly string query = query;
+    public readonly string[] tokens = string.IsNullOrWhiteSpace(query) ? [] : query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+    public readonly bool empty => tokens == null || tokens.Length == 0;
 
-        public bool Match(string text) {
-            if (empty) {
-                return true;
-            }
-
-            foreach (string token in tokens) {
-                if (text.IndexOf(token, StringComparison.OrdinalIgnoreCase) < 0) {
-                    return false;
-                }
-            }
-
+    public bool Match(string text) {
+        if (empty) {
             return true;
         }
+
+        foreach (string token in tokens) {
+            if (text.IndexOf(token, StringComparison.OrdinalIgnoreCase) < 0) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Yafc.UI/Core/Structs.cs
+++ b/Yafc.UI/Core/Structs.cs
@@ -1,154 +1,153 @@
-﻿namespace Yafc.UI {
-    public enum SchemeColor {
-        // Special colors
-        None,
-        TextSelection,
-        Link,
-        Reserved1,
-        // Pure colors
-        PureBackground, // White with light theme, black with dark
-        PureForeground, // Black with light theme, white with dark
-        Source, // Always white
-        SourceFaint,
-        // Background group
-        Background,
-        BackgroundAlt,
-        BackgroundText,
-        BackgroundTextFaint,
-        // Primary group
-        Primary,
-        PrimaryAlt,
-        PrimaryText,
-        PrimaryTextFaint,
-        // Secondary group
-        Secondary,
-        SecondaryAlt,
-        SecondaryText,
-        SecondaryTextFaint,
-        // Error group
-        Error,
-        ErrorAlt,
-        ErrorText,
-        ErrorTextFaint,
-        // Grey group
-        Grey,
-        GreyAlt,
-        GreyText,
-        GreyTextFaint,
-        // Magenta group (indicate overproduction)
-        Magenta,
-        MagentaAlt,
-        MagentaText,
-        MagentaTextFaint,
-        // Green group
-        Green,
-        GreenAlt,
-        GreenText,
-        GreenTextFaint,
-        // Tagged row colors
-        TagColorGreen,
-        TagColorGreenAlt,
-        TagColorGreenText,
-        TagColorGreenTextFaint,
-        TagColorYellow,
-        TagColorYellowAlt,
-        TagColorYellowText,
-        TagColorYellowTextFaint,
-        TagColorRed,
-        TagColorRedAlt,
-        TagColorRedText,
-        TagColorRedTextFaint,
-        TagColorBlue,
-        TagColorBlueAlt,
-        TagColorBlueText,
-        TagColorBlueTextFaint
+﻿namespace Yafc.UI;
+public enum SchemeColor {
+    // Special colors
+    None,
+    TextSelection,
+    Link,
+    Reserved1,
+    // Pure colors
+    PureBackground, // White with light theme, black with dark
+    PureForeground, // Black with light theme, white with dark
+    Source, // Always white
+    SourceFaint,
+    // Background group
+    Background,
+    BackgroundAlt,
+    BackgroundText,
+    BackgroundTextFaint,
+    // Primary group
+    Primary,
+    PrimaryAlt,
+    PrimaryText,
+    PrimaryTextFaint,
+    // Secondary group
+    Secondary,
+    SecondaryAlt,
+    SecondaryText,
+    SecondaryTextFaint,
+    // Error group
+    Error,
+    ErrorAlt,
+    ErrorText,
+    ErrorTextFaint,
+    // Grey group
+    Grey,
+    GreyAlt,
+    GreyText,
+    GreyTextFaint,
+    // Magenta group (indicate overproduction)
+    Magenta,
+    MagentaAlt,
+    MagentaText,
+    MagentaTextFaint,
+    // Green group
+    Green,
+    GreenAlt,
+    GreenText,
+    GreenTextFaint,
+    // Tagged row colors
+    TagColorGreen,
+    TagColorGreenAlt,
+    TagColorGreenText,
+    TagColorGreenTextFaint,
+    TagColorYellow,
+    TagColorYellowAlt,
+    TagColorYellowText,
+    TagColorYellowTextFaint,
+    TagColorRed,
+    TagColorRedAlt,
+    TagColorRedText,
+    TagColorRedTextFaint,
+    TagColorBlue,
+    TagColorBlueAlt,
+    TagColorBlueText,
+    TagColorBlueTextFaint
+}
+
+public enum SchemeColorGroup {
+    Pure = SchemeColor.PureBackground,
+    Background = SchemeColor.Background,
+    Primary = SchemeColor.Primary,
+    Secondary = SchemeColor.Secondary,
+    Error = SchemeColor.Error,
+    Grey = SchemeColor.Grey,
+    Magenta = SchemeColor.Magenta,
+    Green = SchemeColor.Green,
+    TagColorGreen = SchemeColor.TagColorGreen,
+    TagColorYellow = SchemeColor.TagColorYellow,
+    TagColorRed = SchemeColor.TagColorRed,
+    TagColorBlue = SchemeColor.TagColorBlue,
+}
+
+public enum RectangleBorder {
+    None,
+    Thin,
+    Full
+}
+
+public enum Icon {
+    None,
+    Check,
+    CheckBoxCheck,
+    CheckBoxEmpty,
+    Close,
+    Edit,
+    Folder,
+    FolderOpen,
+    Help,
+    NewFolder,
+    Plus,
+    Refresh,
+    Search,
+    Settings,
+    Time,
+    Upload,
+    RadioEmpty,
+    RadioCheck,
+    Error,
+    Warning,
+    Add,
+    DropDown,
+    ShevronDown,
+    ShevronUp,
+    ShevronRight,
+    Menu,
+    ArrowRight,
+    ArrowDownRight,
+    Empty,
+    DarkMode,
+    Copy,
+    Delete,
+    OpenNew,
+    StarEmpty,
+    StarFull,
+
+    FirstCustom,
+}
+
+public enum RectAlignment {
+    Full,
+    MiddleLeft,
+    Middle,
+    MiddleFullRow,
+    MiddleRight,
+    UpperCenter
+}
+
+public readonly struct Padding {
+    public readonly float left, right, top, bottom;
+
+    public Padding(float allOffsets) => top = bottom = left = right = allOffsets;
+
+    public Padding(float leftRight, float topBottom) {
+        left = right = leftRight;
+        top = bottom = topBottom;
     }
 
-    public enum SchemeColorGroup {
-        Pure = SchemeColor.PureBackground,
-        Background = SchemeColor.Background,
-        Primary = SchemeColor.Primary,
-        Secondary = SchemeColor.Secondary,
-        Error = SchemeColor.Error,
-        Grey = SchemeColor.Grey,
-        Magenta = SchemeColor.Magenta,
-        Green = SchemeColor.Green,
-        TagColorGreen = SchemeColor.TagColorGreen,
-        TagColorYellow = SchemeColor.TagColorYellow,
-        TagColorRed = SchemeColor.TagColorRed,
-        TagColorBlue = SchemeColor.TagColorBlue,
-    }
-
-    public enum RectangleBorder {
-        None,
-        Thin,
-        Full
-    }
-
-    public enum Icon {
-        None,
-        Check,
-        CheckBoxCheck,
-        CheckBoxEmpty,
-        Close,
-        Edit,
-        Folder,
-        FolderOpen,
-        Help,
-        NewFolder,
-        Plus,
-        Refresh,
-        Search,
-        Settings,
-        Time,
-        Upload,
-        RadioEmpty,
-        RadioCheck,
-        Error,
-        Warning,
-        Add,
-        DropDown,
-        ShevronDown,
-        ShevronUp,
-        ShevronRight,
-        Menu,
-        ArrowRight,
-        ArrowDownRight,
-        Empty,
-        DarkMode,
-        Copy,
-        Delete,
-        OpenNew,
-        StarEmpty,
-        StarFull,
-
-        FirstCustom,
-    }
-
-    public enum RectAlignment {
-        Full,
-        MiddleLeft,
-        Middle,
-        MiddleFullRow,
-        MiddleRight,
-        UpperCenter
-    }
-
-    public readonly struct Padding {
-        public readonly float left, right, top, bottom;
-
-        public Padding(float allOffsets) => top = bottom = left = right = allOffsets;
-
-        public Padding(float leftRight, float topBottom) {
-            left = right = leftRight;
-            top = bottom = topBottom;
-        }
-
-        public Padding(float left, float right, float top, float bottom) {
-            this.left = left;
-            this.right = right;
-            this.top = top;
-            this.bottom = bottom;
-        }
+    public Padding(float left, float right, float top, float bottom) {
+        this.left = left;
+        this.right = right;
+        this.top = top;
+        this.bottom = bottom;
     }
 }

--- a/Yafc.UI/Core/TaskWindow.cs
+++ b/Yafc.UI/Core/TaskWindow.cs
@@ -2,24 +2,23 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace Yafc.UI {
-    public abstract class TaskWindow<T> : WindowUtility {
-        private TaskCompletionSource<T?>? tcs;
+namespace Yafc.UI;
+public abstract class TaskWindow<T> : WindowUtility {
+    private TaskCompletionSource<T?>? tcs;
 
-        protected TaskWindow() : base(new Padding(1f)) => tcs = new TaskCompletionSource<T?>();
+    protected TaskWindow() : base(new Padding(1f)) => tcs = new TaskCompletionSource<T?>();
 
-        public TaskAwaiter<T?> GetAwaiter() => tcs?.Task.GetAwaiter() ?? throw new InvalidOperationException("Cannot await a closed window.");
+    public TaskAwaiter<T?> GetAwaiter() => tcs?.Task.GetAwaiter() ?? throw new InvalidOperationException("Cannot await a closed window.");
 
-        protected void CloseWithResult(T result) {
-            _ = (tcs?.TrySetResult(result));
-            tcs = null;
-            Close();
-        }
+    protected void CloseWithResult(T result) {
+        _ = (tcs?.TrySetResult(result));
+        tcs = null;
+        Close();
+    }
 
-        protected internal override void Close() {
-            _ = (tcs?.TrySetResult(default));
-            tcs = null;
-            base.Close();
-        }
+    protected internal override void Close() {
+        _ = (tcs?.TrySetResult(default));
+        tcs = null;
+        base.Close();
     }
 }

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -8,267 +8,266 @@ using System.Threading;
 using SDL2;
 using Serilog;
 
-namespace Yafc.UI {
-    public static class Ui {
-        private static readonly ILogger logger = Logging.GetLogger(typeof(Ui));
+namespace Yafc.UI;
+public static class Ui {
+    private static readonly ILogger logger = Logging.GetLogger(typeof(Ui));
 
-        public static bool quit { get; private set; }
+    public static bool quit { get; private set; }
 
-        private static readonly Dictionary<uint, Window> windows = [];
-        internal static void RegisterWindow(uint id, Window window) => windows[id] = window;
+    private static readonly Dictionary<uint, Window> windows = [];
+    internal static void RegisterWindow(uint id, Window window) => windows[id] = window;
 
-        [DllImport("SHCore.dll", SetLastError = true)]
-        private static extern bool SetProcessDpiAwareness(int awareness);
-        public static void Start() {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                try {
-                    _ = SetProcessDpiAwareness(2);
-                }
-                catch (Exception) {
-                    logger.Information("DPI awareness setup failed"); // On older versions on Windows
-                }
-            }
-            _ = SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
-            _ = SDL.SDL_SetHint(SDL.SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-            SDL.SDL_EnableScreenSaver();
-            _ = SDL_ttf.TTF_Init();
-            _ = SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG | SDL_image.IMG_InitFlags.IMG_INIT_JPG);
-            asyncCallbacksAdded = SDL.SDL_RegisterEvents(1);
-            SynchronizationContext.SetSynchronizationContext(new UiSynchronizationContext());
-            mainThreadId = Thread.CurrentThread.ManagedThreadId;
-        }
-
-        public static long time { get; private set; }
-        private static readonly Stopwatch timeWatch = Stopwatch.StartNew();
-
-        public static bool IsMainThread() => Thread.CurrentThread.ManagedThreadId == mainThreadId;
-
-        private static int mainThreadId;
-        private static uint asyncCallbacksAdded;
-        private static readonly Queue<(SendOrPostCallback, object?)> CallbacksQueued = new();
-
-        public static void VisitLink(string url) => _ = Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
-
-        public static void MainLoop() {
-            while (!quit) {
-                ProcessEvents();
-                Render();
-                Thread.Sleep(10);
-            }
-        }
-
-        private static void RebuildTimedOutWindows() {
-            foreach (var (_, window) in windows.Where(item => item.Value.nextRepaintTime <= time)) {
-                window.Rebuild();
-            }
-        }
-
-        public static void ProcessEvents() {
+    [DllImport("SHCore.dll", SetLastError = true)]
+    private static extern bool SetProcessDpiAwareness(int awareness);
+    public static void Start() {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             try {
-                var inputSystem = InputSystem.Instance;
-                long minNextEvent = long.MaxValue - 1;
-                time = timeWatch.ElapsedMilliseconds;
-                foreach (var (_, window) in windows) {
-                    minNextEvent = Math.Min(minNextEvent, window.nextRepaintTime);
-                }
+                _ = SetProcessDpiAwareness(2);
+            }
+            catch (Exception) {
+                logger.Information("DPI awareness setup failed"); // On older versions on Windows
+            }
+        }
+        _ = SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
+        _ = SDL.SDL_SetHint(SDL.SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+        SDL.SDL_EnableScreenSaver();
+        _ = SDL_ttf.TTF_Init();
+        _ = SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG | SDL_image.IMG_InitFlags.IMG_INIT_JPG);
+        asyncCallbacksAdded = SDL.SDL_RegisterEvents(1);
+        SynchronizationContext.SetSynchronizationContext(new UiSynchronizationContext());
+        mainThreadId = Thread.CurrentThread.ManagedThreadId;
+    }
 
-                long delta = Math.Min(1 + (minNextEvent - timeWatch.ElapsedMilliseconds), int.MaxValue);
-                bool hasEvents = (delta <= 0 ? SDL.SDL_PollEvent(out var evt) : SDL.SDL_WaitEventTimeout(out evt, (int)delta)) != 0;
-                time = timeWatch.ElapsedMilliseconds;
+    public static long time { get; private set; }
+    private static readonly Stopwatch timeWatch = Stopwatch.StartNew();
 
-                while (hasEvents) {
-                    switch (evt.type) {
-                        case SDL.SDL_EventType.SDL_QUIT:
-                            if (!quit) {
-                                quit = true;
-                                foreach (var (_, v) in windows) {
-                                    if (v.preventQuit) {
-                                        quit = false;
-                                        break;
-                                    }
+    public static bool IsMainThread() => Thread.CurrentThread.ManagedThreadId == mainThreadId;
+
+    private static int mainThreadId;
+    private static uint asyncCallbacksAdded;
+    private static readonly Queue<(SendOrPostCallback, object?)> CallbacksQueued = new();
+
+    public static void VisitLink(string url) => _ = Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+
+    public static void MainLoop() {
+        while (!quit) {
+            ProcessEvents();
+            Render();
+            Thread.Sleep(10);
+        }
+    }
+
+    private static void RebuildTimedOutWindows() {
+        foreach (var (_, window) in windows.Where(item => item.Value.nextRepaintTime <= time)) {
+            window.Rebuild();
+        }
+    }
+
+    public static void ProcessEvents() {
+        try {
+            var inputSystem = InputSystem.Instance;
+            long minNextEvent = long.MaxValue - 1;
+            time = timeWatch.ElapsedMilliseconds;
+            foreach (var (_, window) in windows) {
+                minNextEvent = Math.Min(minNextEvent, window.nextRepaintTime);
+            }
+
+            long delta = Math.Min(1 + (minNextEvent - timeWatch.ElapsedMilliseconds), int.MaxValue);
+            bool hasEvents = (delta <= 0 ? SDL.SDL_PollEvent(out var evt) : SDL.SDL_WaitEventTimeout(out evt, (int)delta)) != 0;
+            time = timeWatch.ElapsedMilliseconds;
+
+            while (hasEvents) {
+                switch (evt.type) {
+                    case SDL.SDL_EventType.SDL_QUIT:
+                        if (!quit) {
+                            quit = true;
+                            foreach (var (_, v) in windows) {
+                                if (v.preventQuit) {
+                                    quit = false;
+                                    break;
                                 }
                             }
-                            break;
-                        case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
-                            inputSystem.MouseUp(evt.button.button);
-                            break;
-                        case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
-                            inputSystem.MouseDown(evt.button.button);
-                            break;
-                        case SDL.SDL_EventType.SDL_MOUSEWHEEL:
-                            int y = -evt.wheel.y;
-                            if (evt.wheel.direction == (uint)SDL.SDL_MouseWheelDirection.SDL_MOUSEWHEEL_FLIPPED) {
-                                y = -y;
+                        }
+                        break;
+                    case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
+                        inputSystem.MouseUp(evt.button.button);
+                        break;
+                    case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                        inputSystem.MouseDown(evt.button.button);
+                        break;
+                    case SDL.SDL_EventType.SDL_MOUSEWHEEL:
+                        int y = -evt.wheel.y;
+                        if (evt.wheel.direction == (uint)SDL.SDL_MouseWheelDirection.SDL_MOUSEWHEEL_FLIPPED) {
+                            y = -y;
+                        }
+
+                        inputSystem.MouseScroll(y);
+                        break;
+                    case SDL.SDL_EventType.SDL_MOUSEMOTION:
+                        inputSystem.MouseMove(evt.motion.x, evt.motion.y);
+                        break;
+                    case SDL.SDL_EventType.SDL_KEYDOWN:
+                        inputSystem.KeyDown(evt.key.keysym);
+                        break;
+                    case SDL.SDL_EventType.SDL_KEYUP:
+                        inputSystem.KeyUp(evt.key.keysym);
+                        break;
+                    case SDL.SDL_EventType.SDL_TEXTINPUT:
+                        unsafe {
+                            int term = 0;
+                            while (evt.text.text[term] != 0) {
+                                ++term;
                             }
 
-                            inputSystem.MouseScroll(y);
-                            break;
-                        case SDL.SDL_EventType.SDL_MOUSEMOTION:
-                            inputSystem.MouseMove(evt.motion.x, evt.motion.y);
-                            break;
-                        case SDL.SDL_EventType.SDL_KEYDOWN:
-                            inputSystem.KeyDown(evt.key.keysym);
-                            break;
-                        case SDL.SDL_EventType.SDL_KEYUP:
-                            inputSystem.KeyUp(evt.key.keysym);
-                            break;
-                        case SDL.SDL_EventType.SDL_TEXTINPUT:
-                            unsafe {
-                                int term = 0;
-                                while (evt.text.text[term] != 0) {
-                                    ++term;
-                                }
+                            string inputString = new string((sbyte*)evt.text.text, 0, term, Encoding.UTF8);
+                            inputSystem.TextInput(inputString);
+                        }
 
-                                string inputString = new string((sbyte*)evt.text.text, 0, term, Encoding.UTF8);
-                                inputSystem.TextInput(inputString);
-                            }
-
+                        break;
+                    case SDL.SDL_EventType.SDL_WINDOWEVENT:
+                        if (!windows.TryGetValue(evt.window.windowID, out var window)) {
                             break;
-                        case SDL.SDL_EventType.SDL_WINDOWEVENT:
-                            if (!windows.TryGetValue(evt.window.windowID, out var window)) {
+                        }
+
+                        switch (evt.window.windowEvent) {
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:
+                                inputSystem.MouseEnterWindow(window);
                                 break;
-                            }
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_LEAVE:
+                                inputSystem.MouseExitWindow(window);
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
+                                window.Close();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
+                                window.FocusLost();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
+                                window.Rebuild();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
+                                window.Minimized();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MOVED:
+                                window.WindowMoved();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
+                                window.WindowResize();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MAXIMIZED:
+                                window.WindowMaximized();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
+                                window.WindowRestored();
+                                break;
+                            default:
+                                logger.Information("Window event of type {event}", evt.window.windowEvent);
+                                window.Rebuild(); // might be something like "window exposed", better to paint the UI again
+                                break;
+                        }
 
-                            switch (evt.window.windowEvent) {
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:
-                                    inputSystem.MouseEnterWindow(window);
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_LEAVE:
-                                    inputSystem.MouseExitWindow(window);
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
-                                    window.Close();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
-                                    window.FocusLost();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
-                                    window.Rebuild();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
-                                    window.Minimized();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MOVED:
-                                    window.WindowMoved();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
-                                    window.WindowResize();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MAXIMIZED:
-                                    window.WindowMaximized();
-                                    break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
-                                    window.WindowRestored();
-                                    break;
-                                default:
-                                    logger.Information("Window event of type {event}", evt.window.windowEvent);
-                                    window.Rebuild(); // might be something like "window exposed", better to paint the UI again
-                                    break;
-                            }
+                        break;
+                    case SDL.SDL_EventType.SDL_RENDER_TARGETS_RESET:
+                        break;
+                    case SDL.SDL_EventType.SDL_USEREVENT:
+                        if (evt.user.type == asyncCallbacksAdded) {
+                            ProcessAsyncCallbackQueue();
+                        }
 
-                            break;
-                        case SDL.SDL_EventType.SDL_RENDER_TARGETS_RESET:
-                            break;
-                        case SDL.SDL_EventType.SDL_USEREVENT:
-                            if (evt.user.type == asyncCallbacksAdded) {
-                                ProcessAsyncCallbackQueue();
-                            }
-
-                            break;
-                        default:
-                            logger.Information("Event of type {event}", evt.type);
-                            break;
-                    }
-
-                    hasEvents = SDL.SDL_PollEvent(out evt) != 0;
+                        break;
+                    default:
+                        logger.Information("Event of type {event}", evt.type);
+                        break;
                 }
-                time = timeWatch.ElapsedMilliseconds;
-                RebuildTimedOutWindows();
-                inputSystem.Update();
+
+                hasEvents = SDL.SDL_PollEvent(out evt) != 0;
+            }
+            time = timeWatch.ElapsedMilliseconds;
+            RebuildTimedOutWindows();
+            inputSystem.Update();
+        }
+        catch (Exception ex) {
+            ExceptionScreen.ShowException(ex);
+        }
+    }
+
+    public static void Render() {
+        foreach (var (_, window) in windows) {
+            try {
+                window.Render();
             }
             catch (Exception ex) {
                 ExceptionScreen.ShowException(ex);
             }
         }
+    }
 
-        public static void Render() {
-            foreach (var (_, window) in windows) {
-                try {
-                    window.Render();
-                }
-                catch (Exception ex) {
-                    ExceptionScreen.ShowException(ex);
-                }
-            }
-        }
+    public static EnterThreadPoolAwaitable ExitMainThread() => default;
 
-        public static EnterThreadPoolAwaitable ExitMainThread() => default;
+    public static EnterMainThreadAwaitable EnterMainThread() => default;
 
-        public static EnterMainThreadAwaitable EnterMainThread() => default;
+    public static void Quit() {
+        quit = true;
+        SDL_ttf.TTF_Quit();
+        SDL_image.IMG_Quit();
+        SDL.SDL_Quit();
+    }
 
-        public static void Quit() {
-            quit = true;
-            SDL_ttf.TTF_Quit();
-            SDL_image.IMG_Quit();
-            SDL.SDL_Quit();
-        }
-
-        private static void ProcessAsyncCallbackQueue() {
-            bool hasCustomCallbacks = true;
-            while (hasCustomCallbacks) {
-                (SendOrPostCallback, object?) next;
-                lock (CallbacksQueued) {
-                    if (CallbacksQueued.Count == 0) {
-                        break;
-                    }
-
-                    next = CallbacksQueued.Dequeue();
-                    hasCustomCallbacks = CallbacksQueued.Count > 0;
-                }
-
-                try {
-                    next.Item1(next.Item2);
-                }
-                catch (Exception ex) {
-                    ExceptionScreen.ShowException(ex);
-                }
-            }
-        }
-
-        public static void DispatchInMainThread(SendOrPostCallback callback, object? data) {
-            bool shouldSendEvent = false;
+    private static void ProcessAsyncCallbackQueue() {
+        bool hasCustomCallbacks = true;
+        while (hasCustomCallbacks) {
+            (SendOrPostCallback, object?) next;
             lock (CallbacksQueued) {
                 if (CallbacksQueued.Count == 0) {
-                    shouldSendEvent = true;
-                }
-
-                CallbacksQueued.Enqueue((callback, data));
-            }
-
-            if (shouldSendEvent) {
-                SDL.SDL_Event evt = new SDL.SDL_Event {
-                    type = SDL.SDL_EventType.SDL_USEREVENT,
-                    user = new SDL.SDL_UserEvent {
-                        type = asyncCallbacksAdded
-                    }
-                };
-                _ = SDL.SDL_PushEvent(ref evt);
-            }
-        }
-
-        public static void UnregisterWindow(Window window) {
-            _ = windows.Remove(window.id);
-            if (windows.Count == 0) {
-                Quit();
-            }
-        }
-
-        public static void CloseWidowOfType(Type type) {
-            foreach (var (_, v) in windows) {
-                if (v.GetType() == type) {
-                    v.Close();
                     break;
                 }
+
+                next = CallbacksQueued.Dequeue();
+                hasCustomCallbacks = CallbacksQueued.Count > 0;
+            }
+
+            try {
+                next.Item1(next.Item2);
+            }
+            catch (Exception ex) {
+                ExceptionScreen.ShowException(ex);
+            }
+        }
+    }
+
+    public static void DispatchInMainThread(SendOrPostCallback callback, object? data) {
+        bool shouldSendEvent = false;
+        lock (CallbacksQueued) {
+            if (CallbacksQueued.Count == 0) {
+                shouldSendEvent = true;
+            }
+
+            CallbacksQueued.Enqueue((callback, data));
+        }
+
+        if (shouldSendEvent) {
+            SDL.SDL_Event evt = new SDL.SDL_Event {
+                type = SDL.SDL_EventType.SDL_USEREVENT,
+                user = new SDL.SDL_UserEvent {
+                    type = asyncCallbacksAdded
+                }
+            };
+            _ = SDL.SDL_PushEvent(ref evt);
+        }
+    }
+
+    public static void UnregisterWindow(Window window) {
+        _ = windows.Remove(window.id);
+        if (windows.Count == 0) {
+            Quit();
+        }
+    }
+
+    public static void CloseWidowOfType(Type type) {
+        foreach (var (_, v) in windows) {
+            if (v.GetType() == type) {
+                v.Close();
+                break;
             }
         }
     }

--- a/Yafc.UI/Core/UiSynchronizationContext.cs
+++ b/Yafc.UI/Core/UiSynchronizationContext.cs
@@ -2,72 +2,70 @@
 using System.Runtime.CompilerServices;
 using System.Threading;
 
-namespace Yafc.UI {
-    public class UiSynchronizationContext : SynchronizationContext {
-        public override void Post(SendOrPostCallback d, object? state) => Ui.DispatchInMainThread(d, state);
+namespace Yafc.UI;
+public class UiSynchronizationContext : SynchronizationContext {
+    public override void Post(SendOrPostCallback d, object? state) => Ui.DispatchInMainThread(d, state);
 
-        private class SendCommand(SendOrPostCallback d, object? state) {
-            public SendOrPostCallback d = d;
-            public object? state = state;
-            public Exception? ex;
+    private class SendCommand(SendOrPostCallback d, object? state) {
+        public SendOrPostCallback d = d;
+        public object? state = state;
+        public Exception? ex;
 
-            public static void Call(object state) {
-                SendCommand send = (SendCommand)state;
-                try {
-                    send.d(send.state);
-                }
-                catch (Exception ex) {
-                    send.ex = ex;
-                }
-
-                lock (send) {
-                    Monitor.Pulse(send);
-                }
+        public static void Call(object state) {
+            SendCommand send = (SendCommand)state;
+            try {
+                send.d(send.state);
             }
-        }
+            catch (Exception ex) {
+                send.ex = ex;
+            }
 
-        public override void Send(SendOrPostCallback d, object? state) {
-            SendCommand send = new SendCommand(d, state);
             lock (send) {
-                Post(SendCommand.Call!, send); // null-forgiving: send is not null, so Call doesn't need to accept a null.
-                _ = Monitor.Wait(send);
-            }
-            if (send.ex != null) {
-                throw send.ex;
+                Monitor.Pulse(send);
             }
         }
     }
 
-    public readonly struct EnterThreadPoolAwaitable : INotifyCompletion {
-        public EnterThreadPoolAwaitable GetAwaiter() => this;
-
-        public void GetResult() { }
-        public bool IsCompleted => !Ui.IsMainThread();
-        public void OnCompleted(Action continuation) {
-            Logging.GetLogger<EnterThreadPoolAwaitable>().Debug("Exiting UI thread for action {id}.", continuation.GetHashCode()); // Stack trace enricher will add the stack trace here.
-            _ = ThreadPool.QueueUserWorkItem(ThreadPoolPost!, () => { // null-forgiving: this action is not null, so ThreadPoolPost doesn't need to accept a null.
-                Logging.GetLogger<EnterThreadPoolAwaitable>().Debug("Resuming action {id} on a thread-pool thread.", continuation.GetHashCode());
-                continuation();
-            });
+    public override void Send(SendOrPostCallback d, object? state) {
+        SendCommand send = new SendCommand(d, state);
+        lock (send) {
+            Post(SendCommand.Call!, send); // null-forgiving: send is not null, so Call doesn't need to accept a null.
+            _ = Monitor.Wait(send);
         }
+        if (send.ex != null) {
+            throw send.ex;
+        }
+    }
+}
 
-        private static void ThreadPoolPost(object state) => ((Action)state)();
+public readonly struct EnterThreadPoolAwaitable : INotifyCompletion {
+    public EnterThreadPoolAwaitable GetAwaiter() => this;
+
+    public void GetResult() { }
+    public bool IsCompleted => !Ui.IsMainThread();
+    public void OnCompleted(Action continuation) {
+        Logging.GetLogger<EnterThreadPoolAwaitable>().Debug("Exiting UI thread for action {id}.", continuation.GetHashCode()); // Stack trace enricher will add the stack trace here.
+        _ = ThreadPool.QueueUserWorkItem(ThreadPoolPost!, () => { // null-forgiving: this action is not null, so ThreadPoolPost doesn't need to accept a null.
+            Logging.GetLogger<EnterThreadPoolAwaitable>().Debug("Resuming action {id} on a thread-pool thread.", continuation.GetHashCode());
+            continuation();
+        });
     }
 
-    public readonly struct EnterMainThreadAwaitable : INotifyCompletion {
-        public EnterMainThreadAwaitable GetAwaiter() => this;
+    private static void ThreadPoolPost(object state) => ((Action)state)();
+}
 
-        public void GetResult() { }
-        public bool IsCompleted => Ui.IsMainThread();
-        public void OnCompleted(Action continuation) {
-            Logging.GetLogger<EnterMainThreadAwaitable>().Debug("Entering UI thread for action {id}.", continuation.GetHashCode()); // Stack trace enricher will add the stack trace here.
-            Ui.DispatchInMainThread(MainThreadPost!, () => { // null-forgiving: this action is not null, so MainThreadPost doesn't need to accept a null.
-                Logging.GetLogger<EnterMainThreadAwaitable>().Debug("Resuming action {id} on the UI thread.", continuation.GetHashCode());
-                continuation();
-            });
-        }
+public readonly struct EnterMainThreadAwaitable : INotifyCompletion {
+    public EnterMainThreadAwaitable GetAwaiter() => this;
 
-        private static void MainThreadPost(object state) => ((Action)state)();
+    public void GetResult() { }
+    public bool IsCompleted => Ui.IsMainThread();
+    public void OnCompleted(Action continuation) {
+        Logging.GetLogger<EnterMainThreadAwaitable>().Debug("Entering UI thread for action {id}.", continuation.GetHashCode()); // Stack trace enricher will add the stack trace here.
+        Ui.DispatchInMainThread(MainThreadPost!, () => { // null-forgiving: this action is not null, so MainThreadPost doesn't need to accept a null.
+            Logging.GetLogger<EnterMainThreadAwaitable>().Debug("Resuming action {id} on the UI thread.", continuation.GetHashCode());
+            continuation();
+        });
     }
 
+    private static void MainThreadPost(object state) => ((Action)state)();
 }

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -3,230 +3,229 @@ using System.Numerics;
 using SDL2;
 using Serilog;
 
-namespace Yafc.UI {
-    public abstract class Window : IDisposable {
-        private static readonly ILogger logger = Logging.GetLogger<Window>();
+namespace Yafc.UI;
+public abstract class Window : IDisposable {
+    private static readonly ILogger logger = Logging.GetLogger<Window>();
 
-        public readonly ImGui rootGui;
-        internal IntPtr window;
-        /// <summary>Window icon, singleton so it is reused for all windows</summary>
-        internal static IntPtr icon;
-        internal Vector2 contentSize;
-        internal uint id;
-        internal bool repaintRequired = true;
-        internal bool visible;
-        internal bool closed;
-        internal long nextRepaintTime = long.MaxValue;
-        internal float pixelsPerUnit;
-        public virtual SchemeColor backgroundColor => SchemeColor.Background;
+    public readonly ImGui rootGui;
+    internal IntPtr window;
+    /// <summary>Window icon, singleton so it is reused for all windows</summary>
+    internal static IntPtr icon;
+    internal Vector2 contentSize;
+    internal uint id;
+    internal bool repaintRequired = true;
+    internal bool visible;
+    internal bool closed;
+    internal long nextRepaintTime = long.MaxValue;
+    internal float pixelsPerUnit;
+    public virtual SchemeColor backgroundColor => SchemeColor.Background;
 
-        private Tooltip? tooltip;
-        private SimpleTooltip? simpleTooltip;
-        protected DropDownPanel? dropDown;
-        private SimpleDropDown? simpleDropDown;
-        private ImGui.DragOverlay? draggingOverlay;
-        public DrawingSurface? surface { get; protected set; }
+    private Tooltip? tooltip;
+    private SimpleTooltip? simpleTooltip;
+    protected DropDownPanel? dropDown;
+    private SimpleDropDown? simpleDropDown;
+    private ImGui.DragOverlay? draggingOverlay;
+    public DrawingSurface? surface { get; protected set; }
 
-        public int displayIndex => SDL.SDL_GetWindowDisplayIndex(window);
-        public int repaintCount { get; private set; }
+    public int displayIndex => SDL.SDL_GetWindowDisplayIndex(window);
+    public int repaintCount { get; private set; }
 
-        public Vector2 size => contentSize;
+    public Vector2 size => contentSize;
 
-        public virtual bool preventQuit => false;
-        internal Window(Padding padding) => rootGui = new ImGui(Build, padding);
+    public virtual bool preventQuit => false;
+    internal Window(Padding padding) => rootGui = new ImGui(Build, padding);
 
-        internal void Create() {
-            if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Create)}."); }
+    internal void Create() {
+        if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Create)}."); }
 
-            SDL.SDL_SetWindowIcon(window, GetIcon());
+        SDL.SDL_SetWindowIcon(window, GetIcon());
 
-            _ = SDL.SDL_SetRenderDrawBlendMode(surface.renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
-            id = SDL.SDL_GetWindowID(window);
-            Ui.CloseWidowOfType(GetType());
-            Ui.RegisterWindow(id, this);
-            visible = true;
-        }
-
-        /// <summary>Load, if needed, the window icon and return its SDL_Surface pointer, or IntPtr.Zero if not loaded due to errors</summary>
-        internal static IntPtr GetIcon() {
-            if (icon == IntPtr.Zero) {
-                icon = SDL_image.IMG_Load("image.ico");
-                if (icon == IntPtr.Zero) {
-                    string error = SDL.SDL_GetError();
-                    logger.Warning("Failed to load application icon: {error}", error);
-                }
-            }
-
-            return icon;
-        }
-
-        internal int CalculateUnitsToPixels(int display) {
-            _ = SDL.SDL_GetDisplayDPI(display, out float dpi, out _, out _);
-            _ = SDL.SDL_GetDisplayBounds(display, out var rect);
-            // 82x60 is the minimum screen size in units, plus some for borders
-            int desiredUnitsToPixels = dpi == 0 ? 13 : MathUtils.Round(dpi / 6.8f);
-            if (desiredUnitsToPixels * 82f >= rect.w) {
-                desiredUnitsToPixels = MathUtils.Floor(rect.w / 82f);
-            }
-
-            if (desiredUnitsToPixels * 65f >= rect.h) {
-                desiredUnitsToPixels = MathUtils.Floor(rect.h / 65f);
-            }
-
-            return desiredUnitsToPixels;
-        }
-
-        protected internal virtual void WindowResize() {
-            rootGui.MarkEverythingForRebuild();
-            rootGui.Rebuild();
-        }
-
-        internal void WindowMoved() {
-            if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(WindowMoved)}."); }
-
-            int index = SDL.SDL_GetWindowDisplayIndex(window);
-            int u2p = CalculateUnitsToPixels(index);
-            if (u2p != pixelsPerUnit) {
-                pixelsPerUnit = u2p;
-                surface.pixelsPerUnit = pixelsPerUnit;
-                repaintRequired = true;
-                rootGui.MarkEverythingForRebuild();
-                WindowResize();
-            }
-        }
-
-        protected virtual void OnRepaint() { }
-
-        internal void Render() {
-            if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Render)}."); }
-
-            if (!repaintRequired && nextRepaintTime > Ui.time) {
-                return;
-            }
-
-            if (nextRepaintTime <= Ui.time) {
-                nextRepaintTime = long.MaxValue;
-            }
-
-            OnRepaint();
-            repaintRequired = false;
-            if (rootGui.IsRebuildRequired()) {
-                _ = rootGui.CalculateState(size.X, pixelsPerUnit);
-            }
-
-            MainRender();
-            surface.Present();
-        }
-
-        protected virtual void MainRender() {
-            if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(MainRender)}."); }
-
-            var bgColor = backgroundColor.ToSdlColor();
-            _ = SDL.SDL_SetRenderDrawColor(surface.renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
-            Rect fullRect = new Rect(default, contentSize);
-            repaintCount++;
-            surface.Clear(rootGui.ToSdlRect(fullRect));
-            rootGui.InternalPresent(surface, fullRect, fullRect);
-        }
-
-        public IPanel HitTest(Vector2 position) => rootGui.HitTest(position);
-
-        public void Rebuild() => rootGui.Rebuild();
-
-        public void Repaint() {
-            if (closed) {
-                return;
-            }
-
-            if (!Ui.IsMainThread()) {
-                throw new NotSupportedException("This should be called from the main thread");
-            }
-
-            repaintRequired = true;
-        }
-
-        protected internal virtual void Close() {
-            visible = false;
-            closed = true;
-            surface?.Dispose();
-            SDL.SDL_DestroyWindow(window);
-            Dispose();
-            window = IntPtr.Zero;
-            Ui.UnregisterWindow(this);
-        }
-
-        private void Focus() {
-            if (window != IntPtr.Zero) {
-                SDL.SDL_RaiseWindow(window);
-                SDL.SDL_RestoreWindow(window);
-                _ = SDL.SDL_SetWindowInputFocus(window);
-            }
-        }
-
-
-        public virtual void FocusLost() { }
-        public virtual void Minimized() { }
-
-        public void SetNextRepaint(long nextRepaintTime) {
-            if (this.nextRepaintTime > nextRepaintTime) {
-                this.nextRepaintTime = nextRepaintTime;
-            }
-        }
-
-        public void ShowTooltip(Tooltip tooltip) {
-            this.tooltip = tooltip;
-            Rebuild();
-        }
-
-        public void HideTooltip() {
-            tooltip = null;
-            Rebuild();
-        }
-
-        public void ShowTooltip(ImGui targetGui, Rect target, GuiBuilder builder, float width = 20f) {
-            simpleTooltip ??= new SimpleTooltip();
-            simpleTooltip.Show(builder, targetGui, target, width);
-            ShowTooltip(simpleTooltip);
-        }
-
-        public void ShowDropDown(DropDownPanel dropDown) {
-            this.dropDown = dropDown;
-            Rebuild();
-        }
-
-        public void ShowDropDown(ImGui targetGui, Rect target, GuiBuilder builder, Padding padding, float width = 20f) {
-            simpleDropDown ??= new SimpleDropDown();
-            simpleDropDown.SetPadding(padding);
-            simpleDropDown.SetFocus(targetGui, target, builder, width);
-            ShowDropDown(simpleDropDown);
-        }
-
-        private void Build(ImGui gui) {
-            if (closed) {
-                return;
-            }
-
-            BuildContents(gui);
-            if (dropDown != null) {
-                dropDown.Build(gui);
-                if (!dropDown.active) {
-                    dropDown = null;
-                }
-            }
-            draggingOverlay?.Build(gui);
-            if (tooltip != null) {
-                tooltip.Build(gui);
-                if (!tooltip.active) {
-                    tooltip = null;
-                }
-            }
-        }
-
-        protected abstract void BuildContents(ImGui gui);
-        public virtual void Dispose() => rootGui.Dispose();
-
-        internal ImGui.DragOverlay GetDragOverlay() => draggingOverlay ??= new ImGui.DragOverlay();
-        protected internal virtual void WindowMaximized() { }
-        protected internal virtual void WindowRestored() { }
+        _ = SDL.SDL_SetRenderDrawBlendMode(surface.renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+        id = SDL.SDL_GetWindowID(window);
+        Ui.CloseWidowOfType(GetType());
+        Ui.RegisterWindow(id, this);
+        visible = true;
     }
+
+    /// <summary>Load, if needed, the window icon and return its SDL_Surface pointer, or IntPtr.Zero if not loaded due to errors</summary>
+    internal static IntPtr GetIcon() {
+        if (icon == IntPtr.Zero) {
+            icon = SDL_image.IMG_Load("image.ico");
+            if (icon == IntPtr.Zero) {
+                string error = SDL.SDL_GetError();
+                logger.Warning("Failed to load application icon: {error}", error);
+            }
+        }
+
+        return icon;
+    }
+
+    internal int CalculateUnitsToPixels(int display) {
+        _ = SDL.SDL_GetDisplayDPI(display, out float dpi, out _, out _);
+        _ = SDL.SDL_GetDisplayBounds(display, out var rect);
+        // 82x60 is the minimum screen size in units, plus some for borders
+        int desiredUnitsToPixels = dpi == 0 ? 13 : MathUtils.Round(dpi / 6.8f);
+        if (desiredUnitsToPixels * 82f >= rect.w) {
+            desiredUnitsToPixels = MathUtils.Floor(rect.w / 82f);
+        }
+
+        if (desiredUnitsToPixels * 65f >= rect.h) {
+            desiredUnitsToPixels = MathUtils.Floor(rect.h / 65f);
+        }
+
+        return desiredUnitsToPixels;
+    }
+
+    protected internal virtual void WindowResize() {
+        rootGui.MarkEverythingForRebuild();
+        rootGui.Rebuild();
+    }
+
+    internal void WindowMoved() {
+        if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(WindowMoved)}."); }
+
+        int index = SDL.SDL_GetWindowDisplayIndex(window);
+        int u2p = CalculateUnitsToPixels(index);
+        if (u2p != pixelsPerUnit) {
+            pixelsPerUnit = u2p;
+            surface.pixelsPerUnit = pixelsPerUnit;
+            repaintRequired = true;
+            rootGui.MarkEverythingForRebuild();
+            WindowResize();
+        }
+    }
+
+    protected virtual void OnRepaint() { }
+
+    internal void Render() {
+        if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Render)}."); }
+
+        if (!repaintRequired && nextRepaintTime > Ui.time) {
+            return;
+        }
+
+        if (nextRepaintTime <= Ui.time) {
+            nextRepaintTime = long.MaxValue;
+        }
+
+        OnRepaint();
+        repaintRequired = false;
+        if (rootGui.IsRebuildRequired()) {
+            _ = rootGui.CalculateState(size.X, pixelsPerUnit);
+        }
+
+        MainRender();
+        surface.Present();
+    }
+
+    protected virtual void MainRender() {
+        if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(MainRender)}."); }
+
+        var bgColor = backgroundColor.ToSdlColor();
+        _ = SDL.SDL_SetRenderDrawColor(surface.renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
+        Rect fullRect = new Rect(default, contentSize);
+        repaintCount++;
+        surface.Clear(rootGui.ToSdlRect(fullRect));
+        rootGui.InternalPresent(surface, fullRect, fullRect);
+    }
+
+    public IPanel HitTest(Vector2 position) => rootGui.HitTest(position);
+
+    public void Rebuild() => rootGui.Rebuild();
+
+    public void Repaint() {
+        if (closed) {
+            return;
+        }
+
+        if (!Ui.IsMainThread()) {
+            throw new NotSupportedException("This should be called from the main thread");
+        }
+
+        repaintRequired = true;
+    }
+
+    protected internal virtual void Close() {
+        visible = false;
+        closed = true;
+        surface?.Dispose();
+        SDL.SDL_DestroyWindow(window);
+        Dispose();
+        window = IntPtr.Zero;
+        Ui.UnregisterWindow(this);
+    }
+
+    private void Focus() {
+        if (window != IntPtr.Zero) {
+            SDL.SDL_RaiseWindow(window);
+            SDL.SDL_RestoreWindow(window);
+            _ = SDL.SDL_SetWindowInputFocus(window);
+        }
+    }
+
+
+    public virtual void FocusLost() { }
+    public virtual void Minimized() { }
+
+    public void SetNextRepaint(long nextRepaintTime) {
+        if (this.nextRepaintTime > nextRepaintTime) {
+            this.nextRepaintTime = nextRepaintTime;
+        }
+    }
+
+    public void ShowTooltip(Tooltip tooltip) {
+        this.tooltip = tooltip;
+        Rebuild();
+    }
+
+    public void HideTooltip() {
+        tooltip = null;
+        Rebuild();
+    }
+
+    public void ShowTooltip(ImGui targetGui, Rect target, GuiBuilder builder, float width = 20f) {
+        simpleTooltip ??= new SimpleTooltip();
+        simpleTooltip.Show(builder, targetGui, target, width);
+        ShowTooltip(simpleTooltip);
+    }
+
+    public void ShowDropDown(DropDownPanel dropDown) {
+        this.dropDown = dropDown;
+        Rebuild();
+    }
+
+    public void ShowDropDown(ImGui targetGui, Rect target, GuiBuilder builder, Padding padding, float width = 20f) {
+        simpleDropDown ??= new SimpleDropDown();
+        simpleDropDown.SetPadding(padding);
+        simpleDropDown.SetFocus(targetGui, target, builder, width);
+        ShowDropDown(simpleDropDown);
+    }
+
+    private void Build(ImGui gui) {
+        if (closed) {
+            return;
+        }
+
+        BuildContents(gui);
+        if (dropDown != null) {
+            dropDown.Build(gui);
+            if (!dropDown.active) {
+                dropDown = null;
+            }
+        }
+        draggingOverlay?.Build(gui);
+        if (tooltip != null) {
+            tooltip.Build(gui);
+            if (!tooltip.active) {
+                tooltip = null;
+            }
+        }
+    }
+
+    protected abstract void BuildContents(ImGui gui);
+    public virtual void Dispose() => rootGui.Dispose();
+
+    internal ImGui.DragOverlay GetDragOverlay() => draggingOverlay ??= new ImGui.DragOverlay();
+    protected internal virtual void WindowMaximized() { }
+    protected internal virtual void WindowRestored() { }
 }

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -4,162 +4,161 @@ using System.Runtime.InteropServices;
 using SDL2;
 using Serilog;
 
-namespace Yafc.UI {
-    // Main window is resizable and hardware-accelerated unless forced to render via software by caller
-    public abstract class WindowMain : Window {
-        protected void Create(string title, int display, float initialWidth, float initialHeight, bool maximized, bool forceSoftwareRenderer) {
-            if (visible) {
-                return;
-            }
-
-            pixelsPerUnit = CalculateUnitsToPixels(display);
-            // Min width/height define the minimum size of the main window when it gets resized.
-            // The minimal size prevents issues/unreachable spots within the UI (like dialogs that do not size with the window size).
-            int minWidth = MathUtils.Round(85f * pixelsPerUnit);
-            int minHeight = MathUtils.Round(60f * pixelsPerUnit);
-            // Initial width/height define the initial size of the MainWindow when it is opened.
-            int initialWidthPixels = Math.Max(minWidth, MathUtils.Round(initialWidth * pixelsPerUnit));
-            int initialHeightPixels = Math.Max(minHeight, MathUtils.Round(initialHeight * pixelsPerUnit));
-            SDL.SDL_WindowFlags flags = SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE | (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL);
-            if (maximized) {
-                flags |= SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
-            }
-            window = SDL.SDL_CreateWindow(title,
-                SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-                SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-                initialWidthPixels, initialHeightPixels, flags
-            );
-            SDL.SDL_SetWindowMinimumSize(window, minWidth, minHeight);
-            WindowResize();
-            surface = new MainWindowDrawingSurface(this, forceSoftwareRenderer);
-            base.Create();
+namespace Yafc.UI;
+// Main window is resizable and hardware-accelerated unless forced to render via software by caller
+public abstract class WindowMain : Window {
+    protected void Create(string title, int display, float initialWidth, float initialHeight, bool maximized, bool forceSoftwareRenderer) {
+        if (visible) {
+            return;
         }
 
-        protected override void BuildContents(ImGui gui) {
-            BuildContent(gui);
-            gui.SetContextRect(new Rect(default, size));
+        pixelsPerUnit = CalculateUnitsToPixels(display);
+        // Min width/height define the minimum size of the main window when it gets resized.
+        // The minimal size prevents issues/unreachable spots within the UI (like dialogs that do not size with the window size).
+        int minWidth = MathUtils.Round(85f * pixelsPerUnit);
+        int minHeight = MathUtils.Round(60f * pixelsPerUnit);
+        // Initial width/height define the initial size of the MainWindow when it is opened.
+        int initialWidthPixels = Math.Max(minWidth, MathUtils.Round(initialWidth * pixelsPerUnit));
+        int initialHeightPixels = Math.Max(minHeight, MathUtils.Round(initialHeight * pixelsPerUnit));
+        SDL.SDL_WindowFlags flags = SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE | (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL);
+        if (maximized) {
+            flags |= SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
         }
-
-        protected abstract void BuildContent(ImGui gui);
-
-        protected override void OnRepaint() {
-            rootGui.Rebuild();
-            base.OnRepaint();
-        }
-
-        protected internal override void WindowResize() {
-            SDL.SDL_GetWindowSize(window, out int windowWidth, out int windowHeight);
-            contentSize = new Vector2(windowWidth / pixelsPerUnit, windowHeight / pixelsPerUnit);
-            base.WindowResize();
-        }
-
-        protected bool IsMaximized {
-            get {
-                SDL.SDL_WindowFlags flags = (SDL.SDL_WindowFlags)SDL.SDL_GetWindowFlags(window);
-                return flags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED);
-            }
-        }
-
-        protected WindowMain(Padding padding) : base(padding) { }
+        window = SDL.SDL_CreateWindow(title,
+            SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
+            SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
+            initialWidthPixels, initialHeightPixels, flags
+        );
+        SDL.SDL_SetWindowMinimumSize(window, minWidth, minHeight);
+        WindowResize();
+        surface = new MainWindowDrawingSurface(this, forceSoftwareRenderer);
+        base.Create();
     }
 
-    internal class MainWindowDrawingSurface : DrawingSurface {
-        private static readonly ILogger logger = Logging.GetLogger<MainWindowDrawingSurface>();
-        private readonly IconAtlas atlas = new IconAtlas();
-        private readonly IntPtr circleTexture;
+    protected override void BuildContents(ImGui gui) {
+        BuildContent(gui);
+        gui.SetContextRect(new Rect(default, size));
+    }
 
-        public override Window window { get; }
+    protected abstract void BuildContent(ImGui gui);
 
-        /// <summary>
-        /// Function <c>PickRenderDriver()</c> picks the best rendering backend available on the platform.
-        /// 
-        /// This seems like something that SDL2 should do on its own, since the point of SDL2 is to abstract across platform render
-        /// APIs, and it sort of does - but SDL2 has been around for a really long time and its defaults reflect that. On Windows,
-        /// it will autoselect DirectX/Direct3D 9 if given half a chance; DX9 was of course the version that shipped in 2002 and
-        /// supported Windows 98. This is despite the fact that SDL2 supports DX12 and DX11 where possible, and in 2024 "where possible"
-        /// is really going to be "everywhere" - it just doesn't seem to default select them.
-        /// 
-        /// Instead, we can specify the render driver to use when building a renderer instance; to figure out which one, you have to
-        /// go iterate through all the render drivers the library supports and pick the right one by string comparing its name.
-        /// </summary>
-        /// <param name="flags">
-        /// The flags you were going to/are about to pass to SDL_CreateRenderer, just to make sure the function doesn't pick something
-        /// incompatible (this is paranoia since the major renderers tend to support everything relevant).
-        /// </param>
-        /// <param name="forceSoftwareRenderer">
-        /// If set, always return the appropriate index for the software renderer. This can be useful if your graphics hardware doesn't support
-        /// the rendering API that would otherwise be returned.
-        /// </param>
-        /// <returns>The index of the selected render driver, including 0 (SDL autoselect) if no known-best driver exists on this machine. 
-        /// This value should be fed to the second argument of SDL_CreateRenderer()</returns>
-        private int PickRenderDriver(SDL.SDL_RendererFlags flags, bool forceSoftwareRenderer) {
-            nint numRenderDrivers = SDL.SDL_GetNumRenderDrivers();
-            logger.Debug($"Render drivers available: {numRenderDrivers}");
-            int selectedRenderDriver = 0;
-            for (int thisRenderDriver = 0; thisRenderDriver < numRenderDrivers; thisRenderDriver++) {
-                nint res = SDL.SDL_GetRenderDriverInfo(thisRenderDriver, out SDL.SDL_RendererInfo rendererInfo);
-                if (res != 0) {
-                    string reason = SDL.SDL_GetError();
-                    logger.Warning($"Render driver {thisRenderDriver} GetInfo failed: {res}: {reason}");
-                    continue;
-                }
-                // This is for some reason the one data structure that the dotnet library doesn't provide a native unmarshal for
-                string? driverName = Marshal.PtrToStringAnsi(rendererInfo.name);
-                if (driverName is null) {
-                    logger.Warning($"Render driver {thisRenderDriver} has an empty name, cannot compare, skipping");
-                    continue;
-                }
-                logger.Debug($"Render driver {thisRenderDriver} is {driverName} flags 0x{rendererInfo.flags.ToString("X")}");
+    protected override void OnRepaint() {
+        rootGui.Rebuild();
+        base.OnRepaint();
+    }
 
-                // SDL2 does actually have a fixed (from code) ordering of available render drivers, so doing a full list scan instead of returning
-                // immediately is a bit paranoid, but paranoia comes well-recommended when dealing with graphics drivers
-                if (forceSoftwareRenderer) {
-                    if (driverName == "software") {
-                        logger.Debug($"Selecting render driver {thisRenderDriver} (software) because it was forced");
-                        selectedRenderDriver = thisRenderDriver;
-                    }
-                }
-                else {
-                    if ((rendererInfo.flags | (uint)flags) != rendererInfo.flags) {
-                        logger.Debug($"Render driver {driverName} flags do not cover requested flags {flags}, skipping");
-                        continue;
-                    }
-                    if (driverName == "direct3d12") {
-                        logger.Debug($"Selecting render driver {thisRenderDriver} (DX12)");
-                        selectedRenderDriver = thisRenderDriver;
-                    }
-                    else if (driverName == "direct3d11" && selectedRenderDriver == 0) {
-                        logger.Debug($"Selecting render driver {thisRenderDriver} (DX11)");
-                        selectedRenderDriver = thisRenderDriver;
-                    }
+    protected internal override void WindowResize() {
+        SDL.SDL_GetWindowSize(window, out int windowWidth, out int windowHeight);
+        contentSize = new Vector2(windowWidth / pixelsPerUnit, windowHeight / pixelsPerUnit);
+        base.WindowResize();
+    }
+
+    protected bool IsMaximized {
+        get {
+            SDL.SDL_WindowFlags flags = (SDL.SDL_WindowFlags)SDL.SDL_GetWindowFlags(window);
+            return flags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED);
+        }
+    }
+
+    protected WindowMain(Padding padding) : base(padding) { }
+}
+
+internal class MainWindowDrawingSurface : DrawingSurface {
+    private static readonly ILogger logger = Logging.GetLogger<MainWindowDrawingSurface>();
+    private readonly IconAtlas atlas = new IconAtlas();
+    private readonly IntPtr circleTexture;
+
+    public override Window window { get; }
+
+    /// <summary>
+    /// Function <c>PickRenderDriver()</c> picks the best rendering backend available on the platform.
+    ///
+    /// This seems like something that SDL2 should do on its own, since the point of SDL2 is to abstract across platform render
+    /// APIs, and it sort of does - but SDL2 has been around for a really long time and its defaults reflect that. On Windows,
+    /// it will autoselect DirectX/Direct3D 9 if given half a chance; DX9 was of course the version that shipped in 2002 and
+    /// supported Windows 98. This is despite the fact that SDL2 supports DX12 and DX11 where possible, and in 2024 "where possible"
+    /// is really going to be "everywhere" - it just doesn't seem to default select them.
+    ///
+    /// Instead, we can specify the render driver to use when building a renderer instance; to figure out which one, you have to
+    /// go iterate through all the render drivers the library supports and pick the right one by string comparing its name.
+    /// </summary>
+    /// <param name="flags">
+    /// The flags you were going to/are about to pass to SDL_CreateRenderer, just to make sure the function doesn't pick something
+    /// incompatible (this is paranoia since the major renderers tend to support everything relevant).
+    /// </param>
+    /// <param name="forceSoftwareRenderer">
+    /// If set, always return the appropriate index for the software renderer. This can be useful if your graphics hardware doesn't support
+    /// the rendering API that would otherwise be returned.
+    /// </param>
+    /// <returns>The index of the selected render driver, including 0 (SDL autoselect) if no known-best driver exists on this machine.
+    /// This value should be fed to the second argument of SDL_CreateRenderer()</returns>
+    private int PickRenderDriver(SDL.SDL_RendererFlags flags, bool forceSoftwareRenderer) {
+        nint numRenderDrivers = SDL.SDL_GetNumRenderDrivers();
+        logger.Debug($"Render drivers available: {numRenderDrivers}");
+        int selectedRenderDriver = 0;
+        for (int thisRenderDriver = 0; thisRenderDriver < numRenderDrivers; thisRenderDriver++) {
+            nint res = SDL.SDL_GetRenderDriverInfo(thisRenderDriver, out SDL.SDL_RendererInfo rendererInfo);
+            if (res != 0) {
+                string reason = SDL.SDL_GetError();
+                logger.Warning($"Render driver {thisRenderDriver} GetInfo failed: {res}: {reason}");
+                continue;
+            }
+            // This is for some reason the one data structure that the dotnet library doesn't provide a native unmarshal for
+            string? driverName = Marshal.PtrToStringAnsi(rendererInfo.name);
+            if (driverName is null) {
+                logger.Warning($"Render driver {thisRenderDriver} has an empty name, cannot compare, skipping");
+                continue;
+            }
+            logger.Debug($"Render driver {thisRenderDriver} is {driverName} flags 0x{rendererInfo.flags.ToString("X")}");
+
+            // SDL2 does actually have a fixed (from code) ordering of available render drivers, so doing a full list scan instead of returning
+            // immediately is a bit paranoid, but paranoia comes well-recommended when dealing with graphics drivers
+            if (forceSoftwareRenderer) {
+                if (driverName == "software") {
+                    logger.Debug($"Selecting render driver {thisRenderDriver} (software) because it was forced");
+                    selectedRenderDriver = thisRenderDriver;
                 }
             }
-            logger.Debug($"Selected render driver index {selectedRenderDriver}");
-            return selectedRenderDriver;
-        }
-
-        public MainWindowDrawingSurface(WindowMain window, bool forceSoftwareRenderer) : base(window.pixelsPerUnit) {
-            this.window = window;
-
-            renderer = SDL.SDL_CreateRenderer(window.window, PickRenderDriver(SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC, forceSoftwareRenderer), SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC);
-
-            nint result = SDL.SDL_GetRendererInfo(renderer, out SDL.SDL_RendererInfo info);
-            logger.Information($"Driver: {SDL.SDL_GetCurrentVideoDriver()} Renderer: {Marshal.PtrToStringAnsi(info.name)}");
-            circleTexture = SDL.SDL_CreateTextureFromSurface(renderer, RenderingUtils.CircleSurface);
-            byte colorMod = RenderingUtils.darkMode ? (byte)255 : (byte)0;
-            _ = SDL.SDL_SetTextureColorMod(circleTexture, colorMod, colorMod, colorMod);
-        }
-
-        internal override void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color) => atlas.DrawIcon(renderer, icon, position, color.ToSdlColor());
-
-        internal override void DrawBorder(SDL.SDL_Rect position, RectangleBorder border) {
-            RenderingUtils.GetBorderParameters(pixelsPerUnit, border, out int top, out int side, out int bottom);
-            RenderingUtils.GetBorderBatch(position, top, side, bottom, ref blitMapping);
-            var bm = blitMapping;
-            for (int i = 0; i < bm.Length; i++) {
-                ref var cur = ref bm[i];
-                _ = SDL.SDL_RenderCopy(renderer, circleTexture, ref cur.texture, ref cur.position);
+            else {
+                if ((rendererInfo.flags | (uint)flags) != rendererInfo.flags) {
+                    logger.Debug($"Render driver {driverName} flags do not cover requested flags {flags}, skipping");
+                    continue;
+                }
+                if (driverName == "direct3d12") {
+                    logger.Debug($"Selecting render driver {thisRenderDriver} (DX12)");
+                    selectedRenderDriver = thisRenderDriver;
+                }
+                else if (driverName == "direct3d11" && selectedRenderDriver == 0) {
+                    logger.Debug($"Selecting render driver {thisRenderDriver} (DX11)");
+                    selectedRenderDriver = thisRenderDriver;
+                }
             }
+        }
+        logger.Debug($"Selected render driver index {selectedRenderDriver}");
+        return selectedRenderDriver;
+    }
+
+    public MainWindowDrawingSurface(WindowMain window, bool forceSoftwareRenderer) : base(window.pixelsPerUnit) {
+        this.window = window;
+
+        renderer = SDL.SDL_CreateRenderer(window.window, PickRenderDriver(SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC, forceSoftwareRenderer), SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC);
+
+        nint result = SDL.SDL_GetRendererInfo(renderer, out SDL.SDL_RendererInfo info);
+        logger.Information($"Driver: {SDL.SDL_GetCurrentVideoDriver()} Renderer: {Marshal.PtrToStringAnsi(info.name)}");
+        circleTexture = SDL.SDL_CreateTextureFromSurface(renderer, RenderingUtils.CircleSurface);
+        byte colorMod = RenderingUtils.darkMode ? (byte)255 : (byte)0;
+        _ = SDL.SDL_SetTextureColorMod(circleTexture, colorMod, colorMod, colorMod);
+    }
+
+    internal override void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color) => atlas.DrawIcon(renderer, icon, position, color.ToSdlColor());
+
+    internal override void DrawBorder(SDL.SDL_Rect position, RectangleBorder border) {
+        RenderingUtils.GetBorderParameters(pixelsPerUnit, border, out int top, out int side, out int bottom);
+        RenderingUtils.GetBorderBatch(position, top, side, bottom, ref blitMapping);
+        var bm = blitMapping;
+        for (int i = 0; i < bm.Length; i++) {
+            ref var cur = ref bm[i];
+            _ = SDL.SDL_RenderCopy(renderer, circleTexture, ref cur.texture, ref cur.position);
         }
     }
 }

--- a/Yafc.UI/ImGui/DropDownPanel.cs
+++ b/Yafc.UI/ImGui/DropDownPanel.cs
@@ -1,162 +1,161 @@
 ﻿using System.Numerics;
 
-namespace Yafc.UI {
-    public abstract class AttachedPanel {
-        protected readonly ImGui contents;
-        protected Rect sourceRect;
-        protected ImGui? source;
-        private ImGui? owner;
-        protected float width;
-        protected virtual SchemeColor background => SchemeColor.PureBackground;
+namespace Yafc.UI;
+public abstract class AttachedPanel {
+    protected readonly ImGui contents;
+    protected Rect sourceRect;
+    protected ImGui? source;
+    private ImGui? owner;
+    protected float width;
+    protected virtual SchemeColor background => SchemeColor.PureBackground;
 
-        protected AttachedPanel(Padding padding, float width) {
-            contents = new ImGui(BuildContents, padding) { boxColor = background, boxShadow = RectangleBorder.Thin };
-            this.width = width;
-        }
-
-        public bool active => source != null;
-
-        public virtual void SetFocus(ImGui source, Rect rect) {
-            this.source = source;
-            sourceRect = rect;
-            contents.Rebuild();
-            owner?.Rebuild();
-        }
-
-        public void Close() {
-            source = null;
-            owner?.Rebuild();
-        }
-
-        public void Build(ImGui gui) {
-            owner = gui;
-            if (source != null && gui.isBuilding) {
-                var rect = source.TranslateRect(sourceRect, gui);
-                if (ShouldBuild(source, sourceRect, gui, rect)) {
-                    var contentSize = contents.CalculateState(width, gui.pixelsPerUnit);
-                    var position = CalculatePosition(gui, rect, contentSize);
-                    Rect parentRect = new Rect(position, contentSize);
-                    gui.DrawPanel(parentRect, contents);
-                }
-                else {
-                    source = null;
-                }
-            }
-        }
-
-        protected abstract Vector2 CalculatePosition(ImGui gui, Rect targetRect, Vector2 contentSize);
-        protected abstract bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect);
-        protected abstract void BuildContents(ImGui gui);
+    protected AttachedPanel(Padding padding, float width) {
+        contents = new ImGui(BuildContents, padding) { boxColor = background, boxShadow = RectangleBorder.Thin };
+        this.width = width;
     }
 
-    public abstract class DropDownPanel : AttachedPanel, IMouseFocus {
-        private bool focused;
-        protected DropDownPanel(Padding padding, float width) : base(padding, width) { }
-        protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) => focused;
+    public bool active => source != null;
 
-        public override void SetFocus(ImGui source, Rect rect) {
-            InputSystem.Instance.SetMouseFocus(this);
-            base.SetFocus(source, rect);
+    public virtual void SetFocus(ImGui source, Rect rect) {
+        this.source = source;
+        sourceRect = rect;
+        contents.Rebuild();
+        owner?.Rebuild();
+    }
+
+    public void Close() {
+        source = null;
+        owner?.Rebuild();
+    }
+
+    public void Build(ImGui gui) {
+        owner = gui;
+        if (source != null && gui.isBuilding) {
+            var rect = source.TranslateRect(sourceRect, gui);
+            if (ShouldBuild(source, sourceRect, gui, rect)) {
+                var contentSize = contents.CalculateState(width, gui.pixelsPerUnit);
+                var position = CalculatePosition(gui, rect, contentSize);
+                Rect parentRect = new Rect(position, contentSize);
+                gui.DrawPanel(parentRect, contents);
+            }
+            else {
+                source = null;
+            }
         }
+    }
 
-        public bool FilterPanel(IPanel? panel) {
-            while (panel != null) {
-                if (panel == contents) {
-                    return true;
-                }
+    protected abstract Vector2 CalculatePosition(ImGui gui, Rect targetRect, Vector2 contentSize);
+    protected abstract bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect);
+    protected abstract void BuildContents(ImGui gui);
+}
 
-                panel = panel.Parent;
+public abstract class DropDownPanel : AttachedPanel, IMouseFocus {
+    private bool focused;
+    protected DropDownPanel(Padding padding, float width) : base(padding, width) { }
+    protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) => focused;
+
+    public override void SetFocus(ImGui source, Rect rect) {
+        InputSystem.Instance.SetMouseFocus(this);
+        base.SetFocus(source, rect);
+    }
+
+    public bool FilterPanel(IPanel? panel) {
+        while (panel != null) {
+            if (panel == contents) {
+                return true;
             }
 
+            panel = panel.Parent;
+        }
+
+        return false;
+    }
+
+    public void FocusChanged(bool focused) {
+        this.focused = focused;
+        contents.parent?.Rebuild();
+    }
+}
+
+public class SimpleDropDown : DropDownPanel {
+    private GuiBuilder? builder;
+
+    public SimpleDropDown() : base(new Padding(1f), 20f) => contents.AddMessageHandler<ImGuiUtils.CloseDropdownEvent>(HandleDropdownClosed);
+
+    private bool HandleDropdownClosed(ImGuiUtils.CloseDropdownEvent _) {
+        Close();
+        return true;
+    }
+
+    public delegate void Builder(ImGui gui, ref bool closed);
+
+    public void SetPadding(Padding padding) => contents.initialPadding = padding;
+
+    public void SetFocus(ImGui source, Rect rect, GuiBuilder builder, float width = 20f) {
+        this.width = width;
+        this.builder = builder;
+        base.SetFocus(source, rect);
+    }
+
+    protected override Vector2 CalculatePosition(ImGui gui, Rect targetRect, Vector2 contentSize) {
+        var size = gui.contentSize;
+        float targetY = targetRect.Bottom + contentSize.Y > size.Y && targetRect.Y >= contentSize.Y ? targetRect.Y - contentSize.Y : targetRect.Bottom;
+        float x = MathUtils.Clamp(targetRect.X, 0, size.X - contentSize.X);
+        float y = MathUtils.Clamp(targetY, 0, size.Y - contentSize.Y);
+        return new Vector2(x, y);
+    }
+
+    protected override void BuildContents(ImGui gui) {
+        gui.boxColor = SchemeColor.PureBackground;
+        gui.textColor = SchemeColor.BackgroundText;
+        if (builder != null) {
+            builder.Invoke(gui);
+        }
+        else {
+            Close();
+        }
+    }
+}
+
+public abstract class Tooltip : AttachedPanel {
+    protected Tooltip(Padding padding, float width) : base(padding, width) => contents.mouseCapture = false;
+    protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) {
+        var window = source.window;
+        if (InputSystem.Instance.mouseOverWindow != window) {
             return false;
         }
 
-        public void FocusChanged(bool focused) {
-            this.focused = focused;
-            contents.parent?.Rebuild();
-        }
+        return parentRect.Contains(parent.mousePosition);
     }
 
-    public class SimpleDropDown : DropDownPanel {
-        private GuiBuilder? builder;
-
-        public SimpleDropDown() : base(new Padding(1f), 20f) => contents.AddMessageHandler<ImGuiUtils.CloseDropdownEvent>(HandleDropdownClosed);
-
-        private bool HandleDropdownClosed(ImGuiUtils.CloseDropdownEvent _) {
-            Close();
-            return true;
+    protected override Vector2 CalculatePosition(ImGui gui, Rect targetRect, Vector2 contentSize) {
+        float x, y;
+        if (targetRect.Bottom < 4) {
+            y = MathUtils.Clamp(targetRect.Bottom, 0f, gui.contentSize.Y - contentSize.Y);
+            x = MathUtils.Clamp(targetRect.X, 0f, gui.contentSize.X - contentSize.X);
         }
-
-        public delegate void Builder(ImGui gui, ref bool closed);
-
-        public void SetPadding(Padding padding) => contents.initialPadding = padding;
-
-        public void SetFocus(ImGui source, Rect rect, GuiBuilder builder, float width = 20f) {
-            this.width = width;
-            this.builder = builder;
-            base.SetFocus(source, rect);
+        else {
+            x = targetRect.Right + contentSize.X <= gui.contentSize.X ? targetRect.Right :
+                targetRect.X >= contentSize.X ? targetRect.X - contentSize.X : (gui.contentSize.X - contentSize.X) / 2;
+            y = MathUtils.Clamp(targetRect.Y, 0f, gui.contentSize.Y - contentSize.Y);
         }
+        return new Vector2(x, y);
+    }
+}
 
-        protected override Vector2 CalculatePosition(ImGui gui, Rect targetRect, Vector2 contentSize) {
-            var size = gui.contentSize;
-            float targetY = targetRect.Bottom + contentSize.Y > size.Y && targetRect.Y >= contentSize.Y ? targetRect.Y - contentSize.Y : targetRect.Bottom;
-            float x = MathUtils.Clamp(targetRect.X, 0, size.X - contentSize.X);
-            float y = MathUtils.Clamp(targetY, 0, size.Y - contentSize.Y);
-            return new Vector2(x, y);
-        }
-
-        protected override void BuildContents(ImGui gui) {
-            gui.boxColor = SchemeColor.PureBackground;
-            gui.textColor = SchemeColor.BackgroundText;
-            if (builder != null) {
-                builder.Invoke(gui);
-            }
-            else {
-                Close();
-            }
-        }
+public class SimpleTooltip : Tooltip {
+    private GuiBuilder? builder;
+    public void Show(GuiBuilder builder, ImGui gui, Rect rect, float width = 30f) {
+        this.width = width;
+        this.builder = builder;
+        base.SetFocus(gui, rect);
     }
 
-    public abstract class Tooltip : AttachedPanel {
-        protected Tooltip(Padding padding, float width) : base(padding, width) => contents.mouseCapture = false;
-        protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) {
-            var window = source.window;
-            if (InputSystem.Instance.mouseOverWindow != window) {
-                return false;
-            }
+    public SimpleTooltip() : base(new Padding(0.5f), 30f) { }
 
-            return parentRect.Contains(parent.mousePosition);
-        }
-
-        protected override Vector2 CalculatePosition(ImGui gui, Rect targetRect, Vector2 contentSize) {
-            float x, y;
-            if (targetRect.Bottom < 4) {
-                y = MathUtils.Clamp(targetRect.Bottom, 0f, gui.contentSize.Y - contentSize.Y);
-                x = MathUtils.Clamp(targetRect.X, 0f, gui.contentSize.X - contentSize.X);
-            }
-            else {
-                x = targetRect.Right + contentSize.X <= gui.contentSize.X ? targetRect.Right :
-                    targetRect.X >= contentSize.X ? targetRect.X - contentSize.X : (gui.contentSize.X - contentSize.X) / 2;
-                y = MathUtils.Clamp(targetRect.Y, 0f, gui.contentSize.Y - contentSize.Y);
-            }
-            return new Vector2(x, y);
-        }
-    }
-
-    public class SimpleTooltip : Tooltip {
-        private GuiBuilder? builder;
-        public void Show(GuiBuilder builder, ImGui gui, Rect rect, float width = 30f) {
-            this.width = width;
-            this.builder = builder;
-            base.SetFocus(gui, rect);
-        }
-
-        public SimpleTooltip() : base(new Padding(0.5f), 30f) { }
-
-        protected override void BuildContents(ImGui gui) {
-            gui.boxColor = SchemeColor.PureBackground;
-            gui.textColor = SchemeColor.BackgroundText;
-            builder?.Invoke(gui);
-        }
+    protected override void BuildContents(ImGui gui) {
+        gui.boxColor = SchemeColor.PureBackground;
+        gui.textColor = SchemeColor.BackgroundText;
+        builder?.Invoke(gui);
     }
 }

--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -5,325 +5,324 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using SDL2;
 
-namespace Yafc.UI {
-    public enum ImGuiAction {
-        Consumed,
-        Build,
-        MouseMove,
-        MouseDown,
-        MouseUp,
-        MouseScroll,
-        MouseDrag
+namespace Yafc.UI;
+public enum ImGuiAction {
+    Consumed,
+    Build,
+    MouseMove,
+    MouseDown,
+    MouseUp,
+    MouseScroll,
+    MouseDrag
+}
+
+public interface IPanel {
+    void MouseDown(int button);
+    void MouseUp(int button);
+    void MouseMove(int mouseDownButton);
+    void MouseScroll(int delta);
+    void MarkEverythingForRebuild();
+    Vector2 CalculateState(float width, float pixelsPerUnit);
+    void Present(DrawingSurface surface, Rect position, Rect screenClip, ImGui parent);
+    IPanel HitTest(Vector2 position);
+    IPanel? Parent { get; }
+    void MouseExit();
+    bool mouseCapture { get; }
+    bool valid { get; }
+}
+
+public interface IRenderable {
+    void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color);
+}
+
+public enum RectAllocator {
+    Stretch,
+    LeftAlign,
+    RightAlign,
+    Center,
+    LeftRow,
+    RightRow,
+    RemainingRow,
+    FixedRect,
+    HalfRow
+}
+
+public delegate void GuiBuilder(ImGui gui);
+
+public sealed partial class ImGui : IDisposable, IPanel {
+    public ImGui(GuiBuilder? guiBuilder, Padding padding, RectAllocator defaultAllocator = RectAllocator.Stretch, bool clip = false) {
+        this.guiBuilder = guiBuilder;
+        if (guiBuilder == null) {
+            action = ImGuiAction.Build;
+        }
+
+        this.defaultAllocator = defaultAllocator;
+        this.clip = clip;
+        initialPadding = padding;
     }
 
-    public interface IPanel {
-        void MouseDown(int button);
-        void MouseUp(int button);
-        void MouseMove(int mouseDownButton);
-        void MouseScroll(int delta);
-        void MarkEverythingForRebuild();
-        Vector2 CalculateState(float width, float pixelsPerUnit);
-        void Present(DrawingSurface surface, Rect position, Rect screenClip, ImGui parent);
-        IPanel HitTest(Vector2 position);
-        IPanel? Parent { get; }
-        void MouseExit();
-        bool mouseCapture { get; }
-        bool valid { get; }
+    public readonly GuiBuilder? guiBuilder;
+    public Window? window { get; private set; }
+    public ImGui? parent { get; private set; }
+    IPanel? IPanel.Parent => parent;
+    private bool rebuildRequested = true;
+    private float buildWidth;
+    public bool mouseCapture { get; set; } = true;
+    [MemberNotNullWhen(true, nameof(window))]
+    public bool valid => !disposed && window != null && window.visible;
+    private bool disposed;
+    public Vector2 contentSize { get; private set; }
+    public ImGuiAction action { get; private set; }
+
+    public bool isBuilding {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => action == ImGuiAction.Build;
     }
+    public int actionParameter { get; private set; }
+    private long nextRebuildTimer = long.MaxValue;
+    public float pixelsPerUnit { get; private set; }
 
-    public interface IRenderable {
-        void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color);
-    }
+    private readonly float scale = 1f;
+    private readonly bool clip;
+    private Vector2 _offset;
+    private Rect screenRect;
+    private Rect localClip;
 
-    public enum RectAllocator {
-        Stretch,
-        LeftAlign,
-        RightAlign,
-        Center,
-        LeftRow,
-        RightRow,
-        RemainingRow,
-        FixedRect,
-        HalfRow
-    }
-
-    public delegate void GuiBuilder(ImGui gui);
-
-    public sealed partial class ImGui : IDisposable, IPanel {
-        public ImGui(GuiBuilder? guiBuilder, Padding padding, RectAllocator defaultAllocator = RectAllocator.Stretch, bool clip = false) {
-            this.guiBuilder = guiBuilder;
-            if (guiBuilder == null) {
-                action = ImGuiAction.Build;
+    public Vector2 offset {
+        get => _offset;
+        set {
+            screenRect -= (_offset - value);
+            _offset = value;
+            if (mousePresent) {
+                MouseMove(InputSystem.Instance.mouseDownButton);
             }
-
-            this.defaultAllocator = defaultAllocator;
-            this.clip = clip;
-            initialPadding = padding;
-        }
-
-        public readonly GuiBuilder? guiBuilder;
-        public Window? window { get; private set; }
-        public ImGui? parent { get; private set; }
-        IPanel? IPanel.Parent => parent;
-        private bool rebuildRequested = true;
-        private float buildWidth;
-        public bool mouseCapture { get; set; } = true;
-        [MemberNotNullWhen(true, nameof(window))]
-        public bool valid => !disposed && window != null && window.visible;
-        private bool disposed;
-        public Vector2 contentSize { get; private set; }
-        public ImGuiAction action { get; private set; }
-
-        public bool isBuilding {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => action == ImGuiAction.Build;
-        }
-        public int actionParameter { get; private set; }
-        private long nextRebuildTimer = long.MaxValue;
-        public float pixelsPerUnit { get; private set; }
-
-        private readonly float scale = 1f;
-        private readonly bool clip;
-        private Vector2 _offset;
-        private Rect screenRect;
-        private Rect localClip;
-
-        public Vector2 offset {
-            get => _offset;
-            set {
-                screenRect -= (_offset - value);
-                _offset = value;
-                if (mousePresent) {
-                    MouseMove(InputSystem.Instance.mouseDownButton);
-                }
-                else {
-                    Repaint();
-                }
+            else {
+                Repaint();
             }
         }
+    }
 
-        public bool IsRebuildRequired() => rebuildRequested || Ui.time >= nextRebuildTimer;
+    public bool IsRebuildRequired() => rebuildRequested || Ui.time >= nextRebuildTimer;
 
-        public void Rebuild() {
-            rebuildRequested = true;
-            Repaint();
+    public void Rebuild() {
+        rebuildRequested = true;
+        Repaint();
+    }
+
+    public void MarkEverythingForRebuild() {
+        CheckMainThread();
+        rebuildRequested = true;
+        foreach (var sub in panels) {
+            sub.data.MarkEverythingForRebuild();
         }
+    }
 
-        public void MarkEverythingForRebuild() {
+    public void SetNextRebuild(long nextRebuildTime) {
+        if (nextRebuildTime < nextRebuildTimer) {
             CheckMainThread();
-            rebuildRequested = true;
-            foreach (var sub in panels) {
-                sub.data.MarkEverythingForRebuild();
-            }
+            nextRebuildTimer = nextRebuildTime;
+            window?.SetNextRepaint(nextRebuildTime);
         }
-
-        public void SetNextRebuild(long nextRebuildTime) {
-            if (nextRebuildTime < nextRebuildTimer) {
-                CheckMainThread();
-                nextRebuildTimer = nextRebuildTime;
-                window?.SetNextRepaint(nextRebuildTime);
-            }
-        }
-
-        public void Repaint() => window?.Repaint();
-
-        public Vector2 CalculateState(float width, float pixelsPerUnit) {
-            if (IsRebuildRequired() || buildWidth != width || this.pixelsPerUnit != pixelsPerUnit) {
-                this.pixelsPerUnit = pixelsPerUnit;
-                BuildGui(width);
-            }
-            return contentSize;
-        }
-
-        public void Present(DrawingSurface surface, Rect position, Rect screenClip, ImGui? parent) {
-            if (parent != null) {
-                this.parent = parent;
-            }
-
-            pixelsPerUnit = surface.pixelsPerUnit;
-            if (IsRebuildRequired() || buildWidth != position.Width) {
-                BuildGui(position.Width);
-            }
-
-            InternalPresent(surface, position, screenClip);
-        }
-
-        private static readonly List<(SDL.SDL_Rect, RectangleBorder)> borders = [];
-        internal void InternalPresent(DrawingSurface surface, Rect position, Rect screenClip) {
-            if (surface.window != null) {
-                window = surface.window;
-                window.SetNextRepaint(nextRebuildTimer);
-            }
-
-            nint renderer = surface.renderer;
-            SDL.SDL_Rect prevClip = default;
-            screenRect = (position * scale) + offset;
-            var screenOffset = screenRect.Position;
-            if (clip) {
-                prevClip = surface.SetClip(ToSdlRect(screenClip));
-            }
-
-            localClip = new Rect(screenClip.Position - screenOffset, screenClip.Size / scale);
-            SchemeColor currentColor = (SchemeColor)(-1);
-            borders.Clear();
-            for (int i = rects.Count - 1; i >= 0; i--) {
-                var (rect, border, color) = rects[i];
-                if (!rect.IntersectsWith(localClip)) {
-                    continue;
-                }
-
-                var sdlRect = ToSdlRect(rect, screenOffset);
-                if (border != RectangleBorder.None) {
-                    borders.Add((sdlRect, border));
-                }
-
-                if (color == SchemeColor.None) {
-                    continue;
-                }
-
-                if (color != currentColor) {
-                    currentColor = color;
-                    var sdlColor = currentColor.ToSdlColor();
-                    _ = SDL.SDL_SetRenderDrawColor(renderer, sdlColor.r, sdlColor.g, sdlColor.b, sdlColor.a);
-                }
-                _ = SDL.SDL_RenderFillRect(renderer, ref sdlRect);
-            }
-
-            foreach (var (pos, icon, color) in icons) {
-                if (!pos.IntersectsWith(localClip)) {
-                    continue;
-                }
-
-                var sdlPos = ToSdlRect(pos, screenOffset);
-                surface.DrawIcon(sdlPos, icon, color);
-            }
-
-            foreach (var (pos, renderable, color) in renderables) {
-                if (!pos.IntersectsWith(localClip)) {
-                    continue;
-                }
-
-                renderable.Render(surface, ToSdlRect(pos, screenOffset), color.ToSdlColor());
-            }
-
-            foreach (var (srect, type) in borders) {
-                surface.DrawBorder(srect, type);
-            }
-
-            foreach (var (rect, batch, _) in panels) {
-                Rect intersection = Rect.Intersect(rect, localClip);
-                if (intersection == default) {
-                    continue;
-                }
-
-                batch.Present(surface, rect + screenOffset, intersection + screenOffset, this);
-            }
-
-            if (clip) {
-                _ = surface.SetClip(prevClip);
-            }
-        }
-
-        public IPanel HitTest(Vector2 position) {
-            position = (position / scale) - offset;
-            for (int i = panels.Count - 1; i >= 0; i--) {
-                var (rect, panel, _) = panels[i];
-                if (panel.mouseCapture && rect.Contains(position)) {
-                    return panel.HitTest(position - rect.Position);
-                }
-            }
-
-            return this;
-        }
-
-        public int UnitsToPixels(float units) => (int)MathF.Round(units * pixelsPerUnit);
-
-        public float PixelsToUnits(int pixels) => pixels / pixelsPerUnit;
-
-        public SDL.SDL_Rect ToSdlRect(Rect rect, Vector2 offset = default) => new SDL.SDL_Rect {
-            x = UnitsToPixels(rect.X + offset.X),
-            y = UnitsToPixels(rect.Y + offset.Y),
-            w = UnitsToPixels(rect.Width),
-            h = UnitsToPixels(rect.Height)
-        };
-
-        private static void CheckMainThread() {
-            if (!Ui.IsMainThread()) {
-                throw new NotSupportedException("This should be called from the main thread");
-            }
-        }
-
-        public Vector2 ToWindowPosition(Vector2 localPosition) {
-            if (window == null) {
-                return localPosition;
-            }
-
-            return screenRect.Position + (localPosition * (window.pixelsPerUnit / pixelsPerUnit));
-        }
-
-        public Rect TranslateRect(Rect localPosition, ImGui target) {
-            var topLeft = target.FromWindowPosition(ToWindowPosition(localPosition.TopLeft));
-            return new Rect(topLeft, localPosition.Size * (target.pixelsPerUnit / pixelsPerUnit));
-        }
-
-        public Vector2 FromWindowPosition(Vector2 windowPosition) {
-            if (window == null) {
-                return windowPosition;
-            }
-
-            return (windowPosition - screenRect.Position) * (pixelsPerUnit / window.pixelsPerUnit);
-        }
-
-        private void ReleaseUnmanagedResources() {
-            disposed = true;
-            textCache.Dispose();
-        }
-
-        public void Dispose() {
-            ReleaseUnmanagedResources();
-            GC.SuppressFinalize(this);
-        }
-
-        ~ImGui() {
-            ReleaseUnmanagedResources();
-        }
-
-        private void ExportDrawCommandsTo<T>(List<DrawCommand<T>> sourceList, List<DrawCommand<T>> targetList, Rect rect) {
-            targetList.Clear();
-            var delta = rect.Position;
-            for (int i = sourceList.Count - 1; i >= 0; i--) {
-                var elem = sourceList[i];
-                if (rect.Contains(elem.rect)) {
-                    targetList.Add(new DrawCommand<T>(elem.rect - delta, elem.data, elem.color));
-                }
-                else {
-                    break;
-                }
-            }
-            targetList.Reverse();
-            sourceList.RemoveRange(sourceList.Count - targetList.Count, targetList.Count);
-        }
-        public void ExportDrawCommandsTo(Rect rect, ImGui target) {
-            ExportDrawCommandsTo(rects, target.rects, rect);
-            ExportDrawCommandsTo(icons, target.icons, rect);
-            ExportDrawCommandsTo(renderables, target.renderables, rect);
-            ExportDrawCommandsTo(panels, target.panels, rect);
-            target.contentSize = rect.Size;
-        }
-
-        public void PropagateMessage<T>(T message) {
-            foreach (object handler in messageHandlers) {
-                if (handler is Func<T, bool> func && func(message)) {
-                    return;
-                }
-            }
-            parent?.PropagateMessage(message);
-        }
-
-        public void AddMessageHandler<T>(Func<T, bool> handler) {
-            messageHandlers.Add(handler);
-        }
-
-        private readonly List<object> messageHandlers = [];
     }
+
+    public void Repaint() => window?.Repaint();
+
+    public Vector2 CalculateState(float width, float pixelsPerUnit) {
+        if (IsRebuildRequired() || buildWidth != width || this.pixelsPerUnit != pixelsPerUnit) {
+            this.pixelsPerUnit = pixelsPerUnit;
+            BuildGui(width);
+        }
+        return contentSize;
+    }
+
+    public void Present(DrawingSurface surface, Rect position, Rect screenClip, ImGui? parent) {
+        if (parent != null) {
+            this.parent = parent;
+        }
+
+        pixelsPerUnit = surface.pixelsPerUnit;
+        if (IsRebuildRequired() || buildWidth != position.Width) {
+            BuildGui(position.Width);
+        }
+
+        InternalPresent(surface, position, screenClip);
+    }
+
+    private static readonly List<(SDL.SDL_Rect, RectangleBorder)> borders = [];
+    internal void InternalPresent(DrawingSurface surface, Rect position, Rect screenClip) {
+        if (surface.window != null) {
+            window = surface.window;
+            window.SetNextRepaint(nextRebuildTimer);
+        }
+
+        nint renderer = surface.renderer;
+        SDL.SDL_Rect prevClip = default;
+        screenRect = (position * scale) + offset;
+        var screenOffset = screenRect.Position;
+        if (clip) {
+            prevClip = surface.SetClip(ToSdlRect(screenClip));
+        }
+
+        localClip = new Rect(screenClip.Position - screenOffset, screenClip.Size / scale);
+        SchemeColor currentColor = (SchemeColor)(-1);
+        borders.Clear();
+        for (int i = rects.Count - 1; i >= 0; i--) {
+            var (rect, border, color) = rects[i];
+            if (!rect.IntersectsWith(localClip)) {
+                continue;
+            }
+
+            var sdlRect = ToSdlRect(rect, screenOffset);
+            if (border != RectangleBorder.None) {
+                borders.Add((sdlRect, border));
+            }
+
+            if (color == SchemeColor.None) {
+                continue;
+            }
+
+            if (color != currentColor) {
+                currentColor = color;
+                var sdlColor = currentColor.ToSdlColor();
+                _ = SDL.SDL_SetRenderDrawColor(renderer, sdlColor.r, sdlColor.g, sdlColor.b, sdlColor.a);
+            }
+            _ = SDL.SDL_RenderFillRect(renderer, ref sdlRect);
+        }
+
+        foreach (var (pos, icon, color) in icons) {
+            if (!pos.IntersectsWith(localClip)) {
+                continue;
+            }
+
+            var sdlPos = ToSdlRect(pos, screenOffset);
+            surface.DrawIcon(sdlPos, icon, color);
+        }
+
+        foreach (var (pos, renderable, color) in renderables) {
+            if (!pos.IntersectsWith(localClip)) {
+                continue;
+            }
+
+            renderable.Render(surface, ToSdlRect(pos, screenOffset), color.ToSdlColor());
+        }
+
+        foreach (var (srect, type) in borders) {
+            surface.DrawBorder(srect, type);
+        }
+
+        foreach (var (rect, batch, _) in panels) {
+            Rect intersection = Rect.Intersect(rect, localClip);
+            if (intersection == default) {
+                continue;
+            }
+
+            batch.Present(surface, rect + screenOffset, intersection + screenOffset, this);
+        }
+
+        if (clip) {
+            _ = surface.SetClip(prevClip);
+        }
+    }
+
+    public IPanel HitTest(Vector2 position) {
+        position = (position / scale) - offset;
+        for (int i = panels.Count - 1; i >= 0; i--) {
+            var (rect, panel, _) = panels[i];
+            if (panel.mouseCapture && rect.Contains(position)) {
+                return panel.HitTest(position - rect.Position);
+            }
+        }
+
+        return this;
+    }
+
+    public int UnitsToPixels(float units) => (int)MathF.Round(units * pixelsPerUnit);
+
+    public float PixelsToUnits(int pixels) => pixels / pixelsPerUnit;
+
+    public SDL.SDL_Rect ToSdlRect(Rect rect, Vector2 offset = default) => new SDL.SDL_Rect {
+        x = UnitsToPixels(rect.X + offset.X),
+        y = UnitsToPixels(rect.Y + offset.Y),
+        w = UnitsToPixels(rect.Width),
+        h = UnitsToPixels(rect.Height)
+    };
+
+    private static void CheckMainThread() {
+        if (!Ui.IsMainThread()) {
+            throw new NotSupportedException("This should be called from the main thread");
+        }
+    }
+
+    public Vector2 ToWindowPosition(Vector2 localPosition) {
+        if (window == null) {
+            return localPosition;
+        }
+
+        return screenRect.Position + (localPosition * (window.pixelsPerUnit / pixelsPerUnit));
+    }
+
+    public Rect TranslateRect(Rect localPosition, ImGui target) {
+        var topLeft = target.FromWindowPosition(ToWindowPosition(localPosition.TopLeft));
+        return new Rect(topLeft, localPosition.Size * (target.pixelsPerUnit / pixelsPerUnit));
+    }
+
+    public Vector2 FromWindowPosition(Vector2 windowPosition) {
+        if (window == null) {
+            return windowPosition;
+        }
+
+        return (windowPosition - screenRect.Position) * (pixelsPerUnit / window.pixelsPerUnit);
+    }
+
+    private void ReleaseUnmanagedResources() {
+        disposed = true;
+        textCache.Dispose();
+    }
+
+    public void Dispose() {
+        ReleaseUnmanagedResources();
+        GC.SuppressFinalize(this);
+    }
+
+    ~ImGui() {
+        ReleaseUnmanagedResources();
+    }
+
+    private void ExportDrawCommandsTo<T>(List<DrawCommand<T>> sourceList, List<DrawCommand<T>> targetList, Rect rect) {
+        targetList.Clear();
+        var delta = rect.Position;
+        for (int i = sourceList.Count - 1; i >= 0; i--) {
+            var elem = sourceList[i];
+            if (rect.Contains(elem.rect)) {
+                targetList.Add(new DrawCommand<T>(elem.rect - delta, elem.data, elem.color));
+            }
+            else {
+                break;
+            }
+        }
+        targetList.Reverse();
+        sourceList.RemoveRange(sourceList.Count - targetList.Count, targetList.Count);
+    }
+    public void ExportDrawCommandsTo(Rect rect, ImGui target) {
+        ExportDrawCommandsTo(rects, target.rects, rect);
+        ExportDrawCommandsTo(icons, target.icons, rect);
+        ExportDrawCommandsTo(renderables, target.renderables, rect);
+        ExportDrawCommandsTo(panels, target.panels, rect);
+        target.contentSize = rect.Size;
+    }
+
+    public void PropagateMessage<T>(T message) {
+        foreach (object handler in messageHandlers) {
+            if (handler is Func<T, bool> func && func(message)) {
+                return;
+            }
+        }
+        parent?.PropagateMessage(message);
+    }
+
+    public void AddMessageHandler<T>(Func<T, bool> handler) {
+        messageHandlers.Add(handler);
+    }
+
+    private readonly List<object> messageHandlers = [];
 }

--- a/Yafc.UI/ImGui/ImGuiBuildCache.cs
+++ b/Yafc.UI/ImGui/ImGuiBuildCache.cs
@@ -1,64 +1,63 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Yafc.UI {
-    public partial class ImGui {
-        public class BuildGroup {
-            private readonly ImGui gui;
-            private object? obj;
-            private float left, right, top;
-            private CopyableState state;
-            private Rect lastRect;
-            private bool finished;
+namespace Yafc.UI;
+public partial class ImGui {
+    public class BuildGroup {
+        private readonly ImGui gui;
+        private object? obj;
+        private float left, right, top;
+        private CopyableState state;
+        private Rect lastRect;
+        private bool finished;
 
-            public BuildGroup(ImGui gui) => this.gui = gui;
+        public BuildGroup(ImGui gui) => this.gui = gui;
 
-            public void Update(object obj) {
-                left = gui.state.left;
-                right = gui.state.right;
-                top = gui.state.top;
-                this.obj = obj;
-                finished = false;
-            }
+        public void Update(object obj) {
+            left = gui.state.left;
+            right = gui.state.right;
+            top = gui.state.top;
+            this.obj = obj;
+            finished = false;
+        }
 
-            public void Complete() {
-                if (!finished) {
-                    finished = true;
-                    state = gui.state;
-                    lastRect = gui.lastRect;
-                }
-            }
-
-            public bool CanSkip(object o) => o == obj && gui.action != ImGuiAction.Build && left == gui.state.left && right == gui.state.right && top == gui.state.top && finished &&
-                       (gui.localClip.Top > state.bottom || gui.localClip.Bottom < top);
-
-            public void Skip() {
-                gui.state = state;
-                gui.lastRect = lastRect;
+        public void Complete() {
+            if (!finished) {
+                finished = true;
+                state = gui.state;
+                lastRect = gui.lastRect;
             }
         }
 
-        private int buildGroupsIndex = -1;
-        private readonly List<BuildGroup> buildGroups = [];
+        public bool CanSkip(object o) => o == obj && gui.action != ImGuiAction.Build && left == gui.state.left && right == gui.state.right && top == gui.state.top && finished &&
+                   (gui.localClip.Top > state.bottom || gui.localClip.Bottom < top);
 
-        public bool ShouldBuildGroup(object o, [MaybeNullWhen(false)] out BuildGroup group) {
-            buildGroupsIndex++;
-            BuildGroup current;
-            if (buildGroups.Count > buildGroupsIndex) {
-                current = buildGroups[buildGroupsIndex];
-                if (current.CanSkip(o)) {
-                    current.Skip();
-                    group = null;
-                    return false;
-                }
-            }
-            else {
-                current = new BuildGroup(this);
-                buildGroups.Add(current);
-            }
-            current.Update(o);
-            group = current;
-            return true;
+        public void Skip() {
+            gui.state = state;
+            gui.lastRect = lastRect;
         }
+    }
+
+    private int buildGroupsIndex = -1;
+    private readonly List<BuildGroup> buildGroups = [];
+
+    public bool ShouldBuildGroup(object o, [MaybeNullWhen(false)] out BuildGroup group) {
+        buildGroupsIndex++;
+        BuildGroup current;
+        if (buildGroups.Count > buildGroupsIndex) {
+            current = buildGroups[buildGroupsIndex];
+            if (current.CanSkip(o)) {
+                current.Skip();
+                group = null;
+                return false;
+            }
+        }
+        else {
+            current = new BuildGroup(this);
+            buildGroups.Add(current);
+        }
+        current.Update(o);
+        group = current;
+        return true;
     }
 }

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -3,366 +3,365 @@ using System.Collections.Generic;
 using System.Numerics;
 using SDL2;
 
-namespace Yafc.UI {
-    public partial class ImGui {
-        private readonly struct DrawCommand<T> {
-            public readonly Rect rect;
-            public readonly T data;
-            public readonly SchemeColor color;
+namespace Yafc.UI;
+public partial class ImGui {
+    private readonly struct DrawCommand<T> {
+        public readonly Rect rect;
+        public readonly T data;
+        public readonly SchemeColor color;
 
-            public DrawCommand(Rect rect, T data, SchemeColor color) {
-                this.rect = rect;
-                this.data = data;
-                this.color = color;
-            }
-            public void Deconstruct(out Rect rect, out T data, out SchemeColor color) {
-                rect = this.rect;
-                data = this.data;
-                color = this.color;
-            }
+        public DrawCommand(Rect rect, T data, SchemeColor color) {
+            this.rect = rect;
+            this.data = data;
+            this.color = color;
+        }
+        public void Deconstruct(out Rect rect, out T data, out SchemeColor color) {
+            rect = this.rect;
+            data = this.data;
+            color = this.color;
+        }
+    }
+
+    private readonly List<DrawCommand<RectangleBorder>> rects = [];
+    private readonly List<DrawCommand<Icon>> icons = [];
+    private readonly List<DrawCommand<IRenderable>> renderables = [];
+    private readonly List<DrawCommand<IPanel>> panels = [];
+    public SchemeColor initialTextColor { get; set; } = SchemeColor.BackgroundText;
+    public SchemeColor boxColor { get; set; } = SchemeColor.None;
+    public RectangleBorder boxShadow { get; set; } = RectangleBorder.None;
+    public Padding initialPadding { get; set; }
+
+    public void DrawRectangle(Rect rect, SchemeColor color, RectangleBorder border = RectangleBorder.None) {
+        if (action != ImGuiAction.Build) {
+            return;
         }
 
-        private readonly List<DrawCommand<RectangleBorder>> rects = [];
-        private readonly List<DrawCommand<Icon>> icons = [];
-        private readonly List<DrawCommand<IRenderable>> renderables = [];
-        private readonly List<DrawCommand<IPanel>> panels = [];
-        public SchemeColor initialTextColor { get; set; } = SchemeColor.BackgroundText;
-        public SchemeColor boxColor { get; set; } = SchemeColor.None;
-        public RectangleBorder boxShadow { get; set; } = RectangleBorder.None;
-        public Padding initialPadding { get; set; }
+        rects.Add(new DrawCommand<RectangleBorder>(rect, border, color));
+    }
 
-        public void DrawRectangle(Rect rect, SchemeColor color, RectangleBorder border = RectangleBorder.None) {
-            if (action != ImGuiAction.Build) {
-                return;
-            }
-
-            rects.Add(new DrawCommand<RectangleBorder>(rect, border, color));
+    public void DrawIcon(Rect rect, Icon icon, SchemeColor color) {
+        if (action != ImGuiAction.Build || icon == Icon.None) {
+            return;
         }
 
-        public void DrawIcon(Rect rect, Icon icon, SchemeColor color) {
-            if (action != ImGuiAction.Build || icon == Icon.None) {
-                return;
-            }
+        icons.Add(new DrawCommand<Icon>(rect, icon, color));
+    }
 
-            icons.Add(new DrawCommand<Icon>(rect, icon, color));
+    public void DrawRenderable(Rect rect, IRenderable? renderable, SchemeColor color) {
+        if (action != ImGuiAction.Build || renderable == null) {
+            return;
         }
 
-        public void DrawRenderable(Rect rect, IRenderable? renderable, SchemeColor color) {
-            if (action != ImGuiAction.Build || renderable == null) {
-                return;
-            }
+        renderables.Add(new DrawCommand<IRenderable>(rect, renderable, color));
+    }
 
-            renderables.Add(new DrawCommand<IRenderable>(rect, renderable, color));
+    public void DrawPanel(Rect rect, IPanel panel) {
+        if (action != ImGuiAction.Build || panel == null) {
+            return;
         }
 
-        public void DrawPanel(Rect rect, IPanel panel) {
-            if (action != ImGuiAction.Build || panel == null) {
-                return;
-            }
+        panels.Add(new DrawCommand<IPanel>(rect, panel, 0));
+        _ = panel.CalculateState(rect.Width, pixelsPerUnit);
+    }
 
-            panels.Add(new DrawCommand<IPanel>(rect, panel, 0));
-            _ = panel.CalculateState(rect.Width, pixelsPerUnit);
-        }
+    private void ClearDrawCommandList() {
+        rects.Clear();
+        icons.Clear();
+        renderables.Clear();
+        panels.Clear();
+    }
 
-        private void ClearDrawCommandList() {
-            rects.Clear();
-            icons.Clear();
-            renderables.Clear();
-            panels.Clear();
-        }
-
-        public void ManualDrawingClear() {
-            if (guiBuilder == null) {
-                ClearDrawCommandList();
-            }
-        }
-
-        public readonly ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache textCache = new ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache();
-
-        public FontFile.FontSize GetFontSize(Font? font = null) {
-            return (font ?? Font.text).GetFontSize(pixelsPerUnit);
-        }
-
-        public SchemeColor textColor {
-            get => state.textColor;
-            set => state.textColor = value;
-        }
-
-        public void BuildText(string? text, TextBlockDisplayStyle? displayStyle = null, float topOffset = 0f, float maxWidth = float.MaxValue) {
-            displayStyle ??= TextBlockDisplayStyle.Default();
-            SchemeColor color = displayStyle.Color;
-            if (color == SchemeColor.None) {
-                color = state.textColor;
-            }
-
-            Rect rect = AllocateTextRect(out TextCache? cache, text, displayStyle, topOffset, maxWidth);
-            if (action == ImGuiAction.Build && cache != null) {
-                DrawRenderable(rect, cache, color);
-            }
-        }
-
-        public Vector2 GetTextDimensions(out TextCache? cache, string? text, Font? font = null, bool wrap = false, float maxWidth = float.MaxValue) {
-            if (string.IsNullOrEmpty(text)) {
-                cache = null;
-                return Vector2.Zero;
-            }
-
-            var fontSize = GetFontSize(font);
-            cache = textCache.GetCached((fontSize, text, wrap ? (uint)UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
-            float textWidth = Math.Min(cache.texRect.w / pixelsPerUnit, maxWidth);
-
-            return new Vector2(textWidth, cache.texRect.h / pixelsPerUnit);
-        }
-
-        public Rect AllocateTextRect(out TextCache? cache, string? text, TextBlockDisplayStyle displayStyle, float topOffset = 0f, float maxWidth = float.MaxValue) {
-            FontFile.FontSize fontSize = GetFontSize(displayStyle.Font);
-            Rect rect;
-            if (string.IsNullOrEmpty(text)) {
-                cache = null;
-                rect = AllocateRect(0f, topOffset + (fontSize.lineSize / pixelsPerUnit));
-            }
-            else {
-                Vector2 textSize = GetTextDimensions(out cache, text, displayStyle.Font, displayStyle.WrapText, maxWidth);
-                rect = AllocateRect(textSize.X, topOffset + (textSize.Y), displayStyle.Alignment);
-            }
-
-            if (topOffset != 0f) {
-                rect.Top += topOffset;
-            }
-
-            return rect;
-        }
-
-        public void DrawText(Rect rect, string text, RectAlignment alignment = RectAlignment.MiddleLeft, Font? font = null, SchemeColor color = SchemeColor.None) {
-            if (color == SchemeColor.None) {
-                color = state.textColor;
-            }
-
-            var fontSize = GetFontSize(font);
-            var cache = textCache.GetCached((fontSize, text, uint.MaxValue));
-            var realRect = AlignRect(rect, alignment, cache.texRect.w / pixelsPerUnit, cache.texRect.h / pixelsPerUnit);
-            if (action == ImGuiAction.Build) {
-                DrawRenderable(realRect, cache, color);
-            }
-        }
-
-        private ImGuiTextInputHelper? textInputHelper;
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, Icon icon = Icon.None, bool delayed = false, bool setInitialFocus = false) {
-            TextBoxDisplayStyle displayStyle = TextBoxDisplayStyle.DefaultTextInput;
-            if (icon != Icon.None) {
-                displayStyle = displayStyle with { Icon = icon };
-            }
-            return BuildTextInput(text, out newText, placeholder, displayStyle, delayed, setInitialFocus);
-        }
-
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, TextBoxDisplayStyle displayStyle, bool delayed, bool setInitialFocus = false) {
-            setInitialFocus &= textInputHelper == null;
-            textInputHelper ??= new ImGuiTextInputHelper(this);
-            bool result = textInputHelper.BuildTextInput(text, out newText, placeholder, GetFontSize(), delayed, displayStyle);
-            if (setInitialFocus) {
-                SetTextInputFocus(lastRect, "");
-            }
-
-            return result;
-        }
-
-        public void BuildIcon(Icon icon, float size = 1.5f, SchemeColor color = SchemeColor.None) {
-            if (color == SchemeColor.None) {
-                color = icon >= Icon.FirstCustom ? SchemeColor.Source : state.textColor;
-            }
-
-            var rect = AllocateRect(size, size, RectAlignment.Middle);
-            if (action == ImGuiAction.Build) {
-                DrawIcon(rect, icon, color);
-            }
-        }
-
-        public Vector2 mousePosition => InputSystem.Instance.mousePosition - screenRect.Position;
-        public bool mousePresent { get; private set; }
-        public Rect mouseDownRect { get; private set; }
-        public Rect mouseOverRect { get; private set; } = Rect.VeryBig;
-        private readonly RectAllocator defaultAllocator;
-        private int mouseDownButton = -1;
-        private float buildingWidth;
-        public event Action? CollectCustomCache;
-
-        private bool DoGui(ImGuiAction action) {
-            if (guiBuilder == null) {
-                return false;
-            }
-
-            this.action = action;
-            ResetLayout();
-            buildingWidth = buildWidth;
-            buildGroupsIndex = -1;
-            using (EnterGroup(initialPadding, defaultAllocator, initialTextColor)) {
-                guiBuilder(this);
-            }
-            actionParameter = 0;
-            if (action == ImGuiAction.Build) {
-                return false;
-            }
-
-            bool consumed = this.action == ImGuiAction.Consumed;
-            if (IsRebuildRequired()) {
-                BuildGui(buildWidth);
-            }
-
-            this.action = ImGuiAction.Consumed;
-            return consumed;
-        }
-
-        private void BuildGui(float width) {
-            if (guiBuilder == null) {
-                return;
-            }
-
-            buildWidth = width;
-            nextRebuildTimer = long.MaxValue;
-            rebuildRequested = false;
+    public void ManualDrawingClear() {
+        if (guiBuilder == null) {
             ClearDrawCommandList();
-            _ = DoGui(ImGuiAction.Build);
-            contentSize = new Vector2(lastContentRect.Right, lastContentRect.Height);
-            if (boxColor != SchemeColor.None) {
-                Rect rect = new Rect(default, contentSize);
-                rects.Add(new DrawCommand<RectangleBorder>(rect, boxShadow, boxColor));
-            }
-            textCache.PurgeUnused();
-            CollectCustomCache?.Invoke();
-            Repaint();
+        }
+    }
+
+    public readonly ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache textCache = new ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache();
+
+    public FontFile.FontSize GetFontSize(Font? font = null) {
+        return (font ?? Font.text).GetFontSize(pixelsPerUnit);
+    }
+
+    public SchemeColor textColor {
+        get => state.textColor;
+        set => state.textColor = value;
+    }
+
+    public void BuildText(string? text, TextBlockDisplayStyle? displayStyle = null, float topOffset = 0f, float maxWidth = float.MaxValue) {
+        displayStyle ??= TextBlockDisplayStyle.Default();
+        SchemeColor color = displayStyle.Color;
+        if (color == SchemeColor.None) {
+            color = state.textColor;
         }
 
-        public void MouseMove(int mouseDownButton) {
-            actionParameter = mouseDownButton;
-            mousePresent = true;
-            if (currentDraggingObject != null) {
-                _ = DoGui(ImGuiAction.MouseDrag);
-                return;
-            }
-            if (!mouseOverRect.Contains(mousePosition)) {
-                mouseOverRect = Rect.VeryBig;
-                rebuildRequested = true;
-                if (!cursorSetByMouseDown) {
-                    SDL.SDL_SetCursor(RenderingUtils.cursorArrow);
-                }
-            }
+        Rect rect = AllocateTextRect(out TextCache? cache, text, displayStyle, topOffset, maxWidth);
+        if (action == ImGuiAction.Build && cache != null) {
+            DrawRenderable(rect, cache, color);
+        }
+    }
 
-            _ = DoGui(ImGuiAction.MouseMove);
+    public Vector2 GetTextDimensions(out TextCache? cache, string? text, Font? font = null, bool wrap = false, float maxWidth = float.MaxValue) {
+        if (string.IsNullOrEmpty(text)) {
+            cache = null;
+            return Vector2.Zero;
         }
 
-        public void MouseDown(int button) {
-            mouseDownButton = button;
-            actionParameter = button;
-            mouseDownRect = default;
-            _ = DoGui(ImGuiAction.MouseDown);
+        var fontSize = GetFontSize(font);
+        cache = textCache.GetCached((fontSize, text, wrap ? (uint)UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
+        float textWidth = Math.Min(cache.texRect.w / pixelsPerUnit, maxWidth);
+
+        return new Vector2(textWidth, cache.texRect.h / pixelsPerUnit);
+    }
+
+    public Rect AllocateTextRect(out TextCache? cache, string? text, TextBlockDisplayStyle displayStyle, float topOffset = 0f, float maxWidth = float.MaxValue) {
+        FontFile.FontSize fontSize = GetFontSize(displayStyle.Font);
+        Rect rect;
+        if (string.IsNullOrEmpty(text)) {
+            cache = null;
+            rect = AllocateRect(0f, topOffset + (fontSize.lineSize / pixelsPerUnit));
+        }
+        else {
+            Vector2 textSize = GetTextDimensions(out cache, text, displayStyle.Font, displayStyle.WrapText, maxWidth);
+            rect = AllocateRect(textSize.X, topOffset + (textSize.Y), displayStyle.Alignment);
         }
 
-        public void MouseLost() {
-            mouseDownButton = -1;
-            mouseDownRect = default;
+        if (topOffset != 0f) {
+            rect.Top += topOffset;
+        }
+
+        return rect;
+    }
+
+    public void DrawText(Rect rect, string text, RectAlignment alignment = RectAlignment.MiddleLeft, Font? font = null, SchemeColor color = SchemeColor.None) {
+        if (color == SchemeColor.None) {
+            color = state.textColor;
+        }
+
+        var fontSize = GetFontSize(font);
+        var cache = textCache.GetCached((fontSize, text, uint.MaxValue));
+        var realRect = AlignRect(rect, alignment, cache.texRect.w / pixelsPerUnit, cache.texRect.h / pixelsPerUnit);
+        if (action == ImGuiAction.Build) {
+            DrawRenderable(realRect, cache, color);
+        }
+    }
+
+    private ImGuiTextInputHelper? textInputHelper;
+    public bool BuildTextInput(string? text, out string newText, string? placeholder, Icon icon = Icon.None, bool delayed = false, bool setInitialFocus = false) {
+        TextBoxDisplayStyle displayStyle = TextBoxDisplayStyle.DefaultTextInput;
+        if (icon != Icon.None) {
+            displayStyle = displayStyle with { Icon = icon };
+        }
+        return BuildTextInput(text, out newText, placeholder, displayStyle, delayed, setInitialFocus);
+    }
+
+    public bool BuildTextInput(string? text, out string newText, string? placeholder, TextBoxDisplayStyle displayStyle, bool delayed, bool setInitialFocus = false) {
+        setInitialFocus &= textInputHelper == null;
+        textInputHelper ??= new ImGuiTextInputHelper(this);
+        bool result = textInputHelper.BuildTextInput(text, out newText, placeholder, GetFontSize(), delayed, displayStyle);
+        if (setInitialFocus) {
+            SetTextInputFocus(lastRect, "");
+        }
+
+        return result;
+    }
+
+    public void BuildIcon(Icon icon, float size = 1.5f, SchemeColor color = SchemeColor.None) {
+        if (color == SchemeColor.None) {
+            color = icon >= Icon.FirstCustom ? SchemeColor.Source : state.textColor;
+        }
+
+        var rect = AllocateRect(size, size, RectAlignment.Middle);
+        if (action == ImGuiAction.Build) {
+            DrawIcon(rect, icon, color);
+        }
+    }
+
+    public Vector2 mousePosition => InputSystem.Instance.mousePosition - screenRect.Position;
+    public bool mousePresent { get; private set; }
+    public Rect mouseDownRect { get; private set; }
+    public Rect mouseOverRect { get; private set; } = Rect.VeryBig;
+    private readonly RectAllocator defaultAllocator;
+    private int mouseDownButton = -1;
+    private float buildingWidth;
+    public event Action? CollectCustomCache;
+
+    private bool DoGui(ImGuiAction action) {
+        if (guiBuilder == null) {
+            return false;
+        }
+
+        this.action = action;
+        ResetLayout();
+        buildingWidth = buildWidth;
+        buildGroupsIndex = -1;
+        using (EnterGroup(initialPadding, defaultAllocator, initialTextColor)) {
+            guiBuilder(this);
+        }
+        actionParameter = 0;
+        if (action == ImGuiAction.Build) {
+            return false;
+        }
+
+        bool consumed = this.action == ImGuiAction.Consumed;
+        if (IsRebuildRequired()) {
+            BuildGui(buildWidth);
+        }
+
+        this.action = ImGuiAction.Consumed;
+        return consumed;
+    }
+
+    private void BuildGui(float width) {
+        if (guiBuilder == null) {
+            return;
+        }
+
+        buildWidth = width;
+        nextRebuildTimer = long.MaxValue;
+        rebuildRequested = false;
+        ClearDrawCommandList();
+        _ = DoGui(ImGuiAction.Build);
+        contentSize = new Vector2(lastContentRect.Right, lastContentRect.Height);
+        if (boxColor != SchemeColor.None) {
+            Rect rect = new Rect(default, contentSize);
+            rects.Add(new DrawCommand<RectangleBorder>(rect, boxShadow, boxColor));
+        }
+        textCache.PurgeUnused();
+        CollectCustomCache?.Invoke();
+        Repaint();
+    }
+
+    public void MouseMove(int mouseDownButton) {
+        actionParameter = mouseDownButton;
+        mousePresent = true;
+        if (currentDraggingObject != null) {
+            _ = DoGui(ImGuiAction.MouseDrag);
+            return;
+        }
+        if (!mouseOverRect.Contains(mousePosition)) {
             mouseOverRect = Rect.VeryBig;
-        }
-
-        public void MouseUp(int button) {
-            mouseDownButton = -1;
-            if (currentDraggingObject != null) {
-                currentDraggingObject = null;
-                rebuildRequested = true;
-                return;
-            }
-
-            if (cursorSetByMouseDown) {
-                SDL.SDL_SetCursor(RenderingUtils.cursorHand);
-                cursorSetByMouseDown = false;
-            }
-
-            actionParameter = button;
-            _ = DoGui(ImGuiAction.MouseUp);
-        }
-
-        public void MouseScroll(int delta) {
-            actionParameter = delta;
-            if (!DoGui(ImGuiAction.MouseScroll)) {
-                parent?.MouseScroll(delta);
-            }
-        }
-
-        public void MouseExit() {
-            mousePresent = false;
-            if (mouseOverRect != Rect.VeryBig) {
-                mouseOverRect = Rect.VeryBig;
+            rebuildRequested = true;
+            if (!cursorSetByMouseDown) {
                 SDL.SDL_SetCursor(RenderingUtils.cursorArrow);
-                BuildGui(buildWidth);
             }
         }
 
-        private bool cursorSetByMouseDown;
-        public bool ConsumeMouseDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT, IntPtr cursor = default) {
-            if (action == ImGuiAction.MouseDown && mousePresent && rect.Contains(mousePosition) && actionParameter == button) {
-                action = ImGuiAction.Consumed;
-                rebuildRequested = true;
-                mouseDownRect = rect;
-                if (cursor != default) {
-                    SDL.SDL_SetCursor(cursor);
-                    cursorSetByMouseDown = true;
+        _ = DoGui(ImGuiAction.MouseMove);
+    }
+
+    public void MouseDown(int button) {
+        mouseDownButton = button;
+        actionParameter = button;
+        mouseDownRect = default;
+        _ = DoGui(ImGuiAction.MouseDown);
+    }
+
+    public void MouseLost() {
+        mouseDownButton = -1;
+        mouseDownRect = default;
+        mouseOverRect = Rect.VeryBig;
+    }
+
+    public void MouseUp(int button) {
+        mouseDownButton = -1;
+        if (currentDraggingObject != null) {
+            currentDraggingObject = null;
+            rebuildRequested = true;
+            return;
+        }
+
+        if (cursorSetByMouseDown) {
+            SDL.SDL_SetCursor(RenderingUtils.cursorHand);
+            cursorSetByMouseDown = false;
+        }
+
+        actionParameter = button;
+        _ = DoGui(ImGuiAction.MouseUp);
+    }
+
+    public void MouseScroll(int delta) {
+        actionParameter = delta;
+        if (!DoGui(ImGuiAction.MouseScroll)) {
+            parent?.MouseScroll(delta);
+        }
+    }
+
+    public void MouseExit() {
+        mousePresent = false;
+        if (mouseOverRect != Rect.VeryBig) {
+            mouseOverRect = Rect.VeryBig;
+            SDL.SDL_SetCursor(RenderingUtils.cursorArrow);
+            BuildGui(buildWidth);
+        }
+    }
+
+    private bool cursorSetByMouseDown;
+    public bool ConsumeMouseDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT, IntPtr cursor = default) {
+        if (action == ImGuiAction.MouseDown && mousePresent && rect.Contains(mousePosition) && actionParameter == button) {
+            action = ImGuiAction.Consumed;
+            rebuildRequested = true;
+            mouseDownRect = rect;
+            if (cursor != default) {
+                SDL.SDL_SetCursor(cursor);
+                cursorSetByMouseDown = true;
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool ConsumeMouseOver(Rect rect, IntPtr cursor = default, bool rebuild = true) {
+        if (action == ImGuiAction.MouseMove && mousePresent && rect.Contains(mousePosition)) {
+            action = ImGuiAction.Consumed;
+            if (mouseOverRect != rect) {
+                if (rebuild) {
+                    rebuildRequested = true;
                 }
-                return true;
-            }
 
-            return false;
-        }
-
-        public bool ConsumeMouseOver(Rect rect, IntPtr cursor = default, bool rebuild = true) {
-            if (action == ImGuiAction.MouseMove && mousePresent && rect.Contains(mousePosition)) {
-                action = ImGuiAction.Consumed;
-                if (mouseOverRect != rect) {
-                    if (rebuild) {
-                        rebuildRequested = true;
-                    }
-
-                    mouseOverRect = rect;
-                    if (!cursorSetByMouseDown) {
-                        SDL.SDL_SetCursor(cursor == default ? RenderingUtils.cursorArrow : cursor);
-                    }
-
-                    return true;
+                mouseOverRect = rect;
+                if (!cursorSetByMouseDown) {
+                    SDL.SDL_SetCursor(cursor == default ? RenderingUtils.cursorArrow : cursor);
                 }
-            }
-            return false;
-        }
 
-        public bool ConsumeMouseUp(Rect rect, bool inside = true, uint button = SDL.SDL_BUTTON_LEFT) {
-            if (action == ImGuiAction.MouseUp && rect == mouseDownRect && (!inside || rect.Contains(mousePosition))) {
-                action = ImGuiAction.Consumed;
-                Rebuild();
                 return true;
             }
+        }
+        return false;
+    }
 
-            return false;
+    public bool ConsumeMouseUp(Rect rect, bool inside = true, uint button = SDL.SDL_BUTTON_LEFT) {
+        if (action == ImGuiAction.MouseUp && rect == mouseDownRect && (!inside || rect.Contains(mousePosition))) {
+            action = ImGuiAction.Consumed;
+            Rebuild();
+            return true;
         }
 
-        public bool ConsumeEvent(Rect rect) {
-            if (action == ImGuiAction.MouseScroll && rect.Contains(mousePosition)) {
-                action = ImGuiAction.Consumed;
-                return true;
-            }
+        return false;
+    }
 
-            return false;
+    public bool ConsumeEvent(Rect rect) {
+        if (action == ImGuiAction.MouseScroll && rect.Contains(mousePosition)) {
+            action = ImGuiAction.Consumed;
+            return true;
         }
 
-        public bool IsMouseOver(Rect rect) => rect == mouseOverRect;
+        return false;
+    }
 
-        public bool IsMouseDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) => rect == mouseDownRect && mouseDownButton == button;
+    public bool IsMouseOver(Rect rect) => rect == mouseOverRect;
 
-        public bool IsMouseOverOrDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) => mouseOverRect == rect || (mouseDownRect == rect && mouseDownButton == button);
+    public bool IsMouseDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) => rect == mouseDownRect && mouseDownButton == button;
 
-        public bool IsLastMouseDown(Rect rect) => rect == mouseDownRect;
+    public bool IsMouseOverOrDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) => mouseOverRect == rect || (mouseDownRect == rect && mouseDownButton == button);
 
-        public void SetTextInputFocus(Rect rect, string text) {
-            if (textInputHelper != null && InputSystem.Instance.currentKeyboardFocus != textInputHelper) {
-                Rebuild();
-                textInputHelper.SetFocus(rect, text);
-            }
+    public bool IsLastMouseDown(Rect rect) => rect == mouseDownRect;
+
+    public void SetTextInputFocus(Rect rect, string text) {
+        if (textInputHelper != null && InputSystem.Instance.currentKeyboardFocus != textInputHelper) {
+            Rebuild();
+            textInputHelper.SetFocus(rect, text);
         }
     }
 }

--- a/Yafc.UI/ImGui/ImGuiCache.cs
+++ b/Yafc.UI/ImGui/ImGuiCache.cs
@@ -3,91 +3,90 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using SDL2;
 
-namespace Yafc.UI {
-    public abstract class ImGuiCache<T, TKey> : IDisposable where T : ImGuiCache<T, TKey> where TKey : IEquatable<TKey> {
-        private static readonly T Constructor = (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+namespace Yafc.UI;
+public abstract class ImGuiCache<T, TKey> : IDisposable where T : ImGuiCache<T, TKey> where TKey : IEquatable<TKey> {
+    private static readonly T Constructor = (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
 
-        public class Cache : IDisposable {
-            private readonly Dictionary<TKey, T> activeCached = [];
-            private readonly HashSet<TKey> unused = [];
+    public class Cache : IDisposable {
+        private readonly Dictionary<TKey, T> activeCached = [];
+        private readonly HashSet<TKey> unused = [];
 
-            public T GetCached(TKey key) {
-                if (activeCached.TryGetValue(key, out var value)) {
-                    _ = unused.Remove(key);
-                    return value;
-                }
-
-                return activeCached[key] = Constructor.CreateForKey(key);
+        public T GetCached(TKey key) {
+            if (activeCached.TryGetValue(key, out var value)) {
+                _ = unused.Remove(key);
+                return value;
             }
 
-            public void PurgeUnused() {
-                foreach (var key in unused) {
-                    if (activeCached.Remove(key, out var value)) {
-                        value.Dispose();
-                    }
-                }
-                unused.Clear();
-                unused.UnionWith(activeCached.Keys);
-            }
-
-            public void Dispose() {
-                foreach (var item in activeCached) {
-                    item.Value.Dispose();
-                }
-
-                activeCached.Clear();
-                unused.Clear();
-            }
+            return activeCached[key] = Constructor.CreateForKey(key);
         }
 
+        public void PurgeUnused() {
+            foreach (var key in unused) {
+                if (activeCached.Remove(key, out var value)) {
+                    value.Dispose();
+                }
+            }
+            unused.Clear();
+            unused.UnionWith(activeCached.Keys);
+        }
 
-        protected abstract T CreateForKey(TKey key);
-        public abstract void Dispose();
+        public void Dispose() {
+            foreach (var item in activeCached) {
+                item.Value.Dispose();
+            }
+
+            activeCached.Clear();
+            unused.Clear();
+        }
     }
 
-    public class TextCache : ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>, IRenderable {
-        public TextureHandle texture;
-        private IntPtr surface;
-        internal SDL.SDL_Rect texRect;
-        private SDL.SDL_Color curColor = RenderingUtils.White;
 
-        private TextCache((FontFile.FontSize size, string text, uint wrapWidth) key) {
-            surface = key.wrapWidth == uint.MaxValue
-                ? SDL_ttf.TTF_RenderUNICODE_Blended(key.size.handle, key.text, RenderingUtils.White)
-                : SDL_ttf.TTF_RenderUNICODE_Blended_Wrapped(key.size.handle, key.text, RenderingUtils.White, key.wrapWidth);
+    protected abstract T CreateForKey(TKey key);
+    public abstract void Dispose();
+}
 
-            ref var surfaceParams = ref RenderingUtils.AsSdlSurface(surface);
-            texRect = new SDL.SDL_Rect { w = surfaceParams.w, h = surfaceParams.h };
+public class TextCache : ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>, IRenderable {
+    public TextureHandle texture;
+    private IntPtr surface;
+    internal SDL.SDL_Rect texRect;
+    private SDL.SDL_Color curColor = RenderingUtils.White;
+
+    private TextCache((FontFile.FontSize size, string text, uint wrapWidth) key) {
+        surface = key.wrapWidth == uint.MaxValue
+            ? SDL_ttf.TTF_RenderUNICODE_Blended(key.size.handle, key.text, RenderingUtils.White)
+            : SDL_ttf.TTF_RenderUNICODE_Blended_Wrapped(key.size.handle, key.text, RenderingUtils.White, key.wrapWidth);
+
+        ref var surfaceParams = ref RenderingUtils.AsSdlSurface(surface);
+        texRect = new SDL.SDL_Rect { w = surfaceParams.w, h = surfaceParams.h };
+    }
+
+    protected override TextCache CreateForKey((FontFile.FontSize size, string text, uint wrapWidth) key) => new TextCache(key);
+
+    public override void Dispose() {
+        if (surface != IntPtr.Zero) {
+            SDL.SDL_FreeSurface(surface);
+            surface = IntPtr.Zero;
         }
 
-        protected override TextCache CreateForKey((FontFile.FontSize size, string text, uint wrapWidth) key) => new TextCache(key);
+        texture = texture.Destroy();
+    }
 
-        public override void Dispose() {
-            if (surface != IntPtr.Zero) {
-                SDL.SDL_FreeSurface(surface);
-                surface = IntPtr.Zero;
-            }
-
+    public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
+        if (texture.surface != surface) {
             texture = texture.Destroy();
+            texture = surface.CreateTextureFromSurface(this.surface);
+            curColor = RenderingUtils.White;
         }
 
-        public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
-            if (texture.surface != surface) {
-                texture = texture.Destroy();
-                texture = surface.CreateTextureFromSurface(this.surface);
-                curColor = RenderingUtils.White;
-            }
-
-            if (color.r != curColor.r || color.g != curColor.g || color.b != curColor.b) {
-                _ = SDL.SDL_SetTextureColorMod(texture.handle, color.r, color.g, color.b);
-            }
-
-            if (color.a != curColor.a) {
-                _ = SDL.SDL_SetTextureAlphaMod(texture.handle, color.a);
-            }
-
-            curColor = color;
-            _ = SDL.SDL_RenderCopy(surface.renderer, texture.handle, ref texRect, ref position);
+        if (color.r != curColor.r || color.g != curColor.g || color.b != curColor.b) {
+            _ = SDL.SDL_SetTextureColorMod(texture.handle, color.r, color.g, color.b);
         }
+
+        if (color.a != curColor.a) {
+            _ = SDL.SDL_SetTextureAlphaMod(texture.handle, color.a);
+        }
+
+        curColor = color;
+        _ = SDL.SDL_RenderCopy(surface.renderer, texture.handle, ref texRect, ref position);
     }
 }

--- a/Yafc.UI/ImGui/ImGuiDrag.cs
+++ b/Yafc.UI/ImGui/ImGuiDrag.cs
@@ -1,144 +1,142 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
-namespace Yafc.UI {
-    public partial class ImGui {
-        private object? currentDraggingObject;
+namespace Yafc.UI;
+public partial class ImGui {
+    private object? currentDraggingObject;
 
-        public void SetDraggingArea<T>(Rect rect, T draggingObject, SchemeColor bgColor) {
-            if (window == null || mouseDownButton == -1) {
-                return;
-            }
-
-            rebuildRequested = false;
-            currentDraggingObject = draggingObject;
-            var overlay = window.GetDragOverlay();
-            overlay.BeginDrag(this, rect, bgColor);
+    public void SetDraggingArea<T>(Rect rect, T draggingObject, SchemeColor bgColor) {
+        if (window == null || mouseDownButton == -1) {
+            return;
         }
 
-        public void UpdateDraggingObject(object? obj) {
-            if (currentDraggingObject != null) {
-                currentDraggingObject = obj;
-            }
+        rebuildRequested = false;
+        currentDraggingObject = draggingObject;
+        var overlay = window.GetDragOverlay();
+        overlay.BeginDrag(this, rect, bgColor);
+    }
+
+    public void UpdateDraggingObject(object? obj) {
+        if (currentDraggingObject != null) {
+            currentDraggingObject = obj;
+        }
+    }
+
+    public bool isDragging => currentDraggingObject != null;
+
+    public bool IsDragging<T>(T obj) {
+        if (currentDraggingObject != null && currentDraggingObject.Equals(obj)) {
+            return true;
         }
 
-        public bool isDragging => currentDraggingObject != null;
+        return false;
+    }
 
-        public bool IsDragging<T>(T obj) {
-            if (currentDraggingObject != null && currentDraggingObject.Equals(obj)) {
-                return true;
-            }
-
+    [MemberNotNullWhen(true, nameof(currentDraggingObject))]
+    public bool ConsumeDrag<T>(Vector2 anchor, T obj) {
+        if (window == null || mouseDownButton == -1) {
             return false;
         }
 
-        [MemberNotNullWhen(true, nameof(currentDraggingObject))]
-        public bool ConsumeDrag<T>(Vector2 anchor, T obj) {
-            if (window == null || mouseDownButton == -1) {
-                return false;
-            }
-
-            if (action == ImGuiAction.MouseDrag && currentDraggingObject != null && !currentDraggingObject.Equals(obj) && window.GetDragOverlay().ShouldConsumeDrag(this, anchor)) {
-                action = ImGuiAction.Consumed;
-                Rebuild();
-                return true;
-            }
-
-            return false;
+        if (action == ImGuiAction.MouseDrag && currentDraggingObject != null && !currentDraggingObject.Equals(obj) && window.GetDragOverlay().ShouldConsumeDrag(this, anchor)) {
+            action = ImGuiAction.Consumed;
+            Rebuild();
+            return true;
         }
 
-        public T? GetDraggingObject<T>() => currentDraggingObject is T t ? t : default;
+        return false;
+    }
 
-        public bool DoListReordering<T>(Rect moveHandle, Rect contents, T index, out T moveFrom, SchemeColor backgroundColor = SchemeColor.PureBackground, bool updateDraggingObject = true) {
-            moveFrom = index;
-            if (!this.InitiateDrag(moveHandle, contents, index, backgroundColor) && action == ImGuiAction.MouseDrag && ConsumeDrag(contents.Center, index)) {
-                moveFrom = (T)currentDraggingObject;
-                if (updateDraggingObject) {
-                    UpdateDraggingObject(index);
-                }
+    public T? GetDraggingObject<T>() => currentDraggingObject is T t ? t : default;
 
-                return true;
-            }
-            return false;
-        }
-
-
-        internal class DragOverlay {
-            private readonly ImGui contents = new ImGui(null, default) { mouseCapture = false };
-
-            private ImGui? currentSource;
-            private Vector2 mouseOffset;
-            private Rect realPosition;
-
-
-            public bool ShouldConsumeDrag(ImGui source, Vector2 point) => currentSource == source && realPosition.Contains(source.ToWindowPosition(point));
-
-            private void ExtractDrawCommandsFrom<T>(List<DrawCommand<T>> sourceList, List<DrawCommand<T>> targetList, Rect rect) {
-                targetList.Clear();
-                var delta = rect.Position;
-                int firstInBlock = -1;
-                for (int i = 0; i < sourceList.Count; i++) {
-                    var elem = sourceList[i];
-                    if (rect.Contains(elem.rect)) {
-                        if (firstInBlock == -1) {
-                            firstInBlock = i;
-                        }
-
-                        targetList.Add(new DrawCommand<T>(elem.rect - delta, elem.data, elem.color));
-                    }
-                    else if (firstInBlock != -1) {
-                        sourceList.RemoveRange(firstInBlock, i - firstInBlock);
-                        i = firstInBlock;
-                        firstInBlock = -1;
-                    }
-                }
-                if (firstInBlock != -1) {
-                    sourceList.RemoveRange(firstInBlock, sourceList.Count - firstInBlock);
-                }
-            }
-
-            public void BeginDrag(ImGui source, Rect rect, SchemeColor bgColor) {
-                if (source != currentSource) {
-                    currentSource = source;
-                    mouseOffset = rect.Position - source.mousePosition;
-                }
-                ExtractDrawCommandsFrom(source.rects, contents.rects, rect);
-                ExtractDrawCommandsFrom(source.icons, contents.icons, rect);
-                ExtractDrawCommandsFrom(source.renderables, contents.renderables, rect);
-                ExtractDrawCommandsFrom(source.panels, contents.panels, rect);
-                contents.rects.Add(new DrawCommand<RectangleBorder>(new Rect(default, rect.Size), RectangleBorder.Thin, bgColor));
-                contents.contentSize = rect.Size;
-            }
-
-            public void Build(ImGui screenGui) {
-                if (currentSource == null) {
-                    return;
-                }
-
-                if (InputSystem.Instance.mouseDownButton == -1) {
-                    currentSource = null;
-                    realPosition = default;
-                    return;
-                }
-
-                if (screenGui.action == ImGuiAction.Build) {
-                    var sourceRect = currentSource.screenRect - currentSource.offset;
-                    var requestedPosition = screenGui.mousePosition + mouseOffset;
-                    Vector2 clampedPos = Vector2.Clamp(requestedPosition, sourceRect.Position, Vector2.Max(sourceRect.Position, sourceRect.BottomRight - contents.contentSize));
-                    realPosition = new Rect(clampedPos, contents.contentSize);
-                    screenGui.DrawPanel(realPosition, contents);
-                }
-            }
-        }
-
-        public bool ShouldEnterDrag(Rect moveHandle) {
-            if (action != ImGuiAction.MouseMove || !IsMouseDown(moveHandle) || isDragging || Vector2.DistanceSquared(InputSystem.Instance.mousePosition, InputSystem.Instance.mouseDownPosition) < 1f) {
-                return false;
+    public bool DoListReordering<T>(Rect moveHandle, Rect contents, T index, out T moveFrom, SchemeColor backgroundColor = SchemeColor.PureBackground, bool updateDraggingObject = true) {
+        moveFrom = index;
+        if (!this.InitiateDrag(moveHandle, contents, index, backgroundColor) && action == ImGuiAction.MouseDrag && ConsumeDrag(contents.Center, index)) {
+            moveFrom = (T)currentDraggingObject;
+            if (updateDraggingObject) {
+                UpdateDraggingObject(index);
             }
 
             return true;
         }
+        return false;
+    }
+
+
+    internal class DragOverlay {
+        private readonly ImGui contents = new ImGui(null, default) { mouseCapture = false };
+
+        private ImGui? currentSource;
+        private Vector2 mouseOffset;
+        private Rect realPosition;
+
+
+        public bool ShouldConsumeDrag(ImGui source, Vector2 point) => currentSource == source && realPosition.Contains(source.ToWindowPosition(point));
+
+        private void ExtractDrawCommandsFrom<T>(List<DrawCommand<T>> sourceList, List<DrawCommand<T>> targetList, Rect rect) {
+            targetList.Clear();
+            var delta = rect.Position;
+            int firstInBlock = -1;
+            for (int i = 0; i < sourceList.Count; i++) {
+                var elem = sourceList[i];
+                if (rect.Contains(elem.rect)) {
+                    if (firstInBlock == -1) {
+                        firstInBlock = i;
+                    }
+
+                    targetList.Add(new DrawCommand<T>(elem.rect - delta, elem.data, elem.color));
+                }
+                else if (firstInBlock != -1) {
+                    sourceList.RemoveRange(firstInBlock, i - firstInBlock);
+                    i = firstInBlock;
+                    firstInBlock = -1;
+                }
+            }
+            if (firstInBlock != -1) {
+                sourceList.RemoveRange(firstInBlock, sourceList.Count - firstInBlock);
+            }
+        }
+
+        public void BeginDrag(ImGui source, Rect rect, SchemeColor bgColor) {
+            if (source != currentSource) {
+                currentSource = source;
+                mouseOffset = rect.Position - source.mousePosition;
+            }
+            ExtractDrawCommandsFrom(source.rects, contents.rects, rect);
+            ExtractDrawCommandsFrom(source.icons, contents.icons, rect);
+            ExtractDrawCommandsFrom(source.renderables, contents.renderables, rect);
+            ExtractDrawCommandsFrom(source.panels, contents.panels, rect);
+            contents.rects.Add(new DrawCommand<RectangleBorder>(new Rect(default, rect.Size), RectangleBorder.Thin, bgColor));
+            contents.contentSize = rect.Size;
+        }
+
+        public void Build(ImGui screenGui) {
+            if (currentSource == null) {
+                return;
+            }
+
+            if (InputSystem.Instance.mouseDownButton == -1) {
+                currentSource = null;
+                realPosition = default;
+                return;
+            }
+
+            if (screenGui.action == ImGuiAction.Build) {
+                var sourceRect = currentSource.screenRect - currentSource.offset;
+                var requestedPosition = screenGui.mousePosition + mouseOffset;
+                Vector2 clampedPos = Vector2.Clamp(requestedPosition, sourceRect.Position, Vector2.Max(sourceRect.Position, sourceRect.BottomRight - contents.contentSize));
+                realPosition = new Rect(clampedPos, contents.contentSize);
+                screenGui.DrawPanel(realPosition, contents);
+            }
+        }
+    }
+
+    public bool ShouldEnterDrag(Rect moveHandle) {
+        if (action != ImGuiAction.MouseMove || !IsMouseDown(moveHandle) || isDragging || Vector2.DistanceSquared(InputSystem.Instance.mousePosition, InputSystem.Instance.mouseDownPosition) < 1f) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Yafc.UI/ImGui/ImGuiLayout.cs
+++ b/Yafc.UI/ImGui/ImGuiLayout.cs
@@ -1,256 +1,255 @@
 ﻿using System;
 using System.Numerics;
 
-namespace Yafc.UI {
-    public partial class ImGui {
-        private CopyableState state;
-        public Rect lastRect { get; set; }
-        public Rect lastContentRect { get; set; }
-        public float width => state.right - state.left;
-        public Rect statePosition => new Rect(state.left, state.top, width, 0f);
-        public ref RectAllocator allocator => ref state.allocator;
-        public ref float spacing => ref state.spacing;
-        public Rect layoutRect => new Rect(state.left, state.top, state.right - state.left, state.bottom - state.top);
+namespace Yafc.UI;
+public partial class ImGui {
+    private CopyableState state;
+    public Rect lastRect { get; set; }
+    public Rect lastContentRect { get; set; }
+    public float width => state.right - state.left;
+    public Rect statePosition => new Rect(state.left, state.top, width, 0f);
+    public ref RectAllocator allocator => ref state.allocator;
+    public ref float spacing => ref state.spacing;
+    public Rect layoutRect => new Rect(state.left, state.top, state.right - state.left, state.bottom - state.top);
 
-        private void ResetLayout() {
-            state = default;
-            lastRect = default;
-            state.right = buildWidth;
-            state.spacing = 0.5f;
+    private void ResetLayout() {
+        state = default;
+        lastRect = default;
+        state.right = buildWidth;
+        state.spacing = 0.5f;
+    }
+
+    public void AllocateSpacing(float spacing) => _ = AllocateRect(0f, 0f, spacing);
+
+    public void AllocateSpacing() => AllocateSpacing(state.spacing);
+
+    public Rect AllocateRect(float width, float height, float spacing = float.NegativeInfinity) {
+        var rect = state.AllocateRect(width, height, spacing);
+        lastRect = state.EncapsulateRect(rect);
+        return lastRect;
+    }
+
+    public Rect EncapsulateRect(Rect rect) {
+        lastRect = state.EncapsulateRect(rect);
+        return lastRect;
+    }
+
+    public Rect AllocateRect(float width, float height, RectAlignment alignment, float spacing = float.NegativeInfinity) {
+        var bigRect = AllocateRect(width, height, spacing);
+        if (alignment == RectAlignment.Full || allocator == RectAllocator.Center || allocator == RectAllocator.LeftAlign || allocator == RectAllocator.RightAlign) {
+            return bigRect;
         }
 
-        public void AllocateSpacing(float spacing) => _ = AllocateRect(0f, 0f, spacing);
+        return AlignRect(bigRect, alignment, width, height);
+    }
 
-        public void AllocateSpacing() => AllocateSpacing(state.spacing);
+    public static Rect AlignRect(Rect boundary, RectAlignment alignment, float width, float height) => alignment switch {
+        RectAlignment.Middle => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
+        RectAlignment.MiddleLeft => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
+        RectAlignment.MiddleRight => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
+        RectAlignment.UpperCenter => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y, width, height),
+        RectAlignment.MiddleFullRow => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), boundary.Width, height),
+        _ => boundary,
+    };
 
-        public Rect AllocateRect(float width, float height, float spacing = float.NegativeInfinity) {
-            var rect = state.AllocateRect(width, height, spacing);
-            lastRect = state.EncapsulateRect(rect);
-            return lastRect;
+    public ImGui RemainingRow(float spacing = float.NegativeInfinity) {
+        state.AllocateSpacing(spacing);
+        allocator = RectAllocator.RemainingRow;
+        return this;
+    }
+
+    public Context EnterGroup(Padding padding, RectAllocator allocator, SchemeColor textColor = SchemeColor.None, float spacing = float.NegativeInfinity) {
+        state.AllocateSpacing();
+        Context ctx = new Context(this, padding);
+        state.allocator = allocator;
+        if (!float.IsNegativeInfinity(spacing)) {
+            state.spacing = spacing;
+        }
+
+        if (textColor != SchemeColor.None) {
+            state.textColor = textColor;
+        }
+
+        return ctx;
+    }
+
+    public Context EnterGroup(Padding padding, SchemeColor textColor = SchemeColor.None) => EnterGroup(padding, allocator, textColor);
+
+    public Context EnterRow(float spacing = 0.5f, RectAllocator allocator = RectAllocator.LeftRow, SchemeColor textColor = SchemeColor.None) => EnterGroup(default, allocator, textColor, spacing);
+
+    public Context EnterFixedPositioning(float width, float height, Padding padding, SchemeColor textColor = SchemeColor.None) {
+        Context context = new Context(this, padding);
+        var rect = AllocateRect(width, height);
+        state.left = rect.X;
+        state.right = rect.Right;
+        state.bottom = state.top = rect.Top;
+        state.allocator = RectAllocator.Stretch;
+        if (textColor != SchemeColor.None) {
+            state.textColor = textColor;
+        }
+
+        return context;
+    }
+
+    private struct CopyableState {
+        public RectAllocator allocator;
+        public float left, right, top, bottom;
+        public Rect contextRect;
+        public float spacing;
+        public bool hasContent;
+        public SchemeColor textColor;
+
+        public Rect AllocateRect(float width, float height, float spacing) {
+            AllocateSpacing(spacing);
+            if (allocator != RectAllocator.LeftRow) {
+                width = Math.Min(width, right - left);
+            }
+
+            float rowHeight = MathF.Max(height, bottom - top);
+            return allocator switch {
+                RectAllocator.Stretch => new Rect(left, top, right - left, height),
+                RectAllocator.LeftAlign => new Rect(left, top, width, height),
+                RectAllocator.RightAlign => new Rect(right - width, top, width, height),
+                RectAllocator.Center => new Rect((right + left - width) * 0.5f, top, width, height),
+                RectAllocator.LeftRow => new Rect(left, top, width, rowHeight),
+                RectAllocator.RightRow => new Rect(right - width, top, width, rowHeight),
+                RectAllocator.RemainingRow => new Rect(left, top, right - left, rowHeight),
+                RectAllocator.FixedRect => new Rect(left, top, right - left, rowHeight),
+                RectAllocator.HalfRow => new Rect(left, top, (right - left - spacing) / 2f, rowHeight),
+                _ => throw new ArgumentOutOfRangeException("Rectangle allocator is out of range with value " + allocator),
+            };
+        }
+
+        public void AllocateSpacing(float amount = float.NegativeInfinity) {
+            if (!hasContent) {
+                return;
+            }
+
+            if (float.IsNegativeInfinity(amount)) {
+                amount = spacing;
+            }
+
+            switch (allocator) {
+                case RectAllocator.Stretch:
+                case RectAllocator.LeftAlign:
+                case RectAllocator.RightAlign:
+                case RectAllocator.Center:
+                    top += amount;
+                    bottom = top;
+                    break;
+                case RectAllocator.LeftRow:
+                    left += amount;
+                    break;
+                case RectAllocator.RightRow:
+                    right -= amount;
+                    break;
+            }
         }
 
         public Rect EncapsulateRect(Rect rect) {
-            lastRect = state.EncapsulateRect(rect);
-            return lastRect;
+            contextRect = hasContent ? Rect.Union(contextRect, rect) : rect;
+            hasContent = true;
+            switch (allocator) {
+                case RectAllocator.Stretch:
+                    top = bottom = MathF.Max(rect.Bottom, top);
+                    rect.X = left;
+                    rect.Width = right - left;
+                    break;
+                case RectAllocator.RightAlign:
+                    top = bottom = MathF.Max(rect.Bottom, top);
+                    rect.Right = right;
+                    break;
+                case RectAllocator.LeftAlign:
+                    top = bottom = MathF.Max(rect.Bottom, top);
+                    rect.Left = left;
+                    break;
+                case RectAllocator.Center:
+                    top = bottom = MathF.Max(rect.Bottom, top);
+                    break;
+                case RectAllocator.LeftRow:
+                    left = rect.Right;
+                    bottom = MathF.Max(rect.Bottom, bottom);
+                    break;
+                case RectAllocator.RightRow:
+                    right = rect.Left;
+                    bottom = MathF.Max(rect.Bottom, bottom);
+                    break;
+                case RectAllocator.HalfRow:
+                    allocator = RectAllocator.RemainingRow;
+                    left = rect.Right + spacing;
+                    bottom = MathF.Max(rect.Bottom, bottom);
+                    break;
+            }
+
+            return rect;
+        }
+    }
+
+    public readonly struct Context : IDisposable {
+        private readonly ImGui gui;
+        private readonly CopyableState state;
+        private readonly Padding padding;
+
+        public Context(ImGui gui, Padding padding) {
+            this.gui = gui;
+            this.padding = padding;
+            ref var cstate = ref gui.state;
+            state = cstate;
+            cstate.contextRect = default;
+            cstate.hasContent = false;
+            cstate.left += padding.left;
+            cstate.right -= padding.right;
+            cstate.top += padding.top;
+            cstate.bottom -= padding.bottom;
         }
 
-        public Rect AllocateRect(float width, float height, RectAlignment alignment, float spacing = float.NegativeInfinity) {
-            var bigRect = AllocateRect(width, height, spacing);
-            if (alignment == RectAlignment.Full || allocator == RectAllocator.Center || allocator == RectAllocator.LeftAlign || allocator == RectAllocator.RightAlign) {
-                return bigRect;
+        public void Dispose() {
+            if (gui == null) {
+                return;
             }
 
-            return AlignRect(bigRect, alignment, width, height);
-        }
-
-        public static Rect AlignRect(Rect boundary, RectAlignment alignment, float width, float height) => alignment switch {
-            RectAlignment.Middle => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
-            RectAlignment.MiddleLeft => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
-            RectAlignment.MiddleRight => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
-            RectAlignment.UpperCenter => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y, width, height),
-            RectAlignment.MiddleFullRow => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), boundary.Width, height),
-            _ => boundary,
-        };
-
-        public ImGui RemainingRow(float spacing = float.NegativeInfinity) {
-            state.AllocateSpacing(spacing);
-            allocator = RectAllocator.RemainingRow;
-            return this;
-        }
-
-        public Context EnterGroup(Padding padding, RectAllocator allocator, SchemeColor textColor = SchemeColor.None, float spacing = float.NegativeInfinity) {
-            state.AllocateSpacing();
-            Context ctx = new Context(this, padding);
-            state.allocator = allocator;
-            if (!float.IsNegativeInfinity(spacing)) {
-                state.spacing = spacing;
+            var rect = gui.state.contextRect;
+            bool hasContent = gui.state.hasContent;
+            gui.state = state;
+            rect.X -= padding.left;
+            rect.Y -= padding.top;
+            rect.Width += padding.left + padding.right;
+            rect.Height += padding.top + padding.bottom;
+            if (hasContent) {
+                gui.lastRect = gui.state.EncapsulateRect(rect);
+                gui.lastContentRect = rect;
             }
-
-            if (textColor != SchemeColor.None) {
-                state.textColor = textColor;
-            }
-
-            return ctx;
-        }
-
-        public Context EnterGroup(Padding padding, SchemeColor textColor = SchemeColor.None) => EnterGroup(padding, allocator, textColor);
-
-        public Context EnterRow(float spacing = 0.5f, RectAllocator allocator = RectAllocator.LeftRow, SchemeColor textColor = SchemeColor.None) => EnterGroup(default, allocator, textColor, spacing);
-
-        public Context EnterFixedPositioning(float width, float height, Padding padding, SchemeColor textColor = SchemeColor.None) {
-            Context context = new Context(this, padding);
-            var rect = AllocateRect(width, height);
-            state.left = rect.X;
-            state.right = rect.Right;
-            state.bottom = state.top = rect.Top;
-            state.allocator = RectAllocator.Stretch;
-            if (textColor != SchemeColor.None) {
-                state.textColor = textColor;
-            }
-
-            return context;
-        }
-
-        private struct CopyableState {
-            public RectAllocator allocator;
-            public float left, right, top, bottom;
-            public Rect contextRect;
-            public float spacing;
-            public bool hasContent;
-            public SchemeColor textColor;
-
-            public Rect AllocateRect(float width, float height, float spacing) {
-                AllocateSpacing(spacing);
-                if (allocator != RectAllocator.LeftRow) {
-                    width = Math.Min(width, right - left);
-                }
-
-                float rowHeight = MathF.Max(height, bottom - top);
-                return allocator switch {
-                    RectAllocator.Stretch => new Rect(left, top, right - left, height),
-                    RectAllocator.LeftAlign => new Rect(left, top, width, height),
-                    RectAllocator.RightAlign => new Rect(right - width, top, width, height),
-                    RectAllocator.Center => new Rect((right + left - width) * 0.5f, top, width, height),
-                    RectAllocator.LeftRow => new Rect(left, top, width, rowHeight),
-                    RectAllocator.RightRow => new Rect(right - width, top, width, rowHeight),
-                    RectAllocator.RemainingRow => new Rect(left, top, right - left, rowHeight),
-                    RectAllocator.FixedRect => new Rect(left, top, right - left, rowHeight),
-                    RectAllocator.HalfRow => new Rect(left, top, (right - left - spacing) / 2f, rowHeight),
-                    _ => throw new ArgumentOutOfRangeException("Rectangle allocator is out of range with value " + allocator),
-                };
-            }
-
-            public void AllocateSpacing(float amount = float.NegativeInfinity) {
-                if (!hasContent) {
-                    return;
-                }
-
-                if (float.IsNegativeInfinity(amount)) {
-                    amount = spacing;
-                }
-
-                switch (allocator) {
-                    case RectAllocator.Stretch:
-                    case RectAllocator.LeftAlign:
-                    case RectAllocator.RightAlign:
-                    case RectAllocator.Center:
-                        top += amount;
-                        bottom = top;
-                        break;
-                    case RectAllocator.LeftRow:
-                        left += amount;
-                        break;
-                    case RectAllocator.RightRow:
-                        right -= amount;
-                        break;
-                }
-            }
-
-            public Rect EncapsulateRect(Rect rect) {
-                contextRect = hasContent ? Rect.Union(contextRect, rect) : rect;
-                hasContent = true;
-                switch (allocator) {
-                    case RectAllocator.Stretch:
-                        top = bottom = MathF.Max(rect.Bottom, top);
-                        rect.X = left;
-                        rect.Width = right - left;
-                        break;
-                    case RectAllocator.RightAlign:
-                        top = bottom = MathF.Max(rect.Bottom, top);
-                        rect.Right = right;
-                        break;
-                    case RectAllocator.LeftAlign:
-                        top = bottom = MathF.Max(rect.Bottom, top);
-                        rect.Left = left;
-                        break;
-                    case RectAllocator.Center:
-                        top = bottom = MathF.Max(rect.Bottom, top);
-                        break;
-                    case RectAllocator.LeftRow:
-                        left = rect.Right;
-                        bottom = MathF.Max(rect.Bottom, bottom);
-                        break;
-                    case RectAllocator.RightRow:
-                        right = rect.Left;
-                        bottom = MathF.Max(rect.Bottom, bottom);
-                        break;
-                    case RectAllocator.HalfRow:
-                        allocator = RectAllocator.RemainingRow;
-                        left = rect.Right + spacing;
-                        bottom = MathF.Max(rect.Bottom, bottom);
-                        break;
-                }
-
-                return rect;
+            else {
+                gui.lastRect = default;
             }
         }
 
-        public readonly struct Context : IDisposable {
-            private readonly ImGui gui;
-            private readonly CopyableState state;
-            private readonly Padding padding;
-
-            public Context(ImGui gui, Padding padding) {
-                this.gui = gui;
-                this.padding = padding;
-                ref var cstate = ref gui.state;
-                state = cstate;
-                cstate.contextRect = default;
-                cstate.hasContent = false;
-                cstate.left += padding.left;
-                cstate.right -= padding.right;
-                cstate.top += padding.top;
-                cstate.bottom -= padding.bottom;
-            }
-
-            public void Dispose() {
-                if (gui == null) {
-                    return;
-                }
-
-                var rect = gui.state.contextRect;
-                bool hasContent = gui.state.hasContent;
-                gui.state = state;
-                rect.X -= padding.left;
-                rect.Y -= padding.top;
-                rect.Width += padding.left + padding.right;
-                rect.Height += padding.top + padding.bottom;
-                if (hasContent) {
-                    gui.lastRect = gui.state.EncapsulateRect(rect);
-                    gui.lastContentRect = rect;
-                }
-                else {
-                    gui.lastRect = default;
-                }
-            }
-
-            public void SetManualRect(Rect rect, RectAllocator allocator = RectAllocator.FixedRect) {
-                rect += new Vector2(state.left, state.top);
-                gui.spacing = 0f;
-                SetManualRectRaw(rect, allocator);
-            }
-
-            public void SetWidth(float width) => gui.state.right = gui.state.left + width;
-
-            public void SetManualRectRaw(Rect rect, RectAllocator allocator = RectAllocator.FixedRect) {
-                ref var cstate = ref gui.state;
-                cstate.left = rect.X + padding.left;
-                cstate.right = cstate.left + rect.Width;
-                cstate.top = rect.Y + padding.top;
-                cstate.bottom = cstate.top + rect.Height;
-                cstate.allocator = allocator;
-            }
+        public void SetManualRect(Rect rect, RectAllocator allocator = RectAllocator.FixedRect) {
+            rect += new Vector2(state.left, state.top);
+            gui.spacing = 0f;
+            SetManualRectRaw(rect, allocator);
         }
 
-        public void SetMinWidth(float width) {
-            if (width > buildingWidth) {
-                buildingWidth = width;
-            }
-        }
+        public void SetWidth(float width) => gui.state.right = gui.state.left + width;
 
-        public void SetContextRect(Rect rect) {
-            state.hasContent = true;
-            state.contextRect = rect;
+        public void SetManualRectRaw(Rect rect, RectAllocator allocator = RectAllocator.FixedRect) {
+            ref var cstate = ref gui.state;
+            cstate.left = rect.X + padding.left;
+            cstate.right = cstate.left + rect.Width;
+            cstate.top = rect.Y + padding.top;
+            cstate.bottom = cstate.top + rect.Height;
+            cstate.allocator = allocator;
         }
+    }
+
+    public void SetMinWidth(float width) {
+        if (width > buildingWidth) {
+            buildingWidth = width;
+        }
+    }
+
+    public void SetContextRect(Rect rect) {
+        state.hasContent = true;
+        state.contextRect = rect;
     }
 }

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -3,375 +3,374 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using SDL2;
 
-namespace Yafc.UI {
-    internal class ImGuiTextInputHelper : IKeyboardFocus {
-        private readonly ImGui gui;
+namespace Yafc.UI;
+internal class ImGuiTextInputHelper : IKeyboardFocus {
+    private readonly ImGui gui;
 
-        public ImGuiTextInputHelper(ImGui gui) => this.gui = gui;
+    public ImGuiTextInputHelper(ImGui gui) => this.gui = gui;
 
-        private string prevText = "";
-        private Rect prevRect;
-        private string text = "";
-        private Rect rect;
-        private readonly Stack<string> editHistory = new Stack<string>();
-        private EditHistoryEvent lastEvent;
+    private string prevText = "";
+    private Rect prevRect;
+    private string text = "";
+    private Rect rect;
+    private readonly Stack<string> editHistory = new Stack<string>();
+    private EditHistoryEvent lastEvent;
 
-        private int caret, selectionAnchor;
-        private bool caretVisible = true;
-        private long nextCaretTimer;
+    private int caret, selectionAnchor;
+    private bool caretVisible = true;
+    private long nextCaretTimer;
 
-        public void SetFocus(Rect boundingRect, string setText) {
-            setText ??= "";
-            if (boundingRect == prevRect) {
-                text = prevText;
-                prevRect = default;
+    public void SetFocus(Rect boundingRect, string setText) {
+        setText ??= "";
+        if (boundingRect == prevRect) {
+            text = prevText;
+            prevRect = default;
+        }
+        else {
+            editHistory.Clear();
+            text = setText;
+        }
+        InputSystem.Instance.SetKeyboardFocus(this);
+        rect = boundingRect;
+        caret = selectionAnchor = setText.Length;
+    }
+
+    private void GetTextParameters(string? textToBuild, Rect textRect, FontFile.FontSize fontSize, RectAlignment alignment, out TextCache? cachedText, out float scale, out float textWidth, out Rect realTextRect) {
+        realTextRect = textRect;
+        scale = 1f;
+        textWidth = 0f;
+        if (!string.IsNullOrEmpty(textToBuild)) {
+            cachedText = gui.textCache.GetCached((fontSize, textToBuild, uint.MaxValue));
+            textWidth = gui.PixelsToUnits(cachedText.texRect.w);
+            if (textWidth > realTextRect.Width) {
+                scale = realTextRect.Width / textWidth;
             }
             else {
-                editHistory.Clear();
-                text = setText;
+                realTextRect = ImGui.AlignRect(textRect, alignment, textWidth, textRect.Height);
             }
-            InputSystem.Instance.SetKeyboardFocus(this);
-            rect = boundingRect;
-            caret = selectionAnchor = setText.Length;
+        }
+        else {
+            realTextRect = ImGui.AlignRect(textRect, alignment, 0f, textRect.Height);
+            cachedText = null;
+        }
+    }
+
+    public bool BuildTextInput(string? text, out string newText, string? placeholder, FontFile.FontSize fontSize, bool delayed, TextBoxDisplayStyle displayStyle) {
+        newText = text ?? "";
+        Rect textRect, realTextRect;
+        using (gui.EnterGroup(displayStyle.Padding, RectAllocator.LeftRow)) {
+            float lineSize = gui.PixelsToUnits(fontSize.lineSize);
+            if (displayStyle.Icon != Icon.None) {
+                gui.BuildIcon(displayStyle.Icon, lineSize, (SchemeColor)displayStyle.ColorGroup + 3);
+            }
+
+            textRect = gui.RemainingRow(0.3f).AllocateRect(0, lineSize, RectAlignment.MiddleFullRow);
+        }
+        var boundingRect = gui.lastRect;
+        bool focused = rect == boundingRect;
+        if (focused && this.text == null) {
+            this.text = text ?? "";
+            SetCaret(0, this.text.Length);
         }
 
-        private void GetTextParameters(string? textToBuild, Rect textRect, FontFile.FontSize fontSize, RectAlignment alignment, out TextCache? cachedText, out float scale, out float textWidth, out Rect realTextRect) {
-            realTextRect = textRect;
-            scale = 1f;
-            textWidth = 0f;
-            if (!string.IsNullOrEmpty(textToBuild)) {
-                cachedText = gui.textCache.GetCached((fontSize, textToBuild, uint.MaxValue));
-                textWidth = gui.PixelsToUnits(cachedText.texRect.w);
-                if (textWidth > realTextRect.Width) {
-                    scale = realTextRect.Width / textWidth;
+        switch (gui.action) {
+            case ImGuiAction.MouseDown:
+                if (gui.actionParameter != SDL.SDL_BUTTON_LEFT) {
+                    break;
+                }
+
+                if (gui.ConsumeMouseDown(boundingRect)) {
+                    SetFocus(boundingRect, text ?? "");
+                    GetTextParameters(this.text, textRect, fontSize, displayStyle.Alignment, out _, out _, out _, out realTextRect);
+                    SetCaret(FindCaretIndex(text, gui.mousePosition.X - realTextRect.X, fontSize, textRect.Width));
+                }
+                break;
+            case ImGuiAction.MouseMove:
+                if (focused && gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
+                    GetTextParameters(this.text, textRect, fontSize, displayStyle.Alignment, out _, out _, out _, out realTextRect);
+                    SetCaret(caret, FindCaretIndex(this.text, gui.mousePosition.X - realTextRect.X, fontSize, textRect.Width));
+                }
+                _ = gui.ConsumeMouseOver(boundingRect, RenderingUtils.cursorCaret, false);
+                break;
+            case ImGuiAction.Build:
+                SchemeColor textColor = (SchemeColor)displayStyle.ColorGroup + 2;
+                string? textToBuild;
+                if (focused && !string.IsNullOrEmpty(text)) {
+                    textToBuild = this.text;
+                }
+                else if (string.IsNullOrEmpty(text)) {
+                    textToBuild = placeholder;
+                    textColor = (SchemeColor)displayStyle.ColorGroup + 3;
                 }
                 else {
-                    realTextRect = ImGui.AlignRect(textRect, alignment, textWidth, textRect.Height);
-                }
-            }
-            else {
-                realTextRect = ImGui.AlignRect(textRect, alignment, 0f, textRect.Height);
-                cachedText = null;
-            }
-        }
-
-        public bool BuildTextInput(string? text, out string newText, string? placeholder, FontFile.FontSize fontSize, bool delayed, TextBoxDisplayStyle displayStyle) {
-            newText = text ?? "";
-            Rect textRect, realTextRect;
-            using (gui.EnterGroup(displayStyle.Padding, RectAllocator.LeftRow)) {
-                float lineSize = gui.PixelsToUnits(fontSize.lineSize);
-                if (displayStyle.Icon != Icon.None) {
-                    gui.BuildIcon(displayStyle.Icon, lineSize, (SchemeColor)displayStyle.ColorGroup + 3);
+                    textToBuild = text;
                 }
 
-                textRect = gui.RemainingRow(0.3f).AllocateRect(0, lineSize, RectAlignment.MiddleFullRow);
-            }
-            var boundingRect = gui.lastRect;
-            bool focused = rect == boundingRect;
-            if (focused && this.text == null) {
-                this.text = text ?? "";
-                SetCaret(0, this.text.Length);
-            }
+                GetTextParameters(textToBuild, textRect, fontSize, displayStyle.Alignment, out TextCache? cachedText, out float scale, out float textWidth, out realTextRect);
+                if (cachedText != null) {
+                    gui.DrawRenderable(realTextRect, cachedText, textColor);
+                }
 
-            switch (gui.action) {
-                case ImGuiAction.MouseDown:
-                    if (gui.actionParameter != SDL.SDL_BUTTON_LEFT) {
-                        break;
-                    }
-
-                    if (gui.ConsumeMouseDown(boundingRect)) {
-                        SetFocus(boundingRect, text ?? "");
-                        GetTextParameters(this.text, textRect, fontSize, displayStyle.Alignment, out _, out _, out _, out realTextRect);
-                        SetCaret(FindCaretIndex(text, gui.mousePosition.X - realTextRect.X, fontSize, textRect.Width));
-                    }
-                    break;
-                case ImGuiAction.MouseMove:
-                    if (focused && gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
-                        GetTextParameters(this.text, textRect, fontSize, displayStyle.Alignment, out _, out _, out _, out realTextRect);
-                        SetCaret(caret, FindCaretIndex(this.text, gui.mousePosition.X - realTextRect.X, fontSize, textRect.Width));
-                    }
-                    _ = gui.ConsumeMouseOver(boundingRect, RenderingUtils.cursorCaret, false);
-                    break;
-                case ImGuiAction.Build:
-                    SchemeColor textColor = (SchemeColor)displayStyle.ColorGroup + 2;
-                    string? textToBuild;
-                    if (focused && !string.IsNullOrEmpty(text)) {
-                        textToBuild = this.text;
-                    }
-                    else if (string.IsNullOrEmpty(text)) {
-                        textToBuild = placeholder;
-                        textColor = (SchemeColor)displayStyle.ColorGroup + 3;
+                if (focused) {
+                    if (selectionAnchor != caret) {
+                        float left = GetCharacterPosition(Math.Min(selectionAnchor, caret), fontSize, textWidth) * scale;
+                        float right = GetCharacterPosition(Math.Max(selectionAnchor, caret), fontSize, textWidth) * scale;
+                        gui.DrawRectangle(new Rect(left + realTextRect.X, realTextRect.Y, right - left, realTextRect.Height), SchemeColor.TextSelection);
                     }
                     else {
-                        textToBuild = text;
-                    }
-
-                    GetTextParameters(textToBuild, textRect, fontSize, displayStyle.Alignment, out TextCache? cachedText, out float scale, out float textWidth, out realTextRect);
-                    if (cachedText != null) {
-                        gui.DrawRenderable(realTextRect, cachedText, textColor);
-                    }
-
-                    if (focused) {
-                        if (selectionAnchor != caret) {
-                            float left = GetCharacterPosition(Math.Min(selectionAnchor, caret), fontSize, textWidth) * scale;
-                            float right = GetCharacterPosition(Math.Max(selectionAnchor, caret), fontSize, textWidth) * scale;
-                            gui.DrawRectangle(new Rect(left + realTextRect.X, realTextRect.Y, right - left, realTextRect.Height), SchemeColor.TextSelection);
+                        if (nextCaretTimer <= Ui.time) {
+                            nextCaretTimer = Ui.time + 500;
+                            caretVisible = !caretVisible;
                         }
-                        else {
-                            if (nextCaretTimer <= Ui.time) {
-                                nextCaretTimer = Ui.time + 500;
-                                caretVisible = !caretVisible;
-                            }
-                            gui.SetNextRebuild(nextCaretTimer);
-                            if (caretVisible) {
-                                float caretPosition = GetCharacterPosition(caret, fontSize, textWidth) * scale;
-                                gui.DrawRectangle(new Rect(caretPosition + realTextRect.X - 0.05f, realTextRect.Y, 0.1f, realTextRect.Height), (SchemeColor)displayStyle.ColorGroup + 2);
-                            }
+                        gui.SetNextRebuild(nextCaretTimer);
+                        if (caretVisible) {
+                            float caretPosition = GetCharacterPosition(caret, fontSize, textWidth) * scale;
+                            gui.DrawRectangle(new Rect(caretPosition + realTextRect.X - 0.05f, realTextRect.Y, 0.1f, realTextRect.Height), (SchemeColor)displayStyle.ColorGroup + 2);
                         }
                     }
-                    gui.DrawRectangle(boundingRect, (SchemeColor)displayStyle.ColorGroup);
-                    break;
-            }
-
-            if (boundingRect == prevRect) {
-                bool changed = text != prevText;
-                if (changed) {
-                    newText = prevText;
                 }
-
-                prevRect = default;
-                prevText = "";
-                return changed;
-            }
-
-            if (focused && !delayed && this.text != text) {
-                newText = this.text;
-                return true;
-            }
-
-            return false;
+                gui.DrawRectangle(boundingRect, (SchemeColor)displayStyle.ColorGroup);
+                break;
         }
 
-        private float GetCharacterPosition(int id, FontFile.FontSize fontSize, float max) {
-            if (id == 0) {
-                return 0;
+        if (boundingRect == prevRect) {
+            bool changed = text != prevText;
+            if (changed) {
+                newText = prevText;
             }
 
-            if (id == text.Length) {
-                return max;
-            }
-
-            _ = SDL_ttf.TTF_SizeUNICODE(fontSize.handle, text[..id], out int w, out _);
-            return gui.PixelsToUnits(w);
+            prevRect = default;
+            prevText = "";
+            return changed;
         }
 
-        private void DeleteSelected() {
-            AddEditHistory(EditHistoryEvent.Delete);
-            int pos = Math.Min(selectionAnchor, caret);
-            text = text.Remove(pos, Math.Abs(selectionAnchor - caret));
-            selectionAnchor = caret = pos;
+        if (focused && !delayed && this.text != text) {
+            newText = this.text;
+            return true;
+        }
+
+        return false;
+    }
+
+    private float GetCharacterPosition(int id, FontFile.FontSize fontSize, float max) {
+        if (id == 0) {
+            return 0;
+        }
+
+        if (id == text.Length) {
+            return max;
+        }
+
+        _ = SDL_ttf.TTF_SizeUNICODE(fontSize.handle, text[..id], out int w, out _);
+        return gui.PixelsToUnits(w);
+    }
+
+    private void DeleteSelected() {
+        AddEditHistory(EditHistoryEvent.Delete);
+        int pos = Math.Min(selectionAnchor, caret);
+        text = text.Remove(pos, Math.Abs(selectionAnchor - caret));
+        selectionAnchor = caret = pos;
+        gui.Rebuild();
+    }
+
+    private void SetCaret(int position, int selection = -1) {
+        position = MathUtils.Clamp(position, 0, text.Length);
+        selection = selection < 0 ? position : Math.Min(selection, text.Length);
+        if (caret != position || selectionAnchor != selection) {
+            caret = position;
+            selectionAnchor = selection;
+            ResetCaret();
             gui.Rebuild();
         }
+    }
 
-        private void SetCaret(int position, int selection = -1) {
-            position = MathUtils.Clamp(position, 0, text.Length);
-            selection = selection < 0 ? position : Math.Min(selection, text.Length);
-            if (caret != position || selectionAnchor != selection) {
-                caret = position;
-                selectionAnchor = selection;
-                ResetCaret();
-                gui.Rebuild();
-            }
+    private void ResetCaret() {
+        caretVisible = true;
+        nextCaretTimer = Ui.time + 500;
+    }
+
+    private enum EditHistoryEvent {
+        None, Delete, Input
+    }
+
+    public string selectedText => text.Substring(Math.Min(selectionAnchor, caret), Math.Abs(selectionAnchor - caret));
+
+    private void AddEditHistory(EditHistoryEvent evt) {
+        if (evt == lastEvent) {
+            return;
         }
 
-        private void ResetCaret() {
-            caretVisible = true;
-            nextCaretTimer = Ui.time + 500;
+        if (editHistory.Count == 0 || editHistory.Peek() != text) {
+            lastEvent = evt;
+            editHistory.Push(text);
         }
+    }
 
-        private enum EditHistoryEvent {
-            None, Delete, Input
-        }
-
-        public string selectedText => text.Substring(Math.Min(selectionAnchor, caret), Math.Abs(selectionAnchor - caret));
-
-        private void AddEditHistory(EditHistoryEvent evt) {
-            if (evt == lastEvent) {
-                return;
-            }
-
-            if (editHistory.Count == 0 || editHistory.Peek() != text) {
-                lastEvent = evt;
-                editHistory.Push(text);
-            }
-        }
-
-        public bool KeyDown(SDL.SDL_Keysym key) {
-            bool ctrl = (key.mod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
-            bool shift = (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
-            switch (key.scancode) {
-                case SDL.SDL_Scancode.SDL_SCANCODE_BACKSPACE:
-                    if (selectionAnchor != caret) {
-                        DeleteSelected();
-                    }
-                    else if (caret > 0) {
-                        int removeFrom = caret;
-                        if (ctrl) {
-                            bool stopOnNextNonLetter = false;
-                            while (removeFrom > 0) {
-                                removeFrom--;
-                                if (char.IsLetterOrDigit(text[removeFrom])) {
-                                    stopOnNextNonLetter = true;
-                                }
-                                else if (stopOnNextNonLetter) {
-                                    removeFrom++;
-                                    break;
-                                }
+    public bool KeyDown(SDL.SDL_Keysym key) {
+        bool ctrl = (key.mod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
+        bool shift = (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
+        switch (key.scancode) {
+            case SDL.SDL_Scancode.SDL_SCANCODE_BACKSPACE:
+                if (selectionAnchor != caret) {
+                    DeleteSelected();
+                }
+                else if (caret > 0) {
+                    int removeFrom = caret;
+                    if (ctrl) {
+                        bool stopOnNextNonLetter = false;
+                        while (removeFrom > 0) {
+                            removeFrom--;
+                            if (char.IsLetterOrDigit(text[removeFrom])) {
+                                stopOnNextNonLetter = true;
+                            }
+                            else if (stopOnNextNonLetter) {
+                                removeFrom++;
+                                break;
                             }
                         }
-                        else {
-                            removeFrom--;
-                        }
-
-                        AddEditHistory(EditHistoryEvent.Delete);
-                        text = text.Remove(removeFrom, caret - removeFrom);
-                        SetCaret(removeFrom);
-                    }
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_DELETE:
-                    if (selectionAnchor != caret) {
-                        DeleteSelected();
-                    }
-                    else if (caret < text.Length) {
-                        AddEditHistory(EditHistoryEvent.Delete);
-                        text = text.Remove(caret, 1);
-                    }
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_RETURN:
-                case SDL.SDL_Scancode.SDL_SCANCODE_RETURN2:
-                case SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER:
-                case SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE:
-                    InputSystem.Instance.SetKeyboardFocus(null);
-                    return false;
-                case SDL.SDL_Scancode.SDL_SCANCODE_LEFT:
-                    if (shift) {
-                        SetCaret(caret - 1, selectionAnchor);
                     }
                     else {
-                        SetCaret(selectionAnchor == caret ? caret - 1 : Math.Min(selectionAnchor, caret));
+                        removeFrom--;
                     }
 
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_RIGHT:
-                    if (shift) {
-                        SetCaret(caret + 1, selectionAnchor);
-                    }
-                    else {
-                        SetCaret(selectionAnchor == caret ? caret + 1 : Math.Max(selectionAnchor, caret));
-                    }
-
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_HOME:
-                    SetCaret(0, shift ? selectionAnchor : 0);
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_END:
-                    SetCaret(int.MaxValue, shift ? selectionAnchor : int.MaxValue);
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_V when ctrl && ImGuiUtils.HasClipboardText():
-                    _ = TextInput(SDL.SDL_GetClipboardText());
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_C when ctrl && selectionAnchor != caret:
-                    _ = SDL.SDL_SetClipboardText(selectedText);
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_X when ctrl && selectionAnchor != caret:
-                    _ = SDL.SDL_SetClipboardText(selectedText);
+                    AddEditHistory(EditHistoryEvent.Delete);
+                    text = text.Remove(removeFrom, caret - removeFrom);
+                    SetCaret(removeFrom);
+                }
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_DELETE:
+                if (selectionAnchor != caret) {
                     DeleteSelected();
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_Z when ctrl && editHistory != null && editHistory.Count > 0:
-                    text = editHistory.Pop();
-                    SetCaret(text.Length);
-                    lastEvent = EditHistoryEvent.None;
-                    break;
-                case SDL.SDL_Scancode.SDL_SCANCODE_A when ctrl:
-                    SetCaret(text.Length, 0);
-                    break;
-            }
+                }
+                else if (caret < text.Length) {
+                    AddEditHistory(EditHistoryEvent.Delete);
+                    text = text.Remove(caret, 1);
+                }
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_RETURN:
+            case SDL.SDL_Scancode.SDL_SCANCODE_RETURN2:
+            case SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER:
+            case SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE:
+                InputSystem.Instance.SetKeyboardFocus(null);
+                return false;
+            case SDL.SDL_Scancode.SDL_SCANCODE_LEFT:
+                if (shift) {
+                    SetCaret(caret - 1, selectionAnchor);
+                }
+                else {
+                    SetCaret(selectionAnchor == caret ? caret - 1 : Math.Min(selectionAnchor, caret));
+                }
 
-            return true;
-        }
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_RIGHT:
+                if (shift) {
+                    SetCaret(caret + 1, selectionAnchor);
+                }
+                else {
+                    SetCaret(selectionAnchor == caret ? caret + 1 : Math.Max(selectionAnchor, caret));
+                }
 
-        public bool TextInput(string input) {
-            if (input.IndexOf(' ') >= 0) {
-                lastEvent = EditHistoryEvent.None;
-            }
-
-            AddEditHistory(EditHistoryEvent.Input);
-            if (selectionAnchor != caret) {
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_HOME:
+                SetCaret(0, shift ? selectionAnchor : 0);
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_END:
+                SetCaret(int.MaxValue, shift ? selectionAnchor : int.MaxValue);
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_V when ctrl && ImGuiUtils.HasClipboardText():
+                _ = TextInput(SDL.SDL_GetClipboardText());
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_C when ctrl && selectionAnchor != caret:
+                _ = SDL.SDL_SetClipboardText(selectedText);
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_X when ctrl && selectionAnchor != caret:
+                _ = SDL.SDL_SetClipboardText(selectedText);
                 DeleteSelected();
-            }
-
-            text = text.Insert(caret, input);
-            SetCaret(caret + input.Length);
-            ResetCaret();
-            return true;
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_Z when ctrl && editHistory != null && editHistory.Count > 0:
+                text = editHistory.Pop();
+                SetCaret(text.Length);
+                lastEvent = EditHistoryEvent.None;
+                break;
+            case SDL.SDL_Scancode.SDL_SCANCODE_A when ctrl:
+                SetCaret(text.Length, 0);
+                break;
         }
 
-        public bool KeyUp(SDL.SDL_Keysym key) => true;
+        return true;
+    }
 
-        public void FocusChanged(bool focused) {
-            if (!focused) {
-                prevRect = rect;
-                prevText = text;
-                rect = default;
-                text = "";
-                gui.Rebuild();
-            }
+    public bool TextInput(string input) {
+        if (input.IndexOf(' ') >= 0) {
+            lastEvent = EditHistoryEvent.None;
         }
 
-        // Fast operations with char* instead of strings
-        [DllImport("SDL2_ttf.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern unsafe int TTF_SizeUNICODE(IntPtr font, char* text, out int w, out int h);
+        AddEditHistory(EditHistoryEvent.Input);
+        if (selectionAnchor != caret) {
+            DeleteSelected();
+        }
 
-        private unsafe int FindCaretIndex(string? text, float position, FontFile.FontSize fontSize, float maxWidth) {
-            if (string.IsNullOrEmpty(text) || position <= 0f) {
-                return 0;
-            }
+        text = text.Insert(caret, input);
+        SetCaret(caret + input.Length);
+        ResetCaret();
+        return true;
+    }
 
-            var cachedText = gui.textCache.GetCached((fontSize, text, uint.MaxValue));
-            float maxW = gui.PixelsToUnits(cachedText.texRect.w);
-            float scale = 1f;
-            if (maxW > maxWidth) {
-                scale = maxWidth / maxW;
-                maxW = maxWidth;
-            }
-            int min = 0, max = text.Length;
-            float minW = 0f;
-            if (position >= maxW) {
-                return max;
-            }
+    public bool KeyUp(SDL.SDL_Keysym key) => true;
 
-            nint handle = fontSize.handle;
-            fixed (char* arr = text) {
-                while (max > min + 1) {
-                    float ratio = (maxW - position) / (maxW - minW);
-                    int mid = MathUtils.Clamp(MathUtils.Round((min * ratio) + (max * (1f - ratio))), min + 1, max - 1);
-                    char prev = arr[mid];
-                    arr[mid] = '\0';
-                    _ = TTF_SizeUNICODE(handle, arr, out int w, out _);
-                    arr[mid] = prev;
-                    float midW = gui.PixelsToUnits(w) * scale;
-                    if (midW > position) {
-                        max = mid;
-                        maxW = midW;
-                    }
-                    else {
-                        min = mid;
-                        minW = midW;
-                    }
+    public void FocusChanged(bool focused) {
+        if (!focused) {
+            prevRect = rect;
+            prevText = text;
+            rect = default;
+            text = "";
+            gui.Rebuild();
+        }
+    }
+
+    // Fast operations with char* instead of strings
+    [DllImport("SDL2_ttf.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern unsafe int TTF_SizeUNICODE(IntPtr font, char* text, out int w, out int h);
+
+    private unsafe int FindCaretIndex(string? text, float position, FontFile.FontSize fontSize, float maxWidth) {
+        if (string.IsNullOrEmpty(text) || position <= 0f) {
+            return 0;
+        }
+
+        var cachedText = gui.textCache.GetCached((fontSize, text, uint.MaxValue));
+        float maxW = gui.PixelsToUnits(cachedText.texRect.w);
+        float scale = 1f;
+        if (maxW > maxWidth) {
+            scale = maxWidth / maxW;
+            maxW = maxWidth;
+        }
+        int min = 0, max = text.Length;
+        float minW = 0f;
+        if (position >= maxW) {
+            return max;
+        }
+
+        nint handle = fontSize.handle;
+        fixed (char* arr = text) {
+            while (max > min + 1) {
+                float ratio = (maxW - position) / (maxW - minW);
+                int mid = MathUtils.Clamp(MathUtils.Round((min * ratio) + (max * (1f - ratio))), min + 1, max - 1);
+                char prev = arr[mid];
+                arr[mid] = '\0';
+                _ = TTF_SizeUNICODE(handle, arr, out int w, out _);
+                arr[mid] = prev;
+                float midW = gui.PixelsToUnits(w) * scale;
+                if (midW > position) {
+                    max = mid;
+                    maxW = midW;
+                }
+                else {
+                    min = mid;
+                    minW = midW;
                 }
             }
-
-            return maxW - position > position - minW ? min : max;
         }
+
+        return maxW - position > position - minW ? min : max;
     }
 }

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -4,450 +4,449 @@ using System.Linq;
 using System.Threading.Tasks;
 using SDL2;
 
-namespace Yafc.UI {
-    // ButtonEvent implicitly converts to true if it is a click event, so for simple buttons that only handle clicks you can just use if() 
-    public readonly struct ButtonEvent {
-        private readonly int value;
-        public static readonly ButtonEvent None = default;
-        public static readonly ButtonEvent Click = new ButtonEvent(1);
-        public static readonly ButtonEvent MouseOver = new ButtonEvent(2);
-        public static readonly ButtonEvent MouseDown = new ButtonEvent(3);
+namespace Yafc.UI;
+// ButtonEvent implicitly converts to true if it is a click event, so for simple buttons that only handle clicks you can just use if()
+public readonly struct ButtonEvent {
+    private readonly int value;
+    public static readonly ButtonEvent None = default;
+    public static readonly ButtonEvent Click = new ButtonEvent(1);
+    public static readonly ButtonEvent MouseOver = new ButtonEvent(2);
+    public static readonly ButtonEvent MouseDown = new ButtonEvent(3);
 
-        private ButtonEvent(int value) => this.value = value;
+    private ButtonEvent(int value) => this.value = value;
 
-        public static bool operator ==(ButtonEvent a, ButtonEvent b) => a.value == b.value;
+    public static bool operator ==(ButtonEvent a, ButtonEvent b) => a.value == b.value;
 
-        public static bool operator !=(ButtonEvent a, ButtonEvent b) => a.value != b.value;
+    public static bool operator !=(ButtonEvent a, ButtonEvent b) => a.value != b.value;
 
-        public bool Equals(ButtonEvent other) => value == other.value;
+    public bool Equals(ButtonEvent other) => value == other.value;
 
-        public override bool Equals(object? obj) => obj is ButtonEvent other && Equals(other);
+    public override bool Equals(object? obj) => obj is ButtonEvent other && Equals(other);
 
-        public override int GetHashCode() => value;
+    public override int GetHashCode() => value;
 
-        public static implicit operator bool(ButtonEvent b) => b == Click;
+    public static implicit operator bool(ButtonEvent b) => b == Click;
+}
+
+public static class ImGuiUtils {
+    public static readonly Padding DefaultButtonPadding = new Padding(1f, 0.5f);
+    public static readonly Padding DefaultButtonPaddingText = new Padding(0f, 0.5f);
+    public static readonly Padding DefaultScreenPadding = new Padding(5f, 2f);
+    public static readonly Padding DefaultIconPadding = new Padding(0.3f);
+
+    /// <summary>Returns true when the clipboard holds content</summary>
+    public static bool HasClipboardText() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE;
+
+    public static ButtonEvent BuildButton(this ImGui gui, Rect rect, SchemeColor normal, SchemeColor over, SchemeColor down = SchemeColor.None, uint button = SDL.SDL_BUTTON_LEFT) {
+        if (button == 0) {
+            button = (uint)InputSystem.Instance.mouseDownButton;
+        }
+
+        switch (gui.action) {
+            case ImGuiAction.MouseMove:
+                bool wasOver = gui.IsMouseOver(rect);
+                return gui.ConsumeMouseOver(rect, RenderingUtils.cursorHand) && !wasOver ? ButtonEvent.MouseOver : ButtonEvent.None;
+            case ImGuiAction.MouseDown:
+                return gui.actionParameter == button && gui.ConsumeMouseDown(rect, button) ? ButtonEvent.MouseDown : ButtonEvent.None;
+            case ImGuiAction.MouseUp:
+                return gui.actionParameter == button && gui.ConsumeMouseUp(rect, true, button) ? ButtonEvent.Click : ButtonEvent.None;
+            case ImGuiAction.Build:
+                var color = gui.IsMouseOver(rect) ? (down != SchemeColor.None && gui.IsMouseDown(rect, button)) ? down : over : normal;
+                gui.DrawRectangle(rect, color);
+                return ButtonEvent.None;
+            default:
+                return ButtonEvent.None;
+        }
     }
 
-    public static class ImGuiUtils {
-        public static readonly Padding DefaultButtonPadding = new Padding(1f, 0.5f);
-        public static readonly Padding DefaultButtonPaddingText = new Padding(0f, 0.5f);
-        public static readonly Padding DefaultScreenPadding = new Padding(5f, 2f);
-        public static readonly Padding DefaultIconPadding = new Padding(0.3f);
+    public static string ScanToString(SDL.SDL_Scancode scancode) => SDL.SDL_GetKeyName(SDL.SDL_GetKeyFromScancode(scancode));
 
-        /// <summary>Returns true when the clipboard holds content</summary>
-        public static bool HasClipboardText() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE;
-
-        public static ButtonEvent BuildButton(this ImGui gui, Rect rect, SchemeColor normal, SchemeColor over, SchemeColor down = SchemeColor.None, uint button = SDL.SDL_BUTTON_LEFT) {
-            if (button == 0) {
-                button = (uint)InputSystem.Instance.mouseDownButton;
-            }
-
-            switch (gui.action) {
-                case ImGuiAction.MouseMove:
-                    bool wasOver = gui.IsMouseOver(rect);
-                    return gui.ConsumeMouseOver(rect, RenderingUtils.cursorHand) && !wasOver ? ButtonEvent.MouseOver : ButtonEvent.None;
-                case ImGuiAction.MouseDown:
-                    return gui.actionParameter == button && gui.ConsumeMouseDown(rect, button) ? ButtonEvent.MouseDown : ButtonEvent.None;
-                case ImGuiAction.MouseUp:
-                    return gui.actionParameter == button && gui.ConsumeMouseUp(rect, true, button) ? ButtonEvent.Click : ButtonEvent.None;
-                case ImGuiAction.Build:
-                    var color = gui.IsMouseOver(rect) ? (down != SchemeColor.None && gui.IsMouseDown(rect, button)) ? down : over : normal;
-                    gui.DrawRectangle(rect, color);
-                    return ButtonEvent.None;
-                default:
-                    return ButtonEvent.None;
-            }
-        }
-
-        public static string ScanToString(SDL.SDL_Scancode scancode) => SDL.SDL_GetKeyName(SDL.SDL_GetKeyFromScancode(scancode));
-
-        public static bool BuildLink(this ImGui gui, string text) {
-            gui.BuildText(text, TextBlockDisplayStyle.Default(SchemeColor.Link));
-            var rect = gui.lastRect;
-            switch (gui.action) {
-                case ImGuiAction.MouseMove:
-                    _ = gui.ConsumeMouseOver(rect, RenderingUtils.cursorHand);
-                    break;
-                case ImGuiAction.MouseDown:
-                    if (gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
-                        _ = gui.ConsumeMouseDown(rect);
-                    }
-
-                    break;
-                case ImGuiAction.MouseUp:
-                    if (gui.ConsumeMouseUp(rect)) {
-                        return true;
-                    }
-
-                    break;
-                case ImGuiAction.Build:
-                    if (gui.IsMouseOver(rect)) {
-                        gui.DrawRectangle(new Rect(rect.X, rect.Bottom - 0.2f, rect.Width, 0.1f), SchemeColor.Link);
-                    }
-
-                    break;
-            }
-
-            return false;
-        }
-
-        public static bool OnClick(this ImGui gui, Rect rect) {
-            if (gui.action == ImGuiAction.MouseUp) {
-                return gui.ConsumeMouseUp(rect);
-            }
-
-            if (gui.action == ImGuiAction.MouseDown && gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
-                _ = gui.ConsumeMouseDown(rect);
-            }
-
-            return false;
-        }
-
-        public static ButtonEvent BuildButton(this ImGui gui, string text, SchemeColor color = SchemeColor.Primary, Padding? padding = null, bool active = true) {
-            if (!active) {
-                color = SchemeColor.Grey;
-            }
-
-            using (gui.EnterGroup(padding ?? DefaultButtonPadding, active ? color + 2 : color + 3)) {
-                gui.BuildText(text, TextBlockDisplayStyle.Centered);
-            }
-
-            return active ? gui.BuildButton(gui.lastRect, color, color + 1) : ButtonEvent.None;
-        }
-
-        public static ButtonEvent BuildContextMenuButton(this ImGui gui, string text, string? rightText = null, Icon icon = default, bool disabled = false) {
-            gui.allocator = RectAllocator.Stretch;
-            using (gui.EnterGroup(DefaultButtonPadding, RectAllocator.LeftRow, SchemeColor.BackgroundText)) {
-                var textColor = disabled ? gui.textColor + 1 : gui.textColor;
-                if (icon != default) {
-                    gui.BuildIcon(icon, color: icon >= Icon.FirstCustom ? disabled ? SchemeColor.SourceFaint : SchemeColor.Source : textColor);
+    public static bool BuildLink(this ImGui gui, string text) {
+        gui.BuildText(text, TextBlockDisplayStyle.Default(SchemeColor.Link));
+        var rect = gui.lastRect;
+        switch (gui.action) {
+            case ImGuiAction.MouseMove:
+                _ = gui.ConsumeMouseOver(rect, RenderingUtils.cursorHand);
+                break;
+            case ImGuiAction.MouseDown:
+                if (gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
+                    _ = gui.ConsumeMouseDown(rect);
                 }
 
-                gui.BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = textColor });
-                if (rightText != null) {
-                    gui.allocator = RectAllocator.RightRow;
-                    gui.BuildText(rightText, new TextBlockDisplayStyle(Alignment: RectAlignment.MiddleRight));
-                }
-            }
-            return gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey);
-        }
-
-        public static void CaptureException(this Task task) => _ = task.ContinueWith(t => throw t.Exception!, TaskContinuationOptions.OnlyOnFaulted); // null-forgiving: OnlyOnFaulted guarantees that Exception is non-null.
-
-        public static bool BuildMouseOverIcon(this ImGui gui, Icon icon, SchemeColor color = SchemeColor.BackgroundText) {
-            if (gui.isBuilding && gui.IsMouseOver(gui.lastRect)) {
-                gui.DrawIcon(gui.lastRect, icon, color);
-            }
-
-            return gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt);
-        }
-
-        public static ButtonEvent BuildRedButton(this ImGui gui, string text) {
-            Rect textRect;
-            TextCache? cache;
-            using (gui.EnterGroup(DefaultButtonPadding)) {
-                textRect = gui.AllocateTextRect(out cache, text, TextBlockDisplayStyle.Centered);
-            }
-
-            var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
-            if (gui.isBuilding) {
-                gui.DrawRenderable(textRect, cache, gui.IsMouseOver(gui.lastRect) ? SchemeColor.ErrorText : SchemeColor.Error);
-            }
-
-            return evt;
-        }
-
-        public static ButtonEvent BuildRedButton(this ImGui gui, Icon icon, float size = 1.5f, bool invertedColors = false) {
-            Rect iconRect;
-            using (gui.EnterGroup(new Padding(0.3f))) {
-                iconRect = gui.AllocateRect(size, size, RectAlignment.Middle);
-            }
-
-            var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
-            if (gui.isBuilding) {
-                SchemeColor color = invertedColors ? SchemeColor.ErrorText : SchemeColor.Error;
-
-                if (gui.IsMouseOver(gui.lastRect)) {
-                    color = invertedColors ? SchemeColor.Error : SchemeColor.ErrorText;
+                break;
+            case ImGuiAction.MouseUp:
+                if (gui.ConsumeMouseUp(rect)) {
+                    return true;
                 }
 
-                gui.DrawIcon(iconRect, icon, color);
-            }
-
-            return evt;
-        }
-
-        public static ButtonEvent BuildButton(this ImGui gui, Icon icon, SchemeColor normal = SchemeColor.None, SchemeColor over = SchemeColor.Grey, SchemeColor down = SchemeColor.None, float size = 1.5f) {
-            using (gui.EnterGroup(new Padding(0.3f))) {
-                gui.BuildIcon(icon, size);
-            }
-
-            return gui.BuildButton(gui.lastRect, normal, over, down);
-        }
-
-        public static ButtonEvent BuildButton(this ImGui gui, Icon icon, string text, SchemeColor normal = SchemeColor.None, SchemeColor over = SchemeColor.Grey, SchemeColor down = SchemeColor.None, float size = 1.5f) {
-            using (gui.EnterGroup(new Padding(0.3f), RectAllocator.LeftRow)) {
-                gui.BuildIcon(icon, size);
-                gui.BuildText(text);
-            }
-            return gui.BuildButton(gui.lastRect, normal, over, down);
-        }
-
-        public static bool WithTooltip(this ButtonEvent evt, ImGui gui, string tooltip, Rect? rect = null) {
-            if (evt == ButtonEvent.MouseOver) {
-                gui.ShowTooltip(rect ?? gui.lastRect, tooltip);
-            }
-
-            return evt;
-        }
-
-        public static bool BuildCheckBox(this ImGui gui, string text, bool value, out bool newValue, SchemeColor color = SchemeColor.None, RectAllocator allocator = RectAllocator.LeftRow) {
-            using (gui.EnterRow(allocator: allocator)) {
-                gui.BuildIcon(value ? Icon.CheckBoxCheck : Icon.CheckBoxEmpty, 1.5f, color);
-                gui.BuildText(text, TextBlockDisplayStyle.Default(color));
-            }
-
-            if (gui.OnClick(gui.lastRect)) {
-                newValue = !value;
-                return true;
-            }
-
-            newValue = value;
-            return false;
-        }
-
-        public static ButtonEvent BuildRadioButton(this ImGui gui, string option, bool selected, SchemeColor textColor = SchemeColor.None, bool enabled = true) {
-            if (textColor == SchemeColor.None) {
-                textColor = enabled ? SchemeColor.PrimaryText : SchemeColor.PrimaryTextFaint;
-            }
-            using (gui.EnterRow()) {
-                gui.BuildIcon(selected ? Icon.RadioCheck : Icon.RadioEmpty, 1.5f, textColor);
-                gui.BuildText(option, TextBlockDisplayStyle.WrappedText with { Color = textColor });
-            }
-            if (!enabled) {
-                return ButtonEvent.None;
-            }
-
-            ButtonEvent click = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.None);
-            if (click == ButtonEvent.Click && selected) { return ButtonEvent.None; }
-            return click;
-        }
-
-        public static bool BuildRadioGroup(this ImGui gui, IReadOnlyList<string> options, int selected, out int newSelected,
-                                           SchemeColor textColor = SchemeColor.None, bool enabled = true)
-            => gui.BuildRadioGroup([.. options.Select(o => (o, (string?)null))], selected, out newSelected, textColor, enabled);
-
-        public static bool BuildRadioGroup(this ImGui gui, IReadOnlyList<(string option, string? tooltip)> options, int selected,
-                                           out int newSelected, SchemeColor textColor = SchemeColor.None, bool enabled = true) {
-            newSelected = selected;
-            for (int i = 0; i < options.Count; i++) {
-                ButtonEvent evt = BuildRadioButton(gui, options[i].option, selected == i, textColor, enabled);
-                if (!string.IsNullOrEmpty(options[i].tooltip)) {
-                    evt.WithTooltip(gui, options[i].tooltip!);
-                }
-                if (evt) {
-                    newSelected = i;
-                }
-            }
-
-            return newSelected != selected;
-        }
-
-        public static bool BuildErrorRow(this ImGui gui, string text) {
-            bool closed = false;
-            using (gui.EnterRow(allocator: RectAllocator.RightRow, textColor: SchemeColor.ErrorText)) {
-                if (gui.BuildButton(Icon.Close, size: 1f, over: SchemeColor.ErrorAlt)) {
-                    closed = true;
+                break;
+            case ImGuiAction.Build:
+                if (gui.IsMouseOver(rect)) {
+                    gui.DrawRectangle(new Rect(rect.X, rect.Bottom - 0.2f, rect.Width, 0.1f), SchemeColor.Link);
                 }
 
-                gui.RemainingRow().BuildText(text, TextBlockDisplayStyle.Centered);
-            }
-            if (gui.isBuilding) {
-                gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
-            }
-
-            return closed;
+                break;
         }
 
-        public static bool BuildIntegerInput(this ImGui gui, int value, out int newValue, bool setInitialFocus = false) {
-            if (gui.BuildTextInput(value.ToString(), out string newText, null, delayed: true, setInitialFocus: setInitialFocus) && int.TryParse(newText, out newValue)) {
-                return true;
-            }
+        return false;
+    }
 
-            newValue = value;
-            return false;
+    public static bool OnClick(this ImGui gui, Rect rect) {
+        if (gui.action == ImGuiAction.MouseUp) {
+            return gui.ConsumeMouseUp(rect);
         }
 
-        public static void ShowDropDown(this ImGui gui, Rect rect, GuiBuilder builder, Padding padding, float width = 20f) => gui.window?.ShowDropDown(gui, rect, builder, padding, width);
+        if (gui.action == ImGuiAction.MouseDown && gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
+            _ = gui.ConsumeMouseDown(rect);
+        }
 
-        public static void ShowDropDown(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowDropDown(gui, gui.lastRect, builder, new Padding(1f), width);
+        return false;
+    }
 
-        public static void ShowTooltip(this ImGui gui, Rect rect, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, rect, builder, width);
+    public static ButtonEvent BuildButton(this ImGui gui, string text, SchemeColor color = SchemeColor.Primary, Padding? padding = null, bool active = true) {
+        if (!active) {
+            color = SchemeColor.Grey;
+        }
 
-        public static void ShowTooltip(this ImGui gui, Rect rect, string text, float width = 20f) => gui.window?.ShowTooltip(gui, rect, x => x.BuildText(text, TextBlockDisplayStyle.WrappedText), width);
+        using (gui.EnterGroup(padding ?? DefaultButtonPadding, active ? color + 2 : color + 3)) {
+            gui.BuildText(text, TextBlockDisplayStyle.Centered);
+        }
 
-        public static void ShowTooltip(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, gui.lastRect, builder, width);
+        return active ? gui.BuildButton(gui.lastRect, color, color + 1) : ButtonEvent.None;
+    }
 
-        public struct InlineGridBuilder : IDisposable {
-            private ImGui.Context savedContext;
-            private readonly ImGui gui;
-            private readonly int elementsPerRow;
-            private readonly float elementWidth;
-            private readonly float spacing;
-            private int currentRowIndex;
+    public static ButtonEvent BuildContextMenuButton(this ImGui gui, string text, string? rightText = null, Icon icon = default, bool disabled = false) {
+        gui.allocator = RectAllocator.Stretch;
+        using (gui.EnterGroup(DefaultButtonPadding, RectAllocator.LeftRow, SchemeColor.BackgroundText)) {
+            var textColor = disabled ? gui.textColor + 1 : gui.textColor;
+            if (icon != default) {
+                gui.BuildIcon(icon, color: icon >= Icon.FirstCustom ? disabled ? SchemeColor.SourceFaint : SchemeColor.Source : textColor);
+            }
 
-            internal InlineGridBuilder(ImGui gui, float elementWidth, float spacing, int elementsPerRow) {
+            gui.BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = textColor });
+            if (rightText != null) {
+                gui.allocator = RectAllocator.RightRow;
+                gui.BuildText(rightText, new TextBlockDisplayStyle(Alignment: RectAlignment.MiddleRight));
+            }
+        }
+        return gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey);
+    }
+
+    public static void CaptureException(this Task task) => _ = task.ContinueWith(t => throw t.Exception!, TaskContinuationOptions.OnlyOnFaulted); // null-forgiving: OnlyOnFaulted guarantees that Exception is non-null.
+
+    public static bool BuildMouseOverIcon(this ImGui gui, Icon icon, SchemeColor color = SchemeColor.BackgroundText) {
+        if (gui.isBuilding && gui.IsMouseOver(gui.lastRect)) {
+            gui.DrawIcon(gui.lastRect, icon, color);
+        }
+
+        return gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt);
+    }
+
+    public static ButtonEvent BuildRedButton(this ImGui gui, string text) {
+        Rect textRect;
+        TextCache? cache;
+        using (gui.EnterGroup(DefaultButtonPadding)) {
+            textRect = gui.AllocateTextRect(out cache, text, TextBlockDisplayStyle.Centered);
+        }
+
+        var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
+        if (gui.isBuilding) {
+            gui.DrawRenderable(textRect, cache, gui.IsMouseOver(gui.lastRect) ? SchemeColor.ErrorText : SchemeColor.Error);
+        }
+
+        return evt;
+    }
+
+    public static ButtonEvent BuildRedButton(this ImGui gui, Icon icon, float size = 1.5f, bool invertedColors = false) {
+        Rect iconRect;
+        using (gui.EnterGroup(new Padding(0.3f))) {
+            iconRect = gui.AllocateRect(size, size, RectAlignment.Middle);
+        }
+
+        var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
+        if (gui.isBuilding) {
+            SchemeColor color = invertedColors ? SchemeColor.ErrorText : SchemeColor.Error;
+
+            if (gui.IsMouseOver(gui.lastRect)) {
+                color = invertedColors ? SchemeColor.Error : SchemeColor.ErrorText;
+            }
+
+            gui.DrawIcon(iconRect, icon, color);
+        }
+
+        return evt;
+    }
+
+    public static ButtonEvent BuildButton(this ImGui gui, Icon icon, SchemeColor normal = SchemeColor.None, SchemeColor over = SchemeColor.Grey, SchemeColor down = SchemeColor.None, float size = 1.5f) {
+        using (gui.EnterGroup(new Padding(0.3f))) {
+            gui.BuildIcon(icon, size);
+        }
+
+        return gui.BuildButton(gui.lastRect, normal, over, down);
+    }
+
+    public static ButtonEvent BuildButton(this ImGui gui, Icon icon, string text, SchemeColor normal = SchemeColor.None, SchemeColor over = SchemeColor.Grey, SchemeColor down = SchemeColor.None, float size = 1.5f) {
+        using (gui.EnterGroup(new Padding(0.3f), RectAllocator.LeftRow)) {
+            gui.BuildIcon(icon, size);
+            gui.BuildText(text);
+        }
+        return gui.BuildButton(gui.lastRect, normal, over, down);
+    }
+
+    public static bool WithTooltip(this ButtonEvent evt, ImGui gui, string tooltip, Rect? rect = null) {
+        if (evt == ButtonEvent.MouseOver) {
+            gui.ShowTooltip(rect ?? gui.lastRect, tooltip);
+        }
+
+        return evt;
+    }
+
+    public static bool BuildCheckBox(this ImGui gui, string text, bool value, out bool newValue, SchemeColor color = SchemeColor.None, RectAllocator allocator = RectAllocator.LeftRow) {
+        using (gui.EnterRow(allocator: allocator)) {
+            gui.BuildIcon(value ? Icon.CheckBoxCheck : Icon.CheckBoxEmpty, 1.5f, color);
+            gui.BuildText(text, TextBlockDisplayStyle.Default(color));
+        }
+
+        if (gui.OnClick(gui.lastRect)) {
+            newValue = !value;
+            return true;
+        }
+
+        newValue = value;
+        return false;
+    }
+
+    public static ButtonEvent BuildRadioButton(this ImGui gui, string option, bool selected, SchemeColor textColor = SchemeColor.None, bool enabled = true) {
+        if (textColor == SchemeColor.None) {
+            textColor = enabled ? SchemeColor.PrimaryText : SchemeColor.PrimaryTextFaint;
+        }
+        using (gui.EnterRow()) {
+            gui.BuildIcon(selected ? Icon.RadioCheck : Icon.RadioEmpty, 1.5f, textColor);
+            gui.BuildText(option, TextBlockDisplayStyle.WrappedText with { Color = textColor });
+        }
+        if (!enabled) {
+            return ButtonEvent.None;
+        }
+
+        ButtonEvent click = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.None);
+        if (click == ButtonEvent.Click && selected) { return ButtonEvent.None; }
+        return click;
+    }
+
+    public static bool BuildRadioGroup(this ImGui gui, IReadOnlyList<string> options, int selected, out int newSelected,
+                                       SchemeColor textColor = SchemeColor.None, bool enabled = true)
+        => gui.BuildRadioGroup([.. options.Select(o => (o, (string?)null))], selected, out newSelected, textColor, enabled);
+
+    public static bool BuildRadioGroup(this ImGui gui, IReadOnlyList<(string option, string? tooltip)> options, int selected,
+                                       out int newSelected, SchemeColor textColor = SchemeColor.None, bool enabled = true) {
+        newSelected = selected;
+        for (int i = 0; i < options.Count; i++) {
+            ButtonEvent evt = BuildRadioButton(gui, options[i].option, selected == i, textColor, enabled);
+            if (!string.IsNullOrEmpty(options[i].tooltip)) {
+                evt.WithTooltip(gui, options[i].tooltip!);
+            }
+            if (evt) {
+                newSelected = i;
+            }
+        }
+
+        return newSelected != selected;
+    }
+
+    public static bool BuildErrorRow(this ImGui gui, string text) {
+        bool closed = false;
+        using (gui.EnterRow(allocator: RectAllocator.RightRow, textColor: SchemeColor.ErrorText)) {
+            if (gui.BuildButton(Icon.Close, size: 1f, over: SchemeColor.ErrorAlt)) {
+                closed = true;
+            }
+
+            gui.RemainingRow().BuildText(text, TextBlockDisplayStyle.Centered);
+        }
+        if (gui.isBuilding) {
+            gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
+        }
+
+        return closed;
+    }
+
+    public static bool BuildIntegerInput(this ImGui gui, int value, out int newValue, bool setInitialFocus = false) {
+        if (gui.BuildTextInput(value.ToString(), out string newText, null, delayed: true, setInitialFocus: setInitialFocus) && int.TryParse(newText, out newValue)) {
+            return true;
+        }
+
+        newValue = value;
+        return false;
+    }
+
+    public static void ShowDropDown(this ImGui gui, Rect rect, GuiBuilder builder, Padding padding, float width = 20f) => gui.window?.ShowDropDown(gui, rect, builder, padding, width);
+
+    public static void ShowDropDown(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowDropDown(gui, gui.lastRect, builder, new Padding(1f), width);
+
+    public static void ShowTooltip(this ImGui gui, Rect rect, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, rect, builder, width);
+
+    public static void ShowTooltip(this ImGui gui, Rect rect, string text, float width = 20f) => gui.window?.ShowTooltip(gui, rect, x => x.BuildText(text, TextBlockDisplayStyle.WrappedText), width);
+
+    public static void ShowTooltip(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, gui.lastRect, builder, width);
+
+    public struct InlineGridBuilder : IDisposable {
+        private ImGui.Context savedContext;
+        private readonly ImGui gui;
+        private readonly int elementsPerRow;
+        private readonly float elementWidth;
+        private readonly float spacing;
+        private int currentRowIndex;
+
+        internal InlineGridBuilder(ImGui gui, float elementWidth, float spacing, int elementsPerRow) {
+            savedContext = default;
+            this.gui = gui;
+            this.spacing = spacing;
+            gui.allocator = RectAllocator.LeftAlign;
+            this.elementWidth = MathF.Min(elementWidth, gui.width);
+            this.elementsPerRow = elementsPerRow == 0 ? MathUtils.Floor((gui.width + spacing) / (elementWidth + spacing)) : elementsPerRow;
+            currentRowIndex = -1;
+            if (elementWidth <= 0) {
+                this.elementsPerRow = 1;
+            }
+        }
+
+        public void Next() {
+            if (currentRowIndex == elementsPerRow - 1) {
+                savedContext.Dispose();
                 savedContext = default;
-                this.gui = gui;
-                this.spacing = spacing;
-                gui.allocator = RectAllocator.LeftAlign;
-                this.elementWidth = MathF.Min(elementWidth, gui.width);
-                this.elementsPerRow = elementsPerRow == 0 ? MathUtils.Floor((gui.width + spacing) / (elementWidth + spacing)) : elementsPerRow;
                 currentRowIndex = -1;
-                if (elementWidth <= 0) {
-                    this.elementsPerRow = 1;
-                }
             }
-
-            public void Next() {
-                if (currentRowIndex == elementsPerRow - 1) {
-                    savedContext.Dispose();
-                    savedContext = default;
-                    currentRowIndex = -1;
-                }
-                currentRowIndex++;
-                if (currentRowIndex == 0) {
-                    savedContext = gui.EnterRow(0f);
-                    gui.spacing = 0f;
-                }
-                savedContext.SetManualRect(new Rect((elementWidth + spacing) * currentRowIndex, 0f, elementWidth, 0f), RectAllocator.Stretch);
+            currentRowIndex++;
+            if (currentRowIndex == 0) {
+                savedContext = gui.EnterRow(0f);
+                gui.spacing = 0f;
             }
-
-            public bool isEmpty() => gui == null;
-
-            public void Dispose() => savedContext.Dispose();
+            savedContext.SetManualRect(new Rect((elementWidth + spacing) * currentRowIndex, 0f, elementWidth, 0f), RectAllocator.Stretch);
         }
 
-        public static InlineGridBuilder EnterInlineGrid(this ImGui gui, float elementWidth, float spacing = 0f, int maxElemCount = 0) => new InlineGridBuilder(
-            gui, elementWidth, spacing, maxElemCount);
+        public bool isEmpty() => gui == null;
 
-        public static InlineGridBuilder EnterHorizontalSplit(this ImGui gui, int elementCount, float spacing = 0f) => new InlineGridBuilder(
-            gui, ((gui.width + spacing) / elementCount) - spacing, spacing, elementCount);
+        public void Dispose() => savedContext.Dispose();
+    }
 
-        public static bool InitiateDrag<T>(this ImGui gui, Rect moveHandle, Rect contents, T index, SchemeColor backgroundColor = SchemeColor.PureBackground) {
-            if (gui.action == ImGuiAction.MouseDown) {
-                _ = gui.ConsumeMouseDown(moveHandle);
-            }
+    public static InlineGridBuilder EnterInlineGrid(this ImGui gui, float elementWidth, float spacing = 0f, int maxElemCount = 0) => new InlineGridBuilder(
+        gui, elementWidth, spacing, maxElemCount);
 
-            if (gui.ShouldEnterDrag(moveHandle) || (gui.action == ImGuiAction.Build && gui.IsDragging(index))) {
-                gui.SetDraggingArea(contents, index, backgroundColor);
-                return true;
-            }
-            return false;
+    public static InlineGridBuilder EnterHorizontalSplit(this ImGui gui, int elementCount, float spacing = 0f) => new InlineGridBuilder(
+        gui, ((gui.width + spacing) / elementCount) - spacing, spacing, elementCount);
+
+    public static bool InitiateDrag<T>(this ImGui gui, Rect moveHandle, Rect contents, T index, SchemeColor backgroundColor = SchemeColor.PureBackground) {
+        if (gui.action == ImGuiAction.MouseDown) {
+            _ = gui.ConsumeMouseDown(moveHandle);
         }
 
-        public static bool BuildSlider(this ImGui gui, float value, out float newValue, float width = 10f) {
-            var sliderRect = gui.AllocateRect(width, 2f, RectAlignment.Full);
-            float handleStart = (sliderRect.Width - 1f) * value;
-            Rect handleRect = new Rect(sliderRect.X + handleStart, sliderRect.Y, 1f, sliderRect.Height);
-            bool update = false;
-            newValue = value;
-
-            switch (gui.action) {
-                case ImGuiAction.Build:
-                    gui.DrawRectangle(handleRect, gui.IsMouseOverOrDown(sliderRect) ? SchemeColor.Background : SchemeColor.PureBackground, RectangleBorder.Thin);
-                    sliderRect.Y += (sliderRect.Height - 0.3f) / 2f;
-                    sliderRect.Height = 0.3f;
-                    gui.DrawRectangle(sliderRect, SchemeColor.Grey);
-                    break;
-                case ImGuiAction.MouseMove:
-                    if (gui.IsMouseDown(sliderRect)) {
-                        update = true;
-                    }
-                    else {
-                        _ = gui.ConsumeMouseOver(sliderRect, RenderingUtils.cursorHand);
-                    }
-
-                    break;
-                case ImGuiAction.MouseDown:
-                    if (gui.IsMouseOver(sliderRect)) {
-                        _ = gui.ConsumeMouseDown(sliderRect);
-                        update = true;
-                    }
-                    break;
-            }
-
-            if (!update) {
-                return false;
-            }
-
-            float positionX = (gui.mousePosition.X - sliderRect.X - 0.5f) / (sliderRect.Width - 1f);
-            newValue = MathUtils.Clamp(positionX, 0f, 1f);
-            gui.Rebuild();
+        if (gui.ShouldEnterDrag(moveHandle) || (gui.action == ImGuiAction.Build && gui.IsDragging(index))) {
+            gui.SetDraggingArea(contents, index, backgroundColor);
             return true;
         }
+        return false;
+    }
 
-        public static bool BuildSearchBox(this ImGui gui, SearchQuery searchQuery, out SearchQuery newQuery, string placeholder = "Search", bool setInitialFocus = false) {
-            newQuery = searchQuery;
-            if (gui.BuildTextInput(searchQuery.query, out string newText, placeholder, Icon.Search, setInitialFocus: setInitialFocus)) {
-                newQuery = new SearchQuery(newText);
-                return true;
-            }
+    public static bool BuildSlider(this ImGui gui, float value, out float newValue, float width = 10f) {
+        var sliderRect = gui.AllocateRect(width, 2f, RectAlignment.Full);
+        float handleStart = (sliderRect.Width - 1f) * value;
+        Rect handleRect = new Rect(sliderRect.X + handleStart, sliderRect.Y, 1f, sliderRect.Height);
+        bool update = false;
+        newValue = value;
 
-            return false;
-        }
-
-        public struct CloseDropdownEvent { }
-
-        public static bool CloseDropdown(this ImGui gui) {
-            gui.PropagateMessage<CloseDropdownEvent>(default);
-            return true;
-        }
-
-        /// <summary>
-        /// Draws a row with a (?) help icon at its right side, and a tooltip when the user hovers over the icon.
-        /// </summary>
-        /// <param name="tooltip">The tooltip that should be displayed when the user hovers over the (?) icon.</param>
-        /// <param name="rightJustify">If <see langword="true"/>, the default, the help icon will be as far right as possible.
-        /// If false, it will be still be drawn at the right end of the row, but as far left as possible.</param>
-        public static IDisposable EnterRowWithHelpIcon(this ImGui gui, string tooltip, bool rightJustify = true) => new RowWithHelpIcon(gui, tooltip, rightJustify);
-
-        /// <summary>
-        /// The class that sets up and stores the state needed to build a row with a help icon.
-        /// </summary>
-        private sealed class RowWithHelpIcon : IDisposable {
-            private readonly ImGui gui;
-            private readonly string tooltip;
-            private readonly ImGui.Context row;
-            private readonly float helpCenterX;
-            private readonly ImGui.Context group;
-
-            public RowWithHelpIcon(ImGui gui, string tooltip, bool rightJustify) {
-                this.gui = gui;
-                this.tooltip = tooltip;
-                row = gui.EnterRow(); // using (gui.EnterRow()) {
-                if (rightJustify) {
-                    gui.allocator = RectAllocator.RightRow;
-                    helpCenterX = gui.AllocateRect(1, 1).Center.X;
-                    group = gui.EnterGroup(new Padding(), RectAllocator.RemainingRow); // using (gui.EnterGroup(...)) { // Required to produce the expected spacing/padding behavior.
-                    gui.allocator = RectAllocator.LeftRow;
-                }
-            }
-
-            public void Dispose() {
-                Rect rect;
-                if (helpCenterX != 0) { // if (rightJustify)
-                    group.Dispose(); // end using block for EnterGroup
-                    rect = Rect.Square(helpCenterX, gui.lastRect.Center.Y, 1.25f);
+        switch (gui.action) {
+            case ImGuiAction.Build:
+                gui.DrawRectangle(handleRect, gui.IsMouseOverOrDown(sliderRect) ? SchemeColor.Background : SchemeColor.PureBackground, RectangleBorder.Thin);
+                sliderRect.Y += (sliderRect.Height - 0.3f) / 2f;
+                sliderRect.Height = 0.3f;
+                gui.DrawRectangle(sliderRect, SchemeColor.Grey);
+                break;
+            case ImGuiAction.MouseMove:
+                if (gui.IsMouseDown(sliderRect)) {
+                    update = true;
                 }
                 else {
-                    rect = gui.AllocateRect(1.25f, 1.25f); // Despite requesting 1.25 x 1.25, rect will be 1.25 x RowHeight, which might be greater than 1.25.
-                    rect = Rect.Square(rect.Center, 1.25f); // Get a vertically-centered rect that's actually 1.25 x 1.25.
+                    _ = gui.ConsumeMouseOver(sliderRect, RenderingUtils.cursorHand);
                 }
-                gui.DrawIcon(rect, Icon.Help, SchemeColor.BackgroundText);
-                gui.BuildButton(rect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, tooltip, rect);
-                row.Dispose(); // end using block for EnterRow
+
+                break;
+            case ImGuiAction.MouseDown:
+                if (gui.IsMouseOver(sliderRect)) {
+                    _ = gui.ConsumeMouseDown(sliderRect);
+                    update = true;
+                }
+                break;
+        }
+
+        if (!update) {
+            return false;
+        }
+
+        float positionX = (gui.mousePosition.X - sliderRect.X - 0.5f) / (sliderRect.Width - 1f);
+        newValue = MathUtils.Clamp(positionX, 0f, 1f);
+        gui.Rebuild();
+        return true;
+    }
+
+    public static bool BuildSearchBox(this ImGui gui, SearchQuery searchQuery, out SearchQuery newQuery, string placeholder = "Search", bool setInitialFocus = false) {
+        newQuery = searchQuery;
+        if (gui.BuildTextInput(searchQuery.query, out string newText, placeholder, Icon.Search, setInitialFocus: setInitialFocus)) {
+            newQuery = new SearchQuery(newText);
+            return true;
+        }
+
+        return false;
+    }
+
+    public struct CloseDropdownEvent { }
+
+    public static bool CloseDropdown(this ImGui gui) {
+        gui.PropagateMessage<CloseDropdownEvent>(default);
+        return true;
+    }
+
+    /// <summary>
+    /// Draws a row with a (?) help icon at its right side, and a tooltip when the user hovers over the icon.
+    /// </summary>
+    /// <param name="tooltip">The tooltip that should be displayed when the user hovers over the (?) icon.</param>
+    /// <param name="rightJustify">If <see langword="true"/>, the default, the help icon will be as far right as possible.
+    /// If false, it will be still be drawn at the right end of the row, but as far left as possible.</param>
+    public static IDisposable EnterRowWithHelpIcon(this ImGui gui, string tooltip, bool rightJustify = true) => new RowWithHelpIcon(gui, tooltip, rightJustify);
+
+    /// <summary>
+    /// The class that sets up and stores the state needed to build a row with a help icon.
+    /// </summary>
+    private sealed class RowWithHelpIcon : IDisposable {
+        private readonly ImGui gui;
+        private readonly string tooltip;
+        private readonly ImGui.Context row;
+        private readonly float helpCenterX;
+        private readonly ImGui.Context group;
+
+        public RowWithHelpIcon(ImGui gui, string tooltip, bool rightJustify) {
+            this.gui = gui;
+            this.tooltip = tooltip;
+            row = gui.EnterRow(); // using (gui.EnterRow()) {
+            if (rightJustify) {
+                gui.allocator = RectAllocator.RightRow;
+                helpCenterX = gui.AllocateRect(1, 1).Center.X;
+                group = gui.EnterGroup(new Padding(), RectAllocator.RemainingRow); // using (gui.EnterGroup(...)) { // Required to produce the expected spacing/padding behavior.
+                gui.allocator = RectAllocator.LeftRow;
             }
+        }
+
+        public void Dispose() {
+            Rect rect;
+            if (helpCenterX != 0) { // if (rightJustify)
+                group.Dispose(); // end using block for EnterGroup
+                rect = Rect.Square(helpCenterX, gui.lastRect.Center.Y, 1.25f);
+            }
+            else {
+                rect = gui.AllocateRect(1.25f, 1.25f); // Despite requesting 1.25 x 1.25, rect will be 1.25 x RowHeight, which might be greater than 1.25.
+                rect = Rect.Square(rect.Center, 1.25f); // Get a vertically-centered rect that's actually 1.25 x 1.25.
+            }
+            gui.DrawIcon(rect, Icon.Help, SchemeColor.BackgroundText);
+            gui.BuildButton(rect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, tooltip, rect);
+            row.Dispose(); // end using block for EnterRow
         }
     }
 }

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -3,325 +3,324 @@ using System.Collections.Generic;
 using System.Numerics;
 using SDL2;
 
-namespace Yafc.UI {
-    /// <summary> Provide scrolling support for any component.</summary>
-    /// <remarks> The component should use the <see cref="scroll"/> property to get the offset of rendering the contents. </remarks>
-    public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible) : IKeyboardFocus {
-        /// <summary>Required size to fit Scrollable (child) contents</summary>
-        private Vector2 requiredContentSize;
-        /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
-        private Rect contentRect;
-        /// <summary>Maximum scroller offset, calculated with the <see cref="requiredContentSize"/> and the available size</summary>
-        private Vector2 maxScroll;
-        private Vector2 _scroll;
-        private ImGui? gui;
-        public const float ScrollbarSize = 1f;
+namespace Yafc.UI;
+/// <summary> Provide scrolling support for any component.</summary>
+/// <remarks> The component should use the <see cref="scroll"/> property to get the offset of rendering the contents. </remarks>
+public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible) : IKeyboardFocus {
+    /// <summary>Required size to fit Scrollable (child) contents</summary>
+    private Vector2 requiredContentSize;
+    /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
+    private Rect contentRect;
+    /// <summary>Maximum scroller offset, calculated with the <see cref="requiredContentSize"/> and the available size</summary>
+    private Vector2 maxScroll;
+    private Vector2 _scroll;
+    private ImGui? gui;
+    public const float ScrollbarSize = 1f;
 
-        // Padding to add at the bottom of the scroll area to be able to scroll past the
-        // last item; needs useBottomPadding to be set to true in method Build()
-        private const float BottomPaddingInPixels = 100f;
+    // Padding to add at the bottom of the scroll area to be able to scroll past the
+    // last item; needs useBottomPadding to be set to true in method Build()
+    private const float BottomPaddingInPixels = 100f;
 
-        protected abstract void PositionContent(ImGui gui, Rect viewport);
+    protected abstract void PositionContent(ImGui gui, Rect viewport);
 
-        /// <param name="availableHeight">Available height without in parent context for the Scrollable</param>
-        public void Build(ImGui gui, float availableHeight, bool useBottomPadding = false) {
-            this.gui = gui;
-            var rect = gui.statePosition;
-            float width = rect.Width;
-            if (vertical) {
-                width -= ScrollbarSize;
+    /// <param name="availableHeight">Available height without in parent context for the Scrollable</param>
+    public void Build(ImGui gui, float availableHeight, bool useBottomPadding = false) {
+        this.gui = gui;
+        var rect = gui.statePosition;
+        float width = rect.Width;
+        if (vertical) {
+            width -= ScrollbarSize;
+        }
+
+        if (gui.isBuilding) {
+            // Calculate required size, including padding if needed
+            requiredContentSize = MeasureContent(width, gui);
+            if (requiredContentSize.Y > availableHeight && useBottomPadding) {
+                requiredContentSize.Y += BottomPaddingInPixels / gui.pixelsPerUnit;
+            }
+        }
+
+        float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
+
+        if (gui.isBuilding) {
+            contentRect = rect;
+            contentRect.Width = width;
+
+            maxScroll = Vector2.Max(requiredContentSize - new Vector2(contentRect.Width, availableHeight), Vector2.Zero);
+            scroll = Vector2.Clamp(scroll, Vector2.Zero, maxScroll);
+
+            contentRect.Height = realHeight;
+            if (horizontal && maxScroll.X > 0) {
+                contentRect.Height -= ScrollbarSize;
             }
 
-            if (gui.isBuilding) {
-                // Calculate required size, including padding if needed
-                requiredContentSize = MeasureContent(width, gui);
-                if (requiredContentSize.Y > availableHeight && useBottomPadding) {
-                    requiredContentSize.Y += BottomPaddingInPixels / gui.pixelsPerUnit;
+            PositionContent(gui, contentRect);
+        }
+
+        rect.Height = realHeight;
+        _ = gui.EncapsulateRect(rect);
+
+        // Calculate scroller dimensions.
+        Vector2 size = new Vector2(width, availableHeight);
+        var scrollerSize = size * size / (size + maxScroll);
+        scrollerSize = Vector2.Max(scrollerSize, Vector2.One);
+        var scrollerStart = _scroll / maxScroll * (size - scrollerSize);
+
+        if ((gui.action == ImGuiAction.MouseDown || gui.action == ImGuiAction.MouseScroll) && rect.Contains(gui.mousePosition)) {
+            InputSystem.Instance.SetKeyboardFocus(this);
+        }
+
+        if (gui.action == ImGuiAction.MouseScroll) {
+            if (gui.ConsumeEvent(rect)) {
+                if (vertical && (!horizontal || !InputSystem.Instance.control)) {
+                    scrollY += gui.actionParameter * 3f;
+                }
+                else {
+                    scrollX += gui.actionParameter * 3f;
                 }
             }
+        }
+        else {
+            if (horizontal && maxScroll.X > 0f) {
+                Rect scrollbarRect = new Rect(rect.X, rect.Bottom - ScrollbarSize, rect.Width, ScrollbarSize);
+                Rect scrollerRect = new Rect(rect.X + scrollerStart.X, scrollbarRect.Y, scrollerSize.X, ScrollbarSize);
+                BuildScrollBar(gui, 0, in scrollbarRect, in scrollerRect);
+            }
 
-            float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
+            if (vertical && maxScroll.Y > 0f) {
+                Rect scrollbarRect = new Rect(rect.Right - ScrollbarSize, rect.Y, ScrollbarSize, rect.Height);
+                Rect scrollerRect = new Rect(scrollbarRect.X, rect.Y + scrollerStart.Y, ScrollbarSize, scrollerSize.Y);
+                BuildScrollBar(gui, 1, in scrollbarRect, in scrollerRect);
+            }
+        }
+    }
 
-            if (gui.isBuilding) {
-                contentRect = rect;
-                contentRect.Width = width;
-
-                maxScroll = Vector2.Max(requiredContentSize - new Vector2(contentRect.Width, availableHeight), Vector2.Zero);
-                scroll = Vector2.Clamp(scroll, Vector2.Zero, maxScroll);
-
-                contentRect.Height = realHeight;
-                if (horizontal && maxScroll.X > 0) {
-                    contentRect.Height -= ScrollbarSize;
+    private void BuildScrollBar(ImGui gui, int axis, in Rect scrollbarRect, in Rect scrollerRect) {
+        switch (gui.action) {
+            case ImGuiAction.MouseDown:
+                if (scrollerRect.Contains(gui.mousePosition)) {
+                    _ = gui.ConsumeMouseDown(scrollbarRect);
                 }
 
-                PositionContent(gui, contentRect);
-            }
-
-            rect.Height = realHeight;
-            _ = gui.EncapsulateRect(rect);
-
-            // Calculate scroller dimensions.
-            Vector2 size = new Vector2(width, availableHeight);
-            var scrollerSize = size * size / (size + maxScroll);
-            scrollerSize = Vector2.Max(scrollerSize, Vector2.One);
-            var scrollerStart = _scroll / maxScroll * (size - scrollerSize);
-
-            if ((gui.action == ImGuiAction.MouseDown || gui.action == ImGuiAction.MouseScroll) && rect.Contains(gui.mousePosition)) {
-                InputSystem.Instance.SetKeyboardFocus(this);
-            }
-
-            if (gui.action == ImGuiAction.MouseScroll) {
-                if (gui.ConsumeEvent(rect)) {
-                    if (vertical && (!horizontal || !InputSystem.Instance.control)) {
-                        scrollY += gui.actionParameter * 3f;
+                break;
+            case ImGuiAction.MouseMove:
+                if (gui.IsMouseDown(scrollbarRect, SDL.SDL_BUTTON_LEFT)) {
+                    if (axis == 0) {
+                        scrollX += InputSystem.Instance.mouseDelta.X * requiredContentSize.X / scrollbarRect.Width;
                     }
                     else {
-                        scrollX += gui.actionParameter * 3f;
+                        scrollY += InputSystem.Instance.mouseDelta.Y * requiredContentSize.Y / scrollbarRect.Height;
                     }
                 }
-            }
-            else {
-                if (horizontal && maxScroll.X > 0f) {
-                    Rect scrollbarRect = new Rect(rect.X, rect.Bottom - ScrollbarSize, rect.Width, ScrollbarSize);
-                    Rect scrollerRect = new Rect(rect.X + scrollerStart.X, scrollbarRect.Y, scrollerSize.X, ScrollbarSize);
-                    BuildScrollBar(gui, 0, in scrollbarRect, in scrollerRect);
-                }
-
-                if (vertical && maxScroll.Y > 0f) {
-                    Rect scrollbarRect = new Rect(rect.Right - ScrollbarSize, rect.Y, ScrollbarSize, rect.Height);
-                    Rect scrollerRect = new Rect(scrollbarRect.X, rect.Y + scrollerStart.Y, ScrollbarSize, scrollerSize.Y);
-                    BuildScrollBar(gui, 1, in scrollbarRect, in scrollerRect);
-                }
-            }
+                break;
+            case ImGuiAction.Build:
+                gui.DrawRectangle(scrollerRect, SchemeColor.Grey);
+                break;
         }
-
-        private void BuildScrollBar(ImGui gui, int axis, in Rect scrollbarRect, in Rect scrollerRect) {
-            switch (gui.action) {
-                case ImGuiAction.MouseDown:
-                    if (scrollerRect.Contains(gui.mousePosition)) {
-                        _ = gui.ConsumeMouseDown(scrollbarRect);
-                    }
-
-                    break;
-                case ImGuiAction.MouseMove:
-                    if (gui.IsMouseDown(scrollbarRect, SDL.SDL_BUTTON_LEFT)) {
-                        if (axis == 0) {
-                            scrollX += InputSystem.Instance.mouseDelta.X * requiredContentSize.X / scrollbarRect.Width;
-                        }
-                        else {
-                            scrollY += InputSystem.Instance.mouseDelta.Y * requiredContentSize.Y / scrollbarRect.Height;
-                        }
-                    }
-                    break;
-                case ImGuiAction.Build:
-                    gui.DrawRectangle(scrollerRect, SchemeColor.Grey);
-                    break;
-            }
-        }
-
-        /// <summary>X and Y positions of the scrollers</summary>
-        public virtual Vector2 scroll {
-            get => _scroll;
-            set {
-                value = Vector2.Clamp(value, Vector2.Zero, maxScroll);
-                if (value != _scroll) {
-                    _scroll = value;
-                    gui?.Rebuild();
-                }
-            }
-        }
-
-        /// <summary>Position of the Y scroller</summary>
-        public float scrollY {
-            get => _scroll.Y;
-            set => scroll = new Vector2(_scroll.X, value);
-        }
-
-        /// <summary>Position of the X scroller</summary>
-        public float scrollX {
-            get => _scroll.X;
-            set => scroll = new Vector2(value, _scroll.Y);
-        }
-
-        ///<summary>This method is called when the required area of the <see cref="Scrollable"/> for the provided <paramref name="width"/> is needed.</summary>
-        /// <returns>The required area of the contents of the <see cref="Scrollable"/>.</returns>
-        protected abstract Vector2 MeasureContent(float width, ImGui gui);
-
-        public bool KeyDown(SDL.SDL_Keysym key) {
-            bool ctrl = InputSystem.Instance.control;
-            bool shift = InputSystem.Instance.shift;
-            switch ((ctrl, shift, key.scancode)) {
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_UP):
-                    scrollY -= 3;
-                    return true;
-                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_UP):
-                    scrollY = 0; // ctrl+up = home
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_DOWN):
-                    scrollY += 3;
-                    return true;
-                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_DOWN):
-                    scrollY = maxScroll.Y; // ctrl+down = end
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_LEFT):
-                    scrollX -= 3;
-                    return true;
-                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_LEFT):
-                    scrollX = 0;
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_RIGHT):
-                    scrollX += 3;
-                    return true;
-                case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_RIGHT):
-                    scrollX = maxScroll.X;
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN):
-                    scrollY += contentRect.Height;
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP):
-                    scrollY -= contentRect.Height;
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_HOME):
-                    scrollY = 0;
-                    return true;
-                case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_END):
-                    scrollY = maxScroll.Y;
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        public bool TextInput(string input) => false;
-
-        public bool KeyUp(SDL.SDL_Keysym key) => false;
-
-        public void FocusChanged(bool focused) { }
     }
 
-    /// <summary>Provides a builder to the Scrollable to render the contents.</summary>
-    public abstract class ScrollAreaBase : Scrollable {
-        protected ImGui contents;
-        protected readonly float height;
-
-        public ScrollAreaBase(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible) {
-            contents = new ImGui(BuildContents, padding, clip: true);
-            this.height = height;
+    /// <summary>X and Y positions of the scrollers</summary>
+    public virtual Vector2 scroll {
+        get => _scroll;
+        set {
+            value = Vector2.Clamp(value, Vector2.Zero, maxScroll);
+            if (value != _scroll) {
+                _scroll = value;
+                gui?.Rebuild();
+            }
         }
-
-        protected override void PositionContent(ImGui gui, Rect viewport) {
-            gui.DrawPanel(viewport, contents);
-            contents.offset = -scroll;
-        }
-
-        public void Build(ImGui gui) => Build(gui, height);
-
-        protected abstract void BuildContents(ImGui gui);
-
-        public void RebuildContents() => contents.Rebuild();
-
-        protected override Vector2 MeasureContent(float width, ImGui gui) => contents.CalculateState(width, gui.pixelsPerUnit);
     }
 
-    ///<summary>Area with scrollbars, which will be visible if it does not fit in the parent area in order to let the user fully view the content of the area.</summary>
-    public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal) {
-        protected override void BuildContents(ImGui gui) => builder(gui);
-
-        public void Rebuild() => RebuildContents();
+    /// <summary>Position of the Y scroller</summary>
+    public float scrollY {
+        get => _scroll.Y;
+        set => scroll = new Vector2(_scroll.X, value);
     }
 
-    public class VirtualScrollList<TData> : ScrollAreaBase {
-        private readonly Vector2 elementSize;
-        // When rendering the scrollable content, render 'blocks' of 4 rows at a time. (As far as I can tell, any positive value works. Shadow picked 4, so I kept that.)
-        private readonly int bufferRows = 4;
-        // The first block of bufferRows that was rendered last time BuildContents was called. If it changes while scrolling, we need to re-render the scrollable content.
-        private int firstVisibleBlock;
-        private int elementsPerRow;
-        private IReadOnlyList<TData> _data = [];
-        private readonly int maxRowsVisible;
-        private readonly Drawer drawer;
-        private float _spacing;
-        private readonly Action<int, int>? reorder;
+    /// <summary>Position of the X scroller</summary>
+    public float scrollX {
+        get => _scroll.X;
+        set => scroll = new Vector2(value, _scroll.Y);
+    }
 
-        public float spacing {
-            get => _spacing;
-            set {
-                _spacing = value;
+    ///<summary>This method is called when the required area of the <see cref="Scrollable"/> for the provided <paramref name="width"/> is needed.</summary>
+    /// <returns>The required area of the contents of the <see cref="Scrollable"/>.</returns>
+    protected abstract Vector2 MeasureContent(float width, ImGui gui);
+
+    public bool KeyDown(SDL.SDL_Keysym key) {
+        bool ctrl = InputSystem.Instance.control;
+        bool shift = InputSystem.Instance.shift;
+        switch ((ctrl, shift, key.scancode)) {
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_UP):
+                scrollY -= 3;
+                return true;
+            case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_UP):
+                scrollY = 0; // ctrl+up = home
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_DOWN):
+                scrollY += 3;
+                return true;
+            case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_DOWN):
+                scrollY = maxScroll.Y; // ctrl+down = end
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_LEFT):
+                scrollX -= 3;
+                return true;
+            case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_LEFT):
+                scrollX = 0;
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_RIGHT):
+                scrollX += 3;
+                return true;
+            case (true, false, SDL.SDL_Scancode.SDL_SCANCODE_RIGHT):
+                scrollX = maxScroll.X;
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN):
+                scrollY += contentRect.Height;
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP):
+                scrollY -= contentRect.Height;
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_HOME):
+                scrollY = 0;
+                return true;
+            case (false, false, SDL.SDL_Scancode.SDL_SCANCODE_END):
+                scrollY = maxScroll.Y;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public bool TextInput(string input) => false;
+
+    public bool KeyUp(SDL.SDL_Keysym key) => false;
+
+    public void FocusChanged(bool focused) { }
+}
+
+/// <summary>Provides a builder to the Scrollable to render the contents.</summary>
+public abstract class ScrollAreaBase : Scrollable {
+    protected ImGui contents;
+    protected readonly float height;
+
+    public ScrollAreaBase(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible) {
+        contents = new ImGui(BuildContents, padding, clip: true);
+        this.height = height;
+    }
+
+    protected override void PositionContent(ImGui gui, Rect viewport) {
+        gui.DrawPanel(viewport, contents);
+        contents.offset = -scroll;
+    }
+
+    public void Build(ImGui gui) => Build(gui, height);
+
+    protected abstract void BuildContents(ImGui gui);
+
+    public void RebuildContents() => contents.Rebuild();
+
+    protected override Vector2 MeasureContent(float width, ImGui gui) => contents.CalculateState(width, gui.pixelsPerUnit);
+}
+
+///<summary>Area with scrollbars, which will be visible if it does not fit in the parent area in order to let the user fully view the content of the area.</summary>
+public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal) {
+    protected override void BuildContents(ImGui gui) => builder(gui);
+
+    public void Rebuild() => RebuildContents();
+}
+
+public class VirtualScrollList<TData> : ScrollAreaBase {
+    private readonly Vector2 elementSize;
+    // When rendering the scrollable content, render 'blocks' of 4 rows at a time. (As far as I can tell, any positive value works. Shadow picked 4, so I kept that.)
+    private readonly int bufferRows = 4;
+    // The first block of bufferRows that was rendered last time BuildContents was called. If it changes while scrolling, we need to re-render the scrollable content.
+    private int firstVisibleBlock;
+    private int elementsPerRow;
+    private IReadOnlyList<TData> _data = [];
+    private readonly int maxRowsVisible;
+    private readonly Drawer drawer;
+    private float _spacing;
+    private readonly Action<int, int>? reorder;
+
+    public float spacing {
+        get => _spacing;
+        set {
+            _spacing = value;
+            RebuildContents();
+        }
+    }
+
+    public delegate void Drawer(ImGui gui, TData element, int index);
+
+    public IReadOnlyList<TData> data {
+        get => _data;
+        set {
+            _data = value ?? [];
+            RebuildContents();
+        }
+    }
+
+    public VirtualScrollList(float height, Vector2 elementSize, Drawer drawer, Padding padding = default, Action<int, int>? reorder = null, bool collapsible = false) : base(height, padding, collapsible) {
+        this.elementSize = elementSize;
+        maxRowsVisible = MathUtils.Ceil(height / this.elementSize.Y) + bufferRows + 1;
+        this.drawer = drawer;
+        this.reorder = reorder;
+    }
+
+    private int CalcFirstBlock() => Math.Max(0, MathUtils.Floor((scrollY - contents.initialPadding.top) / (elementSize.Y * bufferRows)));
+
+    public override Vector2 scroll {
+        get => base.scroll;
+        set {
+            base.scroll = value;
+            int row = CalcFirstBlock();
+            if (row != firstVisibleBlock) {
                 RebuildContents();
             }
         }
-
-        public delegate void Drawer(ImGui gui, TData element, int index);
-
-        public IReadOnlyList<TData> data {
-            get => _data;
-            set {
-                _data = value ?? [];
-                RebuildContents();
-            }
-        }
-
-        public VirtualScrollList(float height, Vector2 elementSize, Drawer drawer, Padding padding = default, Action<int, int>? reorder = null, bool collapsible = false) : base(height, padding, collapsible) {
-            this.elementSize = elementSize;
-            maxRowsVisible = MathUtils.Ceil(height / this.elementSize.Y) + bufferRows + 1;
-            this.drawer = drawer;
-            this.reorder = reorder;
-        }
-
-        private int CalcFirstBlock() => Math.Max(0, MathUtils.Floor((scrollY - contents.initialPadding.top) / (elementSize.Y * bufferRows)));
-
-        public override Vector2 scroll {
-            get => base.scroll;
-            set {
-                base.scroll = value;
-                int row = CalcFirstBlock();
-                if (row != firstVisibleBlock) {
-                    RebuildContents();
-                }
-            }
-        }
-
-        protected override void BuildContents(ImGui gui) {
-            elementsPerRow = MathUtils.Floor((gui.width + _spacing) / (elementSize.X + _spacing));
-            if (elementsPerRow < 1) {
-                elementsPerRow = 1;
-            }
-
-            int rowCount = ((_data.Count - 1) / elementsPerRow) + 1;
-            firstVisibleBlock = CalcFirstBlock();
-            // Scroll up until there are maxRowsVisible, or to the top.
-            int firstRow = Math.Max(0, Math.Min(firstVisibleBlock * bufferRows, rowCount - maxRowsVisible));
-            int index = firstRow * elementsPerRow;
-            if (index >= _data.Count) {
-                // If _data is empty, there's nothing to draw. Make sure MeasureContent reports that, instead of the size of the most recent non-empty content.
-                // This will remove the scroll bar when the search doesn't match anything.
-                gui.lastContentRect = new Rect(gui.lastContentRect.X, gui.lastContentRect.Y, 0, 0);
-                return;
-            }
-
-            int lastRow = firstRow + maxRowsVisible;
-            using var manualPlacing = gui.EnterFixedPositioning(gui.width, rowCount * elementSize.Y, default);
-            var offset = gui.statePosition.Position;
-            float elementWidth = gui.width / elementsPerRow;
-            Rect cell = new Rect(offset.X, offset.Y, elementWidth - _spacing, elementSize.Y);
-            for (int row = firstRow; row < lastRow; row++) {
-                cell.Y = row * (elementSize.Y + _spacing);
-                for (int elem = 0; elem < elementsPerRow; elem++) {
-                    cell.X = elem * elementWidth;
-                    manualPlacing.SetManualRectRaw(cell);
-                    BuildElement(gui, _data[index], index);
-                    if (reorder != null) {
-                        if (gui.DoListReordering(cell, cell, index, out int fromIndex)) {
-                            reorder(fromIndex, index);
-                        }
-                    }
-                    if (++index >= _data.Count) {
-                        return;
-                    }
-                }
-            }
-        }
-
-        protected virtual void BuildElement(ImGui gui, TData element, int index) => drawer(gui, element, index);
     }
+
+    protected override void BuildContents(ImGui gui) {
+        elementsPerRow = MathUtils.Floor((gui.width + _spacing) / (elementSize.X + _spacing));
+        if (elementsPerRow < 1) {
+            elementsPerRow = 1;
+        }
+
+        int rowCount = ((_data.Count - 1) / elementsPerRow) + 1;
+        firstVisibleBlock = CalcFirstBlock();
+        // Scroll up until there are maxRowsVisible, or to the top.
+        int firstRow = Math.Max(0, Math.Min(firstVisibleBlock * bufferRows, rowCount - maxRowsVisible));
+        int index = firstRow * elementsPerRow;
+        if (index >= _data.Count) {
+            // If _data is empty, there's nothing to draw. Make sure MeasureContent reports that, instead of the size of the most recent non-empty content.
+            // This will remove the scroll bar when the search doesn't match anything.
+            gui.lastContentRect = new Rect(gui.lastContentRect.X, gui.lastContentRect.Y, 0, 0);
+            return;
+        }
+
+        int lastRow = firstRow + maxRowsVisible;
+        using var manualPlacing = gui.EnterFixedPositioning(gui.width, rowCount * elementSize.Y, default);
+        var offset = gui.statePosition.Position;
+        float elementWidth = gui.width / elementsPerRow;
+        Rect cell = new Rect(offset.X, offset.Y, elementWidth - _spacing, elementSize.Y);
+        for (int row = firstRow; row < lastRow; row++) {
+            cell.Y = row * (elementSize.Y + _spacing);
+            for (int elem = 0; elem < elementsPerRow; elem++) {
+                cell.X = elem * elementWidth;
+                manualPlacing.SetManualRectRaw(cell);
+                BuildElement(gui, _data[index], index);
+                if (reorder != null) {
+                    if (gui.DoListReordering(cell, cell, index, out int fromIndex)) {
+                        reorder(fromIndex, index);
+                    }
+                }
+                if (++index >= _data.Count) {
+                    return;
+                }
+            }
+        }
+    }
+
+    protected virtual void BuildElement(ImGui gui, TData element, int index) => drawer(gui, element, index);
 }

--- a/Yafc.UI/Rendering/Font.cs
+++ b/Yafc.UI/Rendering/Font.cs
@@ -2,71 +2,70 @@
 using System.Collections.Generic;
 using SDL2;
 
-namespace Yafc.UI {
-    public class Font {
-        public static Font header { get; set; } = null!; // null-forgiving: Set by Main
-        public static Font subheader { get; set; } = null!; // null-forgiving: Set by Main
-        public static Font productionTableHeader { get; set; } = null!; // null-forgiving: Set by Main
-        public static Font text { get; set; } = null!; // null-forgiving: Set by Main
+namespace Yafc.UI;
+public class Font {
+    public static Font header { get; set; } = null!; // null-forgiving: Set by Main
+    public static Font subheader { get; set; } = null!; // null-forgiving: Set by Main
+    public static Font productionTableHeader { get; set; } = null!; // null-forgiving: Set by Main
+    public static Font text { get; set; } = null!; // null-forgiving: Set by Main
 
-        public readonly float size;
+    public readonly float size;
 
-        private readonly FontFile fontFile;
-        private FontFile.FontSize? lastFontSize;
+    private readonly FontFile fontFile;
+    private FontFile.FontSize? lastFontSize;
 
-        public FontFile.FontSize GetFontSize(float pixelsPreUnit) {
-            int actualSize = MathUtils.Round(pixelsPreUnit * size);
-            if (lastFontSize == null || lastFontSize.size != actualSize) {
-                lastFontSize = fontFile.GetFontForSize(actualSize);
-            }
-
-            return lastFontSize;
+    public FontFile.FontSize GetFontSize(float pixelsPreUnit) {
+        int actualSize = MathUtils.Round(pixelsPreUnit * size);
+        if (lastFontSize == null || lastFontSize.size != actualSize) {
+            lastFontSize = fontFile.GetFontForSize(actualSize);
         }
 
-        public IntPtr GetHandle(float pixelsPreUnit) => GetFontSize(pixelsPreUnit).handle;
-
-        public float GetLineSize(float pixelsPreUnit) => GetFontSize(pixelsPreUnit).lineSize / pixelsPreUnit;
-
-        public Font(FontFile file, float size) {
-            this.size = size;
-            fontFile = file;
-        }
-
-        public void Dispose() => fontFile.Dispose();
+        return lastFontSize;
     }
 
-    public class FontFile : IDisposable {
-        public readonly string fileName;
-        private readonly Dictionary<int, FontSize> sizes = [];
-        public FontFile(string fileName) => this.fileName = fileName;
+    public IntPtr GetHandle(float pixelsPreUnit) => GetFontSize(pixelsPreUnit).handle;
 
-        public class FontSize : UnmanagedResource {
-            public readonly int size;
-            public readonly int lineSize;
-            public FontSize(FontFile font, int size) {
-                this.size = size;
-                _handle = SDL_ttf.TTF_OpenFont(font.fileName, size);
-                lineSize = SDL_ttf.TTF_FontLineSkip(_handle);
-            }
+    public float GetLineSize(float pixelsPreUnit) => GetFontSize(pixelsPreUnit).lineSize / pixelsPreUnit;
 
-            public IntPtr handle => _handle;
-            protected override void ReleaseUnmanagedResources() => SDL_ttf.TTF_CloseFont(_handle);
+    public Font(FontFile file, float size) {
+        this.size = size;
+        fontFile = file;
+    }
+
+    public void Dispose() => fontFile.Dispose();
+}
+
+public class FontFile : IDisposable {
+    public readonly string fileName;
+    private readonly Dictionary<int, FontSize> sizes = [];
+    public FontFile(string fileName) => this.fileName = fileName;
+
+    public class FontSize : UnmanagedResource {
+        public readonly int size;
+        public readonly int lineSize;
+        public FontSize(FontFile font, int size) {
+            this.size = size;
+            _handle = SDL_ttf.TTF_OpenFont(font.fileName, size);
+            lineSize = SDL_ttf.TTF_FontLineSkip(_handle);
         }
 
-        public FontSize GetFontForSize(int size) {
-            if (sizes.TryGetValue(size, out var result)) {
-                return result;
-            }
+        public IntPtr handle => _handle;
+        protected override void ReleaseUnmanagedResources() => SDL_ttf.TTF_CloseFont(_handle);
+    }
 
-            return sizes[size] = new FontSize(this, size);
+    public FontSize GetFontForSize(int size) {
+        if (sizes.TryGetValue(size, out var result)) {
+            return result;
         }
 
-        public void Dispose() {
-            foreach (var (_, size) in sizes) {
-                size.Dispose();
-            }
+        return sizes[size] = new FontSize(this, size);
+    }
 
-            sizes.Clear();
+    public void Dispose() {
+        foreach (var (_, size) in sizes) {
+            size.Dispose();
         }
+
+        sizes.Clear();
     }
 }

--- a/Yafc.UI/Rendering/IconAtlas.cs
+++ b/Yafc.UI/Rendering/IconAtlas.cs
@@ -2,77 +2,76 @@
 using SDL2;
 using Serilog;
 
-namespace Yafc.UI {
-    public class IconAtlas {
-        private static readonly ILogger logger = Logging.GetLogger<IconAtlas>();
-        private IntPtr prevRender;
+namespace Yafc.UI;
+public class IconAtlas {
+    private static readonly ILogger logger = Logging.GetLogger<IconAtlas>();
+    private IntPtr prevRender;
 
-        private const int IconSize = IconCollection.IconSize;
-        private const int TextureSize = 2048;
-        private const int IconStride = IconSize + 1;
-        private const int IconsPerRow = TextureSize / IconStride;
-        private const int IconPerTexture = IconsPerRow * IconsPerRow;
+    private const int IconSize = IconCollection.IconSize;
+    private const int TextureSize = 2048;
+    private const int IconStride = IconSize + 1;
+    private const int IconsPerRow = TextureSize / IconStride;
+    private const int IconPerTexture = IconsPerRow * IconsPerRow;
 
-        private struct TextureInfo {
-            public TextureInfo(IntPtr texture) {
-                this.texture = texture;
-                existMap = new bool[IconPerTexture];
-                color = RenderingUtils.White;
-            }
-
-            public readonly IntPtr texture;
-            public readonly bool[] existMap;
-            public SDL.SDL_Color color;
+    private struct TextureInfo {
+        public TextureInfo(IntPtr texture) {
+            this.texture = texture;
+            existMap = new bool[IconPerTexture];
+            color = RenderingUtils.White;
         }
 
-        private TextureInfo[] textures = new TextureInfo[1];
+        public readonly IntPtr texture;
+        public readonly bool[] existMap;
+        public SDL.SDL_Color color;
+    }
 
-        public void DrawIcon(IntPtr renderer, Icon icon, SDL.SDL_Rect position, SDL.SDL_Color color) {
-            if (renderer != prevRender) {
-                Array.Clear(textures, 0, textures.Length);
-            }
-            prevRender = renderer;
-            int index = (int)icon;
-            ref var texture = ref textures[0];
-            int ix = index % IconsPerRow;
-            int iy = index / IconsPerRow;
-            if (index >= IconPerTexture) // That is very unlikely
-            {
-                int texId = index / IconPerTexture;
-                if (texId >= textures.Length) {
-                    Array.Resize(ref textures, texId + 1);
-                }
+    private TextureInfo[] textures = new TextureInfo[1];
 
-                index -= texId * IconPerTexture;
-                iy -= texId * IconsPerRow;
-                texture = ref textures[texId];
-            }
-            SDL.SDL_Rect rect = new SDL.SDL_Rect { x = ix * IconStride, y = iy * IconStride, w = IconSize, h = IconSize };
-            if (texture.texture == IntPtr.Zero) {
-                texture = new TextureInfo(SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_STATIC, TextureSize, TextureSize));
-                _ = SDL.SDL_SetTextureBlendMode(texture.texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
-            }
-            if (!texture.existMap[index]) {
-                nint iconSurfacePtr = IconCollection.GetIconSurface(icon);
-                if (iconSurfacePtr == IntPtr.Zero) {
-                    logger.Error("Non-existing icon: " + icon);
-                    return;
-                }
-                ref var iconSurface = ref RenderingUtils.AsSdlSurface(iconSurfacePtr);
-                texture.existMap[index] = true;
-                _ = SDL.SDL_UpdateTexture(texture.texture, ref rect, iconSurface.pixels, iconSurface.pitch);
-            }
-
-            if (texture.color.r != color.r || texture.color.g != color.g || texture.color.b != color.b) {
-                _ = SDL.SDL_SetTextureColorMod(texture.texture, color.r, color.g, color.b);
-            }
-
-            if (texture.color.a != color.a) {
-                _ = SDL.SDL_SetTextureAlphaMod(texture.texture, color.a);
-            }
-
-            texture.color = color;
-            _ = SDL.SDL_RenderCopy(renderer, texture.texture, ref rect, ref position);
+    public void DrawIcon(IntPtr renderer, Icon icon, SDL.SDL_Rect position, SDL.SDL_Color color) {
+        if (renderer != prevRender) {
+            Array.Clear(textures, 0, textures.Length);
         }
+        prevRender = renderer;
+        int index = (int)icon;
+        ref var texture = ref textures[0];
+        int ix = index % IconsPerRow;
+        int iy = index / IconsPerRow;
+        if (index >= IconPerTexture) // That is very unlikely
+        {
+            int texId = index / IconPerTexture;
+            if (texId >= textures.Length) {
+                Array.Resize(ref textures, texId + 1);
+            }
+
+            index -= texId * IconPerTexture;
+            iy -= texId * IconsPerRow;
+            texture = ref textures[texId];
+        }
+        SDL.SDL_Rect rect = new SDL.SDL_Rect { x = ix * IconStride, y = iy * IconStride, w = IconSize, h = IconSize };
+        if (texture.texture == IntPtr.Zero) {
+            texture = new TextureInfo(SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_STATIC, TextureSize, TextureSize));
+            _ = SDL.SDL_SetTextureBlendMode(texture.texture, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+        }
+        if (!texture.existMap[index]) {
+            nint iconSurfacePtr = IconCollection.GetIconSurface(icon);
+            if (iconSurfacePtr == IntPtr.Zero) {
+                logger.Error("Non-existing icon: " + icon);
+                return;
+            }
+            ref var iconSurface = ref RenderingUtils.AsSdlSurface(iconSurfacePtr);
+            texture.existMap[index] = true;
+            _ = SDL.SDL_UpdateTexture(texture.texture, ref rect, iconSurface.pixels, iconSurface.pitch);
+        }
+
+        if (texture.color.r != color.r || texture.color.g != color.g || texture.color.b != color.b) {
+            _ = SDL.SDL_SetTextureColorMod(texture.texture, color.r, color.g, color.b);
+        }
+
+        if (texture.color.a != color.a) {
+            _ = SDL.SDL_SetTextureAlphaMod(texture.texture, color.a);
+        }
+
+        texture.color = color;
+        _ = SDL.SDL_RenderCopy(renderer, texture.texture, ref rect, ref position);
     }
 }

--- a/Yafc.UI/Rendering/RenderingUtils.cs
+++ b/Yafc.UI/Rendering/RenderingUtils.cs
@@ -3,161 +3,160 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using SDL2;
 
-namespace Yafc.UI {
-    public static class RenderingUtils {
-        public static readonly IntPtr cursorCaret = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_IBEAM);
-        public static readonly IntPtr cursorArrow = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_ARROW);
-        public static readonly IntPtr cursorHand = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_HAND);
-        public static readonly IntPtr cursorHorizontalResize = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZEWE);
-        public const byte SEMITRANSPARENT = 100;
+namespace Yafc.UI;
+public static class RenderingUtils {
+    public static readonly IntPtr cursorCaret = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_IBEAM);
+    public static readonly IntPtr cursorArrow = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_ARROW);
+    public static readonly IntPtr cursorHand = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_HAND);
+    public static readonly IntPtr cursorHorizontalResize = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZEWE);
+    public const byte SEMITRANSPARENT = 100;
 
-        private static SDL.SDL_Color ColorFromHex(int hex) => new SDL.SDL_Color { r = (byte)(hex >> 16), g = (byte)(hex >> 8), b = (byte)hex, a = 255 };
+    private static SDL.SDL_Color ColorFromHex(int hex) => new SDL.SDL_Color { r = (byte)(hex >> 16), g = (byte)(hex >> 8), b = (byte)hex, a = 255 };
 
-        public static readonly SDL.SDL_Color Black = new SDL.SDL_Color { a = 255 };
-        public static readonly SDL.SDL_Color White = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
-        public static readonly SDL.SDL_Color BlackTransparent = new SDL.SDL_Color { a = SEMITRANSPARENT };
-        public static readonly SDL.SDL_Color WhiteTransparent = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = SEMITRANSPARENT };
+    public static readonly SDL.SDL_Color Black = new SDL.SDL_Color { a = 255 };
+    public static readonly SDL.SDL_Color White = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
+    public static readonly SDL.SDL_Color BlackTransparent = new SDL.SDL_Color { a = SEMITRANSPARENT };
+    public static readonly SDL.SDL_Color WhiteTransparent = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = SEMITRANSPARENT };
 
-        public static SchemeColor GetTextColorFromBackgroundColor(SchemeColor color) => (SchemeColor)((int)color & ~3) + 2;
+    public static SchemeColor GetTextColorFromBackgroundColor(SchemeColor color) => (SchemeColor)((int)color & ~3) + 2;
 
-        private static readonly SDL.SDL_Color[] LightModeScheme = {
-            default, new SDL.SDL_Color {b = 255, g = 128, a = 60}, ColorFromHex(0x0645AD), ColorFromHex(0x1b5e20), // Special group
-            White, Black, White, WhiteTransparent, // pure group
-            
-            ColorFromHex(0xf4f4f4), White, Black, BlackTransparent, // Background group 
-            ColorFromHex(0x26c6da), ColorFromHex(0x0095a8), Black, BlackTransparent, // Primary group
-            ColorFromHex(0xff9800), ColorFromHex(0xc66900), Black, BlackTransparent, // Secondary group
-            ColorFromHex(0xbf360c), ColorFromHex(0x870000), White, WhiteTransparent, // Error group
-            ColorFromHex(0xe4e4e4), ColorFromHex(0xc4c4c4), Black, BlackTransparent, // Grey group
-            ColorFromHex(0xbd33a4), ColorFromHex(0x8b008b), Black, BlackTransparent, // Magenta group
-            ColorFromHex(0x6abf69), ColorFromHex(0x388e3c), Black, BlackTransparent, // Green group
+    private static readonly SDL.SDL_Color[] LightModeScheme = {
+        default, new SDL.SDL_Color {b = 255, g = 128, a = 60}, ColorFromHex(0x0645AD), ColorFromHex(0x1b5e20), // Special group
+        White, Black, White, WhiteTransparent, // pure group
 
-            // Row highlighting colors (background, background alt, text, text alt)
-            ColorFromHex(0xe8ffe8), ColorFromHex(0xefffef), ColorFromHex(0x56ad65), ColorFromHex(0x0), // Green
-            ColorFromHex(0xffffe8), ColorFromHex(0xffffef), ColorFromHex(0x8c8756), ColorFromHex(0x0), // Yellow
-            ColorFromHex(0xffe8e8), ColorFromHex(0xffefef), ColorFromHex(0xaa5555), ColorFromHex(0x0), // Red
-            ColorFromHex(0xe8efff), ColorFromHex(0xeff4ff), ColorFromHex(0x526ea5), ColorFromHex(0x0), // Blue
-        };
+        ColorFromHex(0xf4f4f4), White, Black, BlackTransparent, // Background group
+        ColorFromHex(0x26c6da), ColorFromHex(0x0095a8), Black, BlackTransparent, // Primary group
+        ColorFromHex(0xff9800), ColorFromHex(0xc66900), Black, BlackTransparent, // Secondary group
+        ColorFromHex(0xbf360c), ColorFromHex(0x870000), White, WhiteTransparent, // Error group
+        ColorFromHex(0xe4e4e4), ColorFromHex(0xc4c4c4), Black, BlackTransparent, // Grey group
+        ColorFromHex(0xbd33a4), ColorFromHex(0x8b008b), Black, BlackTransparent, // Magenta group
+        ColorFromHex(0x6abf69), ColorFromHex(0x388e3c), Black, BlackTransparent, // Green group
 
-        private static readonly SDL.SDL_Color[] DarkModeScheme = {
-            default, new SDL.SDL_Color {b = 255, g = 128, a = 120}, ColorFromHex(0xff9800), ColorFromHex(0x1b5e20), // Special group
-            Black, White, White, WhiteTransparent, // pure group
+        // Row highlighting colors (background, background alt, text, text alt)
+        ColorFromHex(0xe8ffe8), ColorFromHex(0xefffef), ColorFromHex(0x56ad65), ColorFromHex(0x0), // Green
+        ColorFromHex(0xffffe8), ColorFromHex(0xffffef), ColorFromHex(0x8c8756), ColorFromHex(0x0), // Yellow
+        ColorFromHex(0xffe8e8), ColorFromHex(0xffefef), ColorFromHex(0xaa5555), ColorFromHex(0x0), // Red
+        ColorFromHex(0xe8efff), ColorFromHex(0xeff4ff), ColorFromHex(0x526ea5), ColorFromHex(0x0), // Blue
+    };
 
-            ColorFromHex(0x141414), Black, White, WhiteTransparent, // Background group 
-            ColorFromHex(0x006978), ColorFromHex(0x0097a7), White, WhiteTransparent, // Primary group
-            ColorFromHex(0x5b2800), ColorFromHex(0x8c5100), White, WhiteTransparent, // Secondary group
-            ColorFromHex(0xbf360c), ColorFromHex(0x870000), White, WhiteTransparent, // Error group
-            ColorFromHex(0x343434), ColorFromHex(0x545454), White, WhiteTransparent, // Grey group
-            ColorFromHex(0x8b008b), ColorFromHex(0xbd33a4), Black, BlackTransparent, // Magenta group
-            ColorFromHex(0x00600f), ColorFromHex(0x00701a), Black, BlackTransparent, // Green group
+    private static readonly SDL.SDL_Color[] DarkModeScheme = {
+        default, new SDL.SDL_Color {b = 255, g = 128, a = 120}, ColorFromHex(0xff9800), ColorFromHex(0x1b5e20), // Special group
+        Black, White, White, WhiteTransparent, // pure group
 
-            // Row highlighting colors (background, background alt, text, text alt)
-            ColorFromHex(0x0d261f), ColorFromHex(0x050f0c), ColorFromHex(0x226355), ColorFromHex(0x0), // Green
-            ColorFromHex(0x28260b), ColorFromHex(0x191807), ColorFromHex(0x5b582a), ColorFromHex(0x0), // Yellow
-            ColorFromHex(0x270c0c), ColorFromHex(0x190808), ColorFromHex(0x922626), ColorFromHex(0x0), // Red
-            ColorFromHex(0x0c0c27), ColorFromHex(0x080819), ColorFromHex(0x2626ab), ColorFromHex(0x0)  // Blue
-        };
+        ColorFromHex(0x141414), Black, White, WhiteTransparent, // Background group
+        ColorFromHex(0x006978), ColorFromHex(0x0097a7), White, WhiteTransparent, // Primary group
+        ColorFromHex(0x5b2800), ColorFromHex(0x8c5100), White, WhiteTransparent, // Secondary group
+        ColorFromHex(0xbf360c), ColorFromHex(0x870000), White, WhiteTransparent, // Error group
+        ColorFromHex(0x343434), ColorFromHex(0x545454), White, WhiteTransparent, // Grey group
+        ColorFromHex(0x8b008b), ColorFromHex(0xbd33a4), Black, BlackTransparent, // Magenta group
+        ColorFromHex(0x00600f), ColorFromHex(0x00701a), Black, BlackTransparent, // Green group
 
-        private static SDL.SDL_Color[] SchemeColors = LightModeScheme;
+        // Row highlighting colors (background, background alt, text, text alt)
+        ColorFromHex(0x0d261f), ColorFromHex(0x050f0c), ColorFromHex(0x226355), ColorFromHex(0x0), // Green
+        ColorFromHex(0x28260b), ColorFromHex(0x191807), ColorFromHex(0x5b582a), ColorFromHex(0x0), // Yellow
+        ColorFromHex(0x270c0c), ColorFromHex(0x190808), ColorFromHex(0x922626), ColorFromHex(0x0), // Red
+        ColorFromHex(0x0c0c27), ColorFromHex(0x080819), ColorFromHex(0x2626ab), ColorFromHex(0x0)  // Blue
+    };
 
-        public static void SetColorScheme(bool darkMode) {
-            RenderingUtils.darkMode = darkMode;
-            SchemeColors = darkMode ? DarkModeScheme : LightModeScheme;
-            byte col = darkMode ? (byte)0 : (byte)255;
-            _ = SDL.SDL_SetSurfaceColorMod(CircleSurface, col, col, col);
-        }
+    private static SDL.SDL_Color[] SchemeColors = LightModeScheme;
 
-        public static SDL.SDL_Color ToSdlColor(this SchemeColor color) => SchemeColors[(int)color];
+    public static void SetColorScheme(bool darkMode) {
+        RenderingUtils.darkMode = darkMode;
+        SchemeColors = darkMode ? DarkModeScheme : LightModeScheme;
+        byte col = darkMode ? (byte)0 : (byte)255;
+        _ = SDL.SDL_SetSurfaceColorMod(CircleSurface, col, col, col);
+    }
 
-        public static unsafe ref SDL.SDL_Surface AsSdlSurface(IntPtr ptr) => ref Unsafe.AsRef<SDL.SDL_Surface>((void*)ptr);
+    public static SDL.SDL_Color ToSdlColor(this SchemeColor color) => SchemeColors[(int)color];
 
-        public static readonly IntPtr CircleSurface;
-        private static readonly SDL.SDL_Rect CircleTopLeft, CircleTopRight, CircleBottomLeft, CircleBottomRight, CircleTop, CircleBottom, CircleLeft, CircleRight;
-        public static bool darkMode { get; private set; }
+    public static unsafe ref SDL.SDL_Surface AsSdlSurface(IntPtr ptr) => ref Unsafe.AsRef<SDL.SDL_Surface>((void*)ptr);
 
-        static unsafe RenderingUtils() {
-            nint surfacePtr = SDL.SDL_CreateRGBSurfaceWithFormat(0, 32, 32, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
-            ref var surface = ref AsSdlSurface(surfacePtr);
+    public static readonly IntPtr CircleSurface;
+    private static readonly SDL.SDL_Rect CircleTopLeft, CircleTopRight, CircleBottomLeft, CircleBottomRight, CircleTop, CircleBottom, CircleLeft, CircleRight;
+    public static bool darkMode { get; private set; }
 
-            const int circleSize = 32;
-            const float center = (circleSize - 1) / 2f;
+    static unsafe RenderingUtils() {
+        nint surfacePtr = SDL.SDL_CreateRGBSurfaceWithFormat(0, 32, 32, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
+        ref var surface = ref AsSdlSurface(surfacePtr);
 
-            uint* pixels = (uint*)surface.pixels;
-            for (int x = 0; x < 32; x++) {
-                for (int y = 0; y < 32; y++) {
-                    float dx = (center - x) / center;
-                    float dy = (center - y) / center;
-                    float dist = MathF.Sqrt((dx * dx) + (dy * dy));
-                    *pixels++ = 0xFFFFFF00 | (dist >= 1f ? 0 : (uint)MathUtils.Round(38 * (1f - dist)));
-                }
-            }
+        const int circleSize = 32;
+        const float center = (circleSize - 1) / 2f;
 
-            const int halfCircle = (circleSize / 2) - 1;
-            const int halfStride = circleSize - halfCircle;
-
-            CircleTopLeft = new SDL.SDL_Rect { x = 0, y = 0, w = halfCircle, h = halfCircle };
-            CircleTopRight = new SDL.SDL_Rect { x = halfStride, y = 0, w = halfCircle, h = halfCircle };
-            CircleBottomLeft = new SDL.SDL_Rect { x = 0, y = halfStride, w = halfCircle, h = halfCircle };
-            CircleBottomRight = new SDL.SDL_Rect { x = halfStride, y = halfStride, w = halfCircle, h = halfCircle };
-            CircleTop = new SDL.SDL_Rect { x = halfCircle, y = 0, w = 2, h = halfCircle };
-            CircleBottom = new SDL.SDL_Rect { x = halfCircle, y = halfStride, w = 2, h = halfCircle };
-            CircleLeft = new SDL.SDL_Rect { x = 0, y = halfCircle, w = halfCircle, h = 2 };
-            CircleRight = new SDL.SDL_Rect { x = halfStride, y = halfCircle, w = halfCircle, h = 2 };
-            CircleSurface = surfacePtr;
-            _ = SDL.SDL_SetSurfaceColorMod(CircleSurface, 0, 0, 0);
-        }
-
-        public struct BlitMapping {
-            public SDL.SDL_Rect position;
-            public SDL.SDL_Rect texture;
-
-            public BlitMapping(SDL.SDL_Rect texture, SDL.SDL_Rect position) {
-                this.texture = texture;
-                this.position = position;
+        uint* pixels = (uint*)surface.pixels;
+        for (int x = 0; x < 32; x++) {
+            for (int y = 0; y < 32; y++) {
+                float dx = (center - x) / center;
+                float dy = (center - y) / center;
+                float dist = MathF.Sqrt((dx * dx) + (dy * dy));
+                *pixels++ = 0xFFFFFF00 | (dist >= 1f ? 0 : (uint)MathUtils.Round(38 * (1f - dist)));
             }
         }
 
-        public static void GetBorderParameters(float unitsToPixels, RectangleBorder border, out int top, out int side, out int bottom) {
-            if (border == RectangleBorder.Full) {
-                top = MathUtils.Round(unitsToPixels * 0.5f);
-                side = MathUtils.Round(unitsToPixels);
-                bottom = MathUtils.Round(unitsToPixels * 2f);
-            }
-            else {
-                top = MathUtils.Round(unitsToPixels * 0.2f);
-                side = MathUtils.Round(unitsToPixels * 0.3f);
-                bottom = MathUtils.Round(unitsToPixels * 0.5f);
-            }
+        const int halfCircle = (circleSize / 2) - 1;
+        const int halfStride = circleSize - halfCircle;
+
+        CircleTopLeft = new SDL.SDL_Rect { x = 0, y = 0, w = halfCircle, h = halfCircle };
+        CircleTopRight = new SDL.SDL_Rect { x = halfStride, y = 0, w = halfCircle, h = halfCircle };
+        CircleBottomLeft = new SDL.SDL_Rect { x = 0, y = halfStride, w = halfCircle, h = halfCircle };
+        CircleBottomRight = new SDL.SDL_Rect { x = halfStride, y = halfStride, w = halfCircle, h = halfCircle };
+        CircleTop = new SDL.SDL_Rect { x = halfCircle, y = 0, w = 2, h = halfCircle };
+        CircleBottom = new SDL.SDL_Rect { x = halfCircle, y = halfStride, w = 2, h = halfCircle };
+        CircleLeft = new SDL.SDL_Rect { x = 0, y = halfCircle, w = halfCircle, h = 2 };
+        CircleRight = new SDL.SDL_Rect { x = halfStride, y = halfCircle, w = halfCircle, h = 2 };
+        CircleSurface = surfacePtr;
+        _ = SDL.SDL_SetSurfaceColorMod(CircleSurface, 0, 0, 0);
+    }
+
+    public struct BlitMapping {
+        public SDL.SDL_Rect position;
+        public SDL.SDL_Rect texture;
+
+        public BlitMapping(SDL.SDL_Rect texture, SDL.SDL_Rect position) {
+            this.texture = texture;
+            this.position = position;
+        }
+    }
+
+    public static void GetBorderParameters(float unitsToPixels, RectangleBorder border, out int top, out int side, out int bottom) {
+        if (border == RectangleBorder.Full) {
+            top = MathUtils.Round(unitsToPixels * 0.5f);
+            side = MathUtils.Round(unitsToPixels);
+            bottom = MathUtils.Round(unitsToPixels * 2f);
+        }
+        else {
+            top = MathUtils.Round(unitsToPixels * 0.2f);
+            side = MathUtils.Round(unitsToPixels * 0.3f);
+            bottom = MathUtils.Round(unitsToPixels * 0.5f);
+        }
+    }
+
+    public static void GetBorderBatch(SDL.SDL_Rect position, int shadowTop, int shadowSide, int shadowBottom, [NotNull] ref BlitMapping[]? result) {
+        if (result == null || result.Length != 8) {
+            Array.Resize(ref result, 8);
         }
 
-        public static void GetBorderBatch(SDL.SDL_Rect position, int shadowTop, int shadowSide, int shadowBottom, [NotNull] ref BlitMapping[]? result) {
-            if (result == null || result.Length != 8) {
-                Array.Resize(ref result, 8);
-            }
-
-            SDL.SDL_Rect rect = new SDL.SDL_Rect { h = shadowTop, x = position.x - shadowSide, y = position.y - shadowTop, w = shadowSide };
-            result[0] = new BlitMapping(CircleTopLeft, rect);
-            rect.x = position.x;
-            rect.w = position.w;
-            result[1] = new BlitMapping(CircleTop, rect);
-            rect.x += rect.w;
-            rect.w = shadowSide;
-            result[2] = new BlitMapping(CircleTopRight, rect);
-            rect.y = position.y;
-            rect.h = position.h;
-            result[3] = new BlitMapping(CircleRight, rect);
-            rect.y += rect.h;
-            rect.h = shadowBottom;
-            result[4] = new BlitMapping(CircleBottomRight, rect);
-            rect.x = position.x;
-            rect.w = position.w;
-            result[5] = new BlitMapping(CircleBottom, rect);
-            rect.x -= shadowSide;
-            rect.w = shadowSide;
-            result[6] = new BlitMapping(CircleBottomLeft, rect);
-            rect.y = position.y;
-            rect.h = position.h;
-            result[7] = new BlitMapping(CircleLeft, rect);
-        }
+        SDL.SDL_Rect rect = new SDL.SDL_Rect { h = shadowTop, x = position.x - shadowSide, y = position.y - shadowTop, w = shadowSide };
+        result[0] = new BlitMapping(CircleTopLeft, rect);
+        rect.x = position.x;
+        rect.w = position.w;
+        result[1] = new BlitMapping(CircleTop, rect);
+        rect.x += rect.w;
+        rect.w = shadowSide;
+        result[2] = new BlitMapping(CircleTopRight, rect);
+        rect.y = position.y;
+        rect.h = position.h;
+        result[3] = new BlitMapping(CircleRight, rect);
+        rect.y += rect.h;
+        rect.h = shadowBottom;
+        result[4] = new BlitMapping(CircleBottomRight, rect);
+        rect.x = position.x;
+        rect.w = position.w;
+        result[5] = new BlitMapping(CircleBottom, rect);
+        rect.x -= shadowSide;
+        rect.w = shadowSide;
+        result[6] = new BlitMapping(CircleBottomLeft, rect);
+        rect.y = position.y;
+        rect.h = position.h;
+        result[7] = new BlitMapping(CircleLeft, rect);
     }
 }

--- a/Yafc.UI/Rendering/UnmanagedResource.cs
+++ b/Yafc.UI/Rendering/UnmanagedResource.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 
-namespace Yafc.UI {
-    public abstract class UnmanagedResource : IDisposable {
-        protected IntPtr _handle;
+namespace Yafc.UI;
+public abstract class UnmanagedResource : IDisposable {
+    protected IntPtr _handle;
 
-        protected abstract void ReleaseUnmanagedResources();
+    protected abstract void ReleaseUnmanagedResources();
 
-        public void Dispose() {
-            if (_handle != IntPtr.Zero) {
-                ReleaseUnmanagedResources();
-                _handle = IntPtr.Zero;
-                GC.SuppressFinalize(this);
-            }
-        }
-
-        ~UnmanagedResource() {
+    public void Dispose() {
+        if (_handle != IntPtr.Zero) {
             ReleaseUnmanagedResources();
+            _handle = IntPtr.Zero;
+            GC.SuppressFinalize(this);
         }
+    }
+
+    ~UnmanagedResource() {
+        ReleaseUnmanagedResources();
     }
 }

--- a/Yafc/Data/Sandbox.lua
+++ b/Yafc/Data/Sandbox.lua
@@ -37,7 +37,7 @@ end
 
 local raw_log = _G.raw_log;
 _G.raw_log = nil;
-function log(s) 
+function log(s)
 	if type(s) ~= "string" then s = serpent.block(s) end;
 	raw_log(s);
 end

--- a/Yafc/Program.cs
+++ b/Yafc/Program.cs
@@ -3,50 +3,49 @@ using System.IO;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public static class Program {
-        public static bool hasOverriddenFont;
+namespace Yafc;
+public static class Program {
+    public static bool hasOverriddenFont;
 
-        private static void Main(string[] args) {
-            YafcLib.RegisterDefaultAnalysis();
-            Ui.Start();
-            string? overrideFont = Preferences.Instance.overrideFont;
-            FontFile? overriddenFontFile = null;
+    private static void Main(string[] args) {
+        YafcLib.RegisterDefaultAnalysis();
+        Ui.Start();
+        string? overrideFont = Preferences.Instance.overrideFont;
+        FontFile? overriddenFontFile = null;
 
-            try {
-                if (!string.IsNullOrEmpty(overrideFont) && File.Exists(overrideFont)) {
-                    overriddenFontFile = new FontFile(overrideFont);
-                }
+        try {
+            if (!string.IsNullOrEmpty(overrideFont) && File.Exists(overrideFont)) {
+                overriddenFontFile = new FontFile(overrideFont);
             }
-            catch (Exception ex) {
-                Console.Error.WriteException(ex);
-            }
+        }
+        catch (Exception ex) {
+            Console.Error.WriteException(ex);
+        }
 
-            hasOverriddenFont = overriddenFontFile != null;
-            Font.header = new Font(overriddenFontFile ?? new FontFile("Data/Roboto-Light.ttf"), 2f);
-            var regular = overriddenFontFile ?? new FontFile("Data/Roboto-Regular.ttf");
-            Font.subheader = new Font(regular, 1.5f);
-            Font.productionTableHeader = new Font(regular, 1.23f);
-            Font.text = new Font(regular, 1f);
+        hasOverriddenFont = overriddenFontFile != null;
+        Font.header = new Font(overriddenFontFile ?? new FontFile("Data/Roboto-Light.ttf"), 2f);
+        var regular = overriddenFontFile ?? new FontFile("Data/Roboto-Regular.ttf");
+        Font.subheader = new Font(regular, 1.5f);
+        Font.productionTableHeader = new Font(regular, 1.23f);
+        Font.text = new Font(regular, 1f);
 
-            ProjectDefinition? cliProject = CommandLineParser.ParseArgs(args);
+        ProjectDefinition? cliProject = CommandLineParser.ParseArgs(args);
 
-            if (CommandLineParser.errorOccured || CommandLineParser.helpRequested) {
-                Console.WriteLine("YAFC CE v" + YafcLib.version.ToString(3));
+        if (CommandLineParser.errorOccured || CommandLineParser.helpRequested) {
+            Console.WriteLine("YAFC CE v" + YafcLib.version.ToString(3));
+            Console.WriteLine();
+
+            if (CommandLineParser.errorOccured) {
+                Console.WriteLine($"Error: {CommandLineParser.lastError}");
                 Console.WriteLine();
-
-                if (CommandLineParser.errorOccured) {
-                    Console.WriteLine($"Error: {CommandLineParser.lastError}");
-                    Console.WriteLine();
-                    Environment.ExitCode = 1;
-                }
-
-                CommandLineParser.PrintHelp();
+                Environment.ExitCode = 1;
             }
-            else {
-                _ = new WelcomeScreen(cliProject);
-                Ui.MainLoop();
-            }
+
+            CommandLineParser.PrintHelp();
+        }
+        else {
+            _ = new WelcomeScreen(cliProject);
+            Ui.MainLoop();
         }
     }
 }

--- a/Yafc/Utils/CommandLineParser.cs
+++ b/Yafc/Utils/CommandLineParser.cs
@@ -2,93 +2,93 @@
 using System.IO;
 using System.Linq;
 
-namespace Yafc {
-    /// <summary>
-    /// The role of this class is to handle things related to launching Yafc from the command line.<br/>
-    /// That includes handling Windows commands after associating the Yafc executable with <c>.yafc</c> files,<br/> 
-    /// because Windows essentially runs <c>./Yafc.exe path/to/file </c> when you click on the file or use the 
-    /// Open-With functionality.
-    /// </summary>
-    public static class CommandLineParser {
-        public static string lastError { get; private set; } = string.Empty;
-        public static bool helpRequested { get; private set; }
+namespace Yafc;
+/// <summary>
+/// The role of this class is to handle things related to launching Yafc from the command line.<br/>
+/// That includes handling Windows commands after associating the Yafc executable with <c>.yafc</c> files,<br/>
+/// because Windows essentially runs <c>./Yafc.exe path/to/file </c> when you click on the file or use the
+/// Open-With functionality.
+/// </summary>
+public static class CommandLineParser {
+    public static string lastError { get; private set; } = string.Empty;
+    public static bool helpRequested { get; private set; }
 
-        public static bool errorOccured => !string.IsNullOrEmpty(lastError);
+    public static bool errorOccured => !string.IsNullOrEmpty(lastError);
 
-        public static ProjectDefinition? ParseArgs(string[] args) {
-            ProjectDefinition projectDefinition = new ProjectDefinition();
+    public static ProjectDefinition? ParseArgs(string[] args) {
+        ProjectDefinition projectDefinition = new ProjectDefinition();
 
-            if (args.Length == 0) {
-                return projectDefinition;
-            }
-
-            if (args.Length == 1 && !args[0].StartsWith("--")) {
-                return LoadProjectFromPath(Path.GetFullPath(args[0]));
-            }
-
-            if (!args[0].StartsWith("--")) {
-                projectDefinition.dataPath = args[0];
-                if (!Directory.Exists(projectDefinition.dataPath)) {
-                    lastError = $"Data path '{projectDefinition.dataPath}' does not exist.";
-                    return null;
-                }
-            }
-
-            for (int i = string.IsNullOrEmpty(projectDefinition.dataPath) ? 0 : 1; i < args.Length; i++) {
-                switch (args[i]) {
-                    case "--mods-path":
-                        if (i + 1 < args.Length && !IsKnownParameter(args[i + 1])) {
-                            projectDefinition.modsPath = args[++i];
-
-                            if (!Directory.Exists(projectDefinition.modsPath)) {
-                                lastError = $"Mods path '{projectDefinition.modsPath}' does not exist.";
-                                return null;
-                            }
-                        }
-                        else {
-                            lastError = "Missing argument for --mods-path.";
-                            return null;
-                        }
-                        break;
-
-                    case "--project-file":
-                        if (i + 1 < args.Length && !IsKnownParameter(args[i + 1])) {
-                            projectDefinition.path = args[++i];
-                            string? directory = Path.GetDirectoryName(projectDefinition.path);
-
-                            if (!Directory.Exists(directory)) {
-                                lastError = $"Project directory for '{projectDefinition.path}' does not exist.";
-                                return null;
-                            }
-                        }
-                        else {
-                            lastError = "Missing argument for --project-file.";
-                            return null;
-                        }
-                        break;
-
-                    case "--expensive":
-                        projectDefinition.expensive = true;
-                        break;
-
-                    case "--net-production":
-                        projectDefinition.netProduction = true;
-                        break;
-
-                    case "--help":
-                        helpRequested = true;
-                        break;
-
-                    default:
-                        lastError = $"Unknown argument '{args[i]}'.";
-                        return null;
-                }
-            }
-
+        if (args.Length == 0) {
             return projectDefinition;
         }
 
-        public static void PrintHelp() => Console.WriteLine(@"Usage:
+        if (args.Length == 1 && !args[0].StartsWith("--")) {
+            return LoadProjectFromPath(Path.GetFullPath(args[0]));
+        }
+
+        if (!args[0].StartsWith("--")) {
+            projectDefinition.dataPath = args[0];
+            if (!Directory.Exists(projectDefinition.dataPath)) {
+                lastError = $"Data path '{projectDefinition.dataPath}' does not exist.";
+                return null;
+            }
+        }
+
+        for (int i = string.IsNullOrEmpty(projectDefinition.dataPath) ? 0 : 1; i < args.Length; i++) {
+            switch (args[i]) {
+                case "--mods-path":
+                    if (i + 1 < args.Length && !IsKnownParameter(args[i + 1])) {
+                        projectDefinition.modsPath = args[++i];
+
+                        if (!Directory.Exists(projectDefinition.modsPath)) {
+                            lastError = $"Mods path '{projectDefinition.modsPath}' does not exist.";
+                            return null;
+                        }
+                    }
+                    else {
+                        lastError = "Missing argument for --mods-path.";
+                        return null;
+                    }
+                    break;
+
+                case "--project-file":
+                    if (i + 1 < args.Length && !IsKnownParameter(args[i + 1])) {
+                        projectDefinition.path = args[++i];
+                        string? directory = Path.GetDirectoryName(projectDefinition.path);
+
+                        if (!Directory.Exists(directory)) {
+                            lastError = $"Project directory for '{projectDefinition.path}' does not exist.";
+                            return null;
+                        }
+                    }
+                    else {
+                        lastError = "Missing argument for --project-file.";
+                        return null;
+                    }
+                    break;
+
+                case "--expensive":
+                    projectDefinition.expensive = true;
+                    break;
+
+                case "--net-production":
+                    projectDefinition.netProduction = true;
+                    break;
+
+                case "--help":
+                    helpRequested = true;
+                    break;
+
+                default:
+                    lastError = $"Unknown argument '{args[i]}'.";
+                    return null;
+            }
+        }
+
+        return projectDefinition;
+    }
+
+    public static void PrintHelp() => Console.WriteLine(@"Usage:
 Yafc [<data-path> [--mods-path <path>] [--project-file <path>] [--expensive]] [--help]
 
 Description:
@@ -138,30 +138,29 @@ Examples:
        data and mods directories. Fails if any of the directories and/or the project file
        do not exist.");
 
-        /// <summary>
-        /// Loads the project from the given path. <br/>
-        /// If the project has not been opened before, then fetches other settings (like mods-folder) from the most-recently opened project.
-        /// </summary>
-        private static ProjectDefinition? LoadProjectFromPath(string fullPathToProject) {
-            // Putting this part as a separate method makes reading the parent method easier.
+    /// <summary>
+    /// Loads the project from the given path. <br/>
+    /// If the project has not been opened before, then fetches other settings (like mods-folder) from the most-recently opened project.
+    /// </summary>
+    private static ProjectDefinition? LoadProjectFromPath(string fullPathToProject) {
+        // Putting this part as a separate method makes reading the parent method easier.
 
-            bool previouslyOpenedProjectMatcher(ProjectDefinition candidate) {
-                bool pathIsNotEmpty = !string.IsNullOrEmpty(candidate.path);
+        bool previouslyOpenedProjectMatcher(ProjectDefinition candidate) {
+            bool pathIsNotEmpty = !string.IsNullOrEmpty(candidate.path);
 
-                return pathIsNotEmpty && string.Equals(fullPathToProject, Path.GetFullPath(candidate.path!), StringComparison.OrdinalIgnoreCase);
-            }
-
-            ProjectDefinition[] recentProjects = Preferences.Instance.recentProjects;
-            ProjectDefinition? projectToOpen = recentProjects.FirstOrDefault(previouslyOpenedProjectMatcher);
-
-            if (projectToOpen == null && recentProjects.Length > 0) {
-                ProjectDefinition donor = recentProjects[0];
-                projectToOpen = new ProjectDefinition(donor.dataPath, donor.modsPath, fullPathToProject, donor.expensive, donor.netProduction);
-            }
-
-            return projectToOpen;
+            return pathIsNotEmpty && string.Equals(fullPathToProject, Path.GetFullPath(candidate.path!), StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsKnownParameter(string arg) => arg is "--mods-path" or "--project-file" or "--expensive" or "--help";
+        ProjectDefinition[] recentProjects = Preferences.Instance.recentProjects;
+        ProjectDefinition? projectToOpen = recentProjects.FirstOrDefault(previouslyOpenedProjectMatcher);
+
+        if (projectToOpen == null && recentProjects.Length > 0) {
+            ProjectDefinition donor = recentProjects[0];
+            projectToOpen = new ProjectDefinition(donor.dataPath, donor.modsPath, fullPathToProject, donor.expensive, donor.netProduction);
+        }
+
+        return projectToOpen;
     }
+
+    private static bool IsKnownParameter(string arg) => arg is "--mods-path" or "--project-file" or "--expensive" or "--help";
 }

--- a/Yafc/Utils/Preferences.cs
+++ b/Yafc/Utils/Preferences.cs
@@ -5,128 +5,127 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using Yafc.Model;
 
-namespace Yafc {
-    public class Preferences {
-        public static readonly Preferences Instance;
-        public static readonly string appDataFolder;
-        private static readonly string fileName;
+namespace Yafc;
+public class Preferences {
+    public static readonly Preferences Instance;
+    public static readonly string appDataFolder;
+    private static readonly string fileName;
 
-        public static readonly string autosaveFilename;
+    public static readonly string autosaveFilename;
 
-        static Preferences() {
-            appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                appDataFolder = Path.Combine(appDataFolder, "YAFC");
-            }
-
-            if (!string.IsNullOrEmpty(appDataFolder) && !Directory.Exists(appDataFolder)) {
-                _ = Directory.CreateDirectory(appDataFolder);
-            }
-
-            autosaveFilename = Path.Combine(appDataFolder, "autosave.yafc");
-            fileName = Path.Combine(appDataFolder, "yafc.config");
-            if (File.Exists(fileName)) {
-                try {
-                    Instance = JsonSerializer.Deserialize<Preferences>(File.ReadAllBytes(fileName))!;
-                    return;
-                }
-                catch (Exception ex) {
-                    Console.Error.WriteException(ex);
-                }
-            }
-            Instance = new Preferences();
+    static Preferences() {
+        appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            appDataFolder = Path.Combine(appDataFolder, "YAFC");
         }
 
-        public void Save() {
-            byte[] data = JsonSerializer.SerializeToUtf8Bytes(this, JsonUtils.DefaultOptions);
-            File.WriteAllBytes(fileName, data);
+        if (!string.IsNullOrEmpty(appDataFolder) && !Directory.Exists(appDataFolder)) {
+            _ = Directory.CreateDirectory(appDataFolder);
         }
-        public ProjectDefinition[] recentProjects { get; set; } = [];
-        public bool darkMode { get; set; }
-        public string language { get; set; } = "en";
-        public string? overrideFont { get; set; }
-        /// <summary>
-        /// Whether or not the main screen should be created maximized.
-        /// </summary>
-        public bool maximizeMainScreen { get; set; }
-        /// <summary>
-        /// The initial width of the main screen or the width the main screen will be after being restored, depending on whether it starts restored or maximized.
-        /// </summary>
-        public float initialMainScreenWidth { get; set; }
-        /// <summary>
-        /// The initial height of the main screen or the height the main screen will be after being restored, depending on whether it starts restored or maximized.
-        /// </summary>
-        public float initialMainScreenHeight { get; set; }
-        public float recipeColumnWidth { get; set; }
-        public float ingredientsColumWidth { get; set; }
-        public float productsColumWidth { get; set; }
-        public float modulesColumnWidth { get; set; }
-        /// <summary>
-        /// Set to always use a software renderer even where we'd normally use a hardware renderer if you know that we make bad decisions about hardware renderers for your system.
-        /// 
-        /// The current known cases in which you should do this are:
-        /// - Your system has a very old graphics card that is not supported by Windows DX12
-        /// </summary>
-        public bool forceSoftwareRenderer { get; set; } = false;
-        /// <summary>
-        /// An opaque integer that the shopping list uses to store its display options. See the ShoppingListScreen properties that read and write this value.
-        /// </summary>
-        public int shoppingDisplayState { get; set; } = 3;
 
-        public void AddProject(string dataPath, string modsPath, string projectPath, bool expensiveRecipes, bool netProduction) {
-            recentProjects = recentProjects.Where(x => string.Compare(projectPath, x.path, StringComparison.InvariantCultureIgnoreCase) != 0)
-                .Prepend(new ProjectDefinition(dataPath, modsPath, projectPath, expensiveRecipes, netProduction))
-                .ToArray();
-            Save();
+        autosaveFilename = Path.Combine(appDataFolder, "autosave.yafc");
+        fileName = Path.Combine(appDataFolder, "yafc.config");
+        if (File.Exists(fileName)) {
+            try {
+                Instance = JsonSerializer.Deserialize<Preferences>(File.ReadAllBytes(fileName))!;
+                return;
+            }
+            catch (Exception ex) {
+                Console.Error.WriteException(ex);
+            }
         }
+        Instance = new Preferences();
+    }
+
+    public void Save() {
+        byte[] data = JsonSerializer.SerializeToUtf8Bytes(this, JsonUtils.DefaultOptions);
+        File.WriteAllBytes(fileName, data);
+    }
+    public ProjectDefinition[] recentProjects { get; set; } = [];
+    public bool darkMode { get; set; }
+    public string language { get; set; } = "en";
+    public string? overrideFont { get; set; }
+    /// <summary>
+    /// Whether or not the main screen should be created maximized.
+    /// </summary>
+    public bool maximizeMainScreen { get; set; }
+    /// <summary>
+    /// The initial width of the main screen or the width the main screen will be after being restored, depending on whether it starts restored or maximized.
+    /// </summary>
+    public float initialMainScreenWidth { get; set; }
+    /// <summary>
+    /// The initial height of the main screen or the height the main screen will be after being restored, depending on whether it starts restored or maximized.
+    /// </summary>
+    public float initialMainScreenHeight { get; set; }
+    public float recipeColumnWidth { get; set; }
+    public float ingredientsColumWidth { get; set; }
+    public float productsColumWidth { get; set; }
+    public float modulesColumnWidth { get; set; }
+    /// <summary>
+    /// Set to always use a software renderer even where we'd normally use a hardware renderer if you know that we make bad decisions about hardware renderers for your system.
+    ///
+    /// The current known cases in which you should do this are:
+    /// - Your system has a very old graphics card that is not supported by Windows DX12
+    /// </summary>
+    public bool forceSoftwareRenderer { get; set; } = false;
+    /// <summary>
+    /// An opaque integer that the shopping list uses to store its display options. See the ShoppingListScreen properties that read and write this value.
+    /// </summary>
+    public int shoppingDisplayState { get; set; } = 3;
+
+    public void AddProject(string dataPath, string modsPath, string projectPath, bool expensiveRecipes, bool netProduction) {
+        recentProjects = recentProjects.Where(x => string.Compare(projectPath, x.path, StringComparison.InvariantCultureIgnoreCase) != 0)
+            .Prepend(new ProjectDefinition(dataPath, modsPath, projectPath, expensiveRecipes, netProduction))
+            .ToArray();
+        Save();
+    }
+}
+
+/// <summary>
+/// The data that is required to load a project into Yafc.<br/>
+/// Contains the location of the project, Factorio data, mods, and so on.
+/// </summary>
+public class ProjectDefinition {
+    // TODO (shpaass/yafc-ce/issues/253): the existing list of recent projects
+    // will break if you rename any of the variables below, due to deserialization.
+    // That eventually will need to be fixed.
+    public ProjectDefinition() {
+        dataPath = "";
+        modsPath = "";
+        path = "";
+        expensive = false;
+        netProduction = false;
+    }
+
+    public ProjectDefinition(string dataPath, string modsPath, string path, bool expensive, bool netProduction) {
+        this.dataPath = dataPath;
+        this.modsPath = modsPath;
+        this.path = path;
+        this.expensive = expensive;
+        this.netProduction = netProduction;
     }
 
     /// <summary>
-    /// The data that is required to load a project into Yafc.<br/>
-    /// Contains the location of the project, Factorio data, mods, and so on.
+    /// The path to the project save file.
     /// </summary>
-    public class ProjectDefinition {
-        // TODO (shpaass/yafc-ce/issues/253): the existing list of recent projects
-        // will break if you rename any of the variables below, due to deserialization.
-        // That eventually will need to be fixed.
-        public ProjectDefinition() {
-            dataPath = "";
-            modsPath = "";
-            path = "";
-            expensive = false;
-            netProduction = false;
-        }
-
-        public ProjectDefinition(string dataPath, string modsPath, string path, bool expensive, bool netProduction) {
-            this.dataPath = dataPath;
-            this.modsPath = modsPath;
-            this.path = path;
-            this.expensive = expensive;
-            this.netProduction = netProduction;
-        }
-
-        /// <summary>
-        /// The path to the project save file.
-        /// </summary>
-        public string path { get; set; }
-        /// <summary>
-        /// The path to the Factorio data folder.
-        /// </summary>
-        public string dataPath { get; set; }
-        /// <summary>
-        /// The path to the Factorio mods folder, which is usually located in Appdata/Roaming.
-        /// </summary>
-        public string modsPath { get; set; }
-        /// <summary>
-        /// If true, the project will use Factorio-expensive recipes.
-        /// </summary>
-        public bool expensive { get; set; }
-        /// <summary>
-        /// If <see langword="true"/>, the recipe-selection windows will only display the recipes that provide net-production or consumption of the <see cref="Goods"/> in question.<br/>
-        /// If <see langword="false"/>, the recipe-selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
-        /// For example, the Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
-        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.
-        /// </summary>
-        public bool netProduction { get; set; }
-    }
+    public string path { get; set; }
+    /// <summary>
+    /// The path to the Factorio data folder.
+    /// </summary>
+    public string dataPath { get; set; }
+    /// <summary>
+    /// The path to the Factorio mods folder, which is usually located in Appdata/Roaming.
+    /// </summary>
+    public string modsPath { get; set; }
+    /// <summary>
+    /// If true, the project will use Factorio-expensive recipes.
+    /// </summary>
+    public bool expensive { get; set; }
+    /// <summary>
+    /// If <see langword="true"/>, the recipe-selection windows will only display the recipes that provide net-production or consumption of the <see cref="Goods"/> in question.<br/>
+    /// If <see langword="false"/>, the recipe-selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+    /// For example, the Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+    /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.
+    /// </summary>
+    public bool netProduction { get; set; }
 }

--- a/Yafc/Utils/WindowsClipboard.cs
+++ b/Yafc/Utils/WindowsClipboard.cs
@@ -3,75 +3,74 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Yafc.UI;
 
-namespace Yafc {
-    public static class WindowsClipboard {
-        [DllImport("user32.dll")] private static extern bool OpenClipboard(IntPtr handle);
-        [DllImport("user32.dll")] private static extern bool EmptyClipboard();
-        [DllImport("user32.dll")] private static extern IntPtr SetClipboardData(uint format, IntPtr data);
-        [DllImport("user32.dll")] private static extern bool CloseClipboard();
+namespace Yafc;
+public static class WindowsClipboard {
+    [DllImport("user32.dll")] private static extern bool OpenClipboard(IntPtr handle);
+    [DllImport("user32.dll")] private static extern bool EmptyClipboard();
+    [DllImport("user32.dll")] private static extern IntPtr SetClipboardData(uint format, IntPtr data);
+    [DllImport("user32.dll")] private static extern bool CloseClipboard();
 
-        private static unsafe void CopyToClipboard<T>(uint format, in T header, Span<byte> data) where T : unmanaged {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                return;
-            }
-
-            int headerSize = Unsafe.SizeOf<T>();
-            nint ptr = Marshal.AllocHGlobal(headerSize + data.Length);
-            _ = OpenClipboard(IntPtr.Zero);
-            try {
-                Marshal.StructureToPtr(header, ptr, false);
-                Span<byte> targetSpan = new Span<byte>((void*)(ptr + headerSize), data.Length);
-                data.CopyTo(targetSpan);
-                _ = EmptyClipboard();
-                _ = SetClipboardData(format, ptr);
-                ptr = IntPtr.Zero;
-            }
-            finally {
-                Marshal.FreeHGlobal(ptr);
-                _ = CloseClipboard();
-            }
+    private static unsafe void CopyToClipboard<T>(uint format, in T header, Span<byte> data) where T : unmanaged {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            return;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct BitmapInfoHeader {
-            public uint biSize;
-            public int biWidth;
-            public int biHeight;
-            public short biPlanes;
-            public short biBitCount;
-            public uint biCompression;
-            public uint biSizeImage;
-            public int biXPixelPerMeter;
-            public int biYPixelPerMeter;
-            public uint biClrUsed;
-            public uint biClrImportant;
+        int headerSize = Unsafe.SizeOf<T>();
+        nint ptr = Marshal.AllocHGlobal(headerSize + data.Length);
+        _ = OpenClipboard(IntPtr.Zero);
+        try {
+            Marshal.StructureToPtr(header, ptr, false);
+            Span<byte> targetSpan = new Span<byte>((void*)(ptr + headerSize), data.Length);
+            data.CopyTo(targetSpan);
+            _ = EmptyClipboard();
+            _ = SetClipboardData(format, ptr);
+            ptr = IntPtr.Zero;
         }
-
-        public static unsafe void CopySurfaceToClipboard(MemoryDrawingSurface surface) {
-            ref var surfaceInfo = ref RenderingUtils.AsSdlSurface(surface.surface);
-            int width = surfaceInfo.w;
-            int height = surfaceInfo.h;
-            int pitch = surfaceInfo.pitch;
-            int size = pitch * surfaceInfo.h;
-
-            // Windows expect images starting at bottom
-            Span<byte> flippedPixels = new Span<byte>(new byte[size]);
-            Span<byte> originalPixels = new Span<byte>((void*)surfaceInfo.pixels, size);
-            for (int i = 0; i < surfaceInfo.h; i++) {
-                originalPixels.Slice(i * pitch, pitch).CopyTo(flippedPixels.Slice((height - i - 1) * pitch, pitch));
-            }
-
-            BitmapInfoHeader header = new BitmapInfoHeader {
-                biSize = (uint)Unsafe.SizeOf<BitmapInfoHeader>(),
-                biWidth = width,
-                biHeight = height,
-                biPlanes = 1,
-                biBitCount = 32,
-                biCompression = 0,
-                biSizeImage = (uint)size,
-            };
-            CopyToClipboard(8, header, flippedPixels);
+        finally {
+            Marshal.FreeHGlobal(ptr);
+            _ = CloseClipboard();
         }
-
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BitmapInfoHeader {
+        public uint biSize;
+        public int biWidth;
+        public int biHeight;
+        public short biPlanes;
+        public short biBitCount;
+        public uint biCompression;
+        public uint biSizeImage;
+        public int biXPixelPerMeter;
+        public int biYPixelPerMeter;
+        public uint biClrUsed;
+        public uint biClrImportant;
+    }
+
+    public static unsafe void CopySurfaceToClipboard(MemoryDrawingSurface surface) {
+        ref var surfaceInfo = ref RenderingUtils.AsSdlSurface(surface.surface);
+        int width = surfaceInfo.w;
+        int height = surfaceInfo.h;
+        int pitch = surfaceInfo.pitch;
+        int size = pitch * surfaceInfo.h;
+
+        // Windows expect images starting at bottom
+        Span<byte> flippedPixels = new Span<byte>(new byte[size]);
+        Span<byte> originalPixels = new Span<byte>((void*)surfaceInfo.pixels, size);
+        for (int i = 0; i < surfaceInfo.h; i++) {
+            originalPixels.Slice(i * pitch, pitch).CopyTo(flippedPixels.Slice((height - i - 1) * pitch, pitch));
+        }
+
+        BitmapInfoHeader header = new BitmapInfoHeader {
+            biSize = (uint)Unsafe.SizeOf<BitmapInfoHeader>(),
+            biWidth = width,
+            biHeight = height,
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0,
+            biSizeImage = (uint)size,
+        };
+        CopyToClipboard(8, header, flippedPixels);
+    }
+
 }

--- a/Yafc/Widgets/DataGrid.cs
+++ b/Yafc/Widgets/DataGrid.cs
@@ -4,231 +4,230 @@ using System.Numerics;
 using System.Reflection;
 using SDL2;
 
-namespace Yafc.UI {
-    public abstract class DataColumn<TData> {
-        public readonly float minWidth;
-        public readonly float maxWidth;
-        public bool isFixedSize => minWidth == maxWidth;
-        private readonly Func<float> getWidth;
-        private readonly Action<float> setWidth;
-        private float _width;
+namespace Yafc.UI;
+public abstract class DataColumn<TData> {
+    public readonly float minWidth;
+    public readonly float maxWidth;
+    public bool isFixedSize => minWidth == maxWidth;
+    private readonly Func<float> getWidth;
+    private readonly Action<float> setWidth;
+    private float _width;
 
-        /// <param name="widthStorage">If not <see langword="null"/>, names a public read-write instance property in <see cref="Preferences"/> that will be used to store the width of this column.
-        /// If the current value of the property is out of range, the initial width will be <paramref name="initialWidth"/>.</param>
-        public DataColumn(float initialWidth, float minWidth = 0f, float maxWidth = 0f, string? widthStorage = null) {
-            this.minWidth = minWidth == 0f ? initialWidth : minWidth;
-            this.maxWidth = maxWidth == 0f ? initialWidth : maxWidth;
-            if (widthStorage != null) {
-                (getWidth, setWidth) = getStorage(widthStorage);
-            }
-            else {
-                getWidth = () => _width;
-                setWidth = f => _width = f;
-            }
-
-            if (width < this.minWidth || width > this.maxWidth) {
-                width = initialWidth;
-            }
-
-            static (Func<float>, Action<float>) getStorage(string storage) {
-                try {
-                    PropertyInfo? property = typeof(Preferences).GetProperty(storage);
-                    Func<float>? getMethod = property?.GetGetMethod()?.CreateDelegate<Func<float>>(Preferences.Instance);
-                    Action<float>? setMethod = property?.GetSetMethod()?.CreateDelegate<Action<float>>(Preferences.Instance);
-                    if (getMethod == null || setMethod == null) {
-                        throw new ArgumentException($"'{storage}' is not a public read-write property in {nameof(Preferences)}.");
-                    }
-                    return (getMethod, setMethod);
-                }
-                catch (ArgumentException) {
-                    // Not including the CreateDelegate's exception, because YAFC displays only the innermost exception message.
-                    throw new ArgumentException($"'{storage}' is not a instance property of type {typeof(float).Name} in {nameof(Preferences)}.");
-                }
-            }
-        }
-
-        public float width {
-            get => getWidth();
-            set => setWidth(value);
-        }
-
-        public abstract void BuildHeader(ImGui gui);
-        public abstract void BuildElement(ImGui gui, TData data);
-    }
-
-    /// <param name="widthStorage">If not <see langword="null"/>, names an instance property in <see cref="Preferences"/> that will be used to store the width of this column.
+    /// <param name="widthStorage">If not <see langword="null"/>, names a public read-write instance property in <see cref="Preferences"/> that will be used to store the width of this column.
     /// If the current value of the property is out of range, the initial width will be <paramref name="initialWidth"/>.</param>
-    public abstract class TextDataColumn<TData>(string header, float initialWidth, float minWidth = 0, float maxWidth = 0, bool hasMenu = false, string? widthStorage = null)
-        : DataColumn<TData>(initialWidth, minWidth, maxWidth, widthStorage) {
-        public override void BuildHeader(ImGui gui) {
-            gui.BuildText(header);
-            if (hasMenu) {
-                var rect = gui.statePosition;
-                Rect menuRect = new Rect(rect.Right - 1.7f, rect.Y, 1.5f, 1.5f);
-                if (gui.isBuilding) {
-                    gui.DrawIcon(menuRect, Icon.DropDown, SchemeColor.BackgroundText);
-                }
-
-                if (gui.BuildButton(menuRect, SchemeColor.None, SchemeColor.Grey)) {
-                    gui.ShowDropDown(menuRect, BuildMenu, new Padding(1f));
-                }
-            }
+    public DataColumn(float initialWidth, float minWidth = 0f, float maxWidth = 0f, string? widthStorage = null) {
+        this.minWidth = minWidth == 0f ? initialWidth : minWidth;
+        this.maxWidth = maxWidth == 0f ? initialWidth : maxWidth;
+        if (widthStorage != null) {
+            (getWidth, setWidth) = getStorage(widthStorage);
+        }
+        else {
+            getWidth = () => _width;
+            setWidth = f => _width = f;
         }
 
-        public virtual void BuildMenu(ImGui gui) { }
+        if (width < this.minWidth || width > this.maxWidth) {
+            width = initialWidth;
+        }
+
+        static (Func<float>, Action<float>) getStorage(string storage) {
+            try {
+                PropertyInfo? property = typeof(Preferences).GetProperty(storage);
+                Func<float>? getMethod = property?.GetGetMethod()?.CreateDelegate<Func<float>>(Preferences.Instance);
+                Action<float>? setMethod = property?.GetSetMethod()?.CreateDelegate<Action<float>>(Preferences.Instance);
+                if (getMethod == null || setMethod == null) {
+                    throw new ArgumentException($"'{storage}' is not a public read-write property in {nameof(Preferences)}.");
+                }
+                return (getMethod, setMethod);
+            }
+            catch (ArgumentException) {
+                // Not including the CreateDelegate's exception, because YAFC displays only the innermost exception message.
+                throw new ArgumentException($"'{storage}' is not a instance property of type {typeof(float).Name} in {nameof(Preferences)}.");
+            }
+        }
     }
 
-    public class DataGrid<TData> where TData : class {
-        public readonly List<DataColumn<TData>> columns;
-        private readonly Padding innerPadding = new Padding(0.2f);
-        public float width { get; private set; }
-        private readonly float spacing;
-        private Vector2 buildingStart;
-        private ImGui? contentGui;
-        public float headerHeight = 1.3f;
+    public float width {
+        get => getWidth();
+        set => setWidth(value);
+    }
 
-        public DataGrid(params DataColumn<TData>[] columns) {
-            this.columns = new List<DataColumn<TData>>(columns);
-            spacing = innerPadding.left + innerPadding.right;
-        }
+    public abstract void BuildHeader(ImGui gui);
+    public abstract void BuildElement(ImGui gui, TData data);
+}
 
+/// <param name="widthStorage">If not <see langword="null"/>, names an instance property in <see cref="Preferences"/> that will be used to store the width of this column.
+/// If the current value of the property is out of range, the initial width will be <paramref name="initialWidth"/>.</param>
+public abstract class TextDataColumn<TData>(string header, float initialWidth, float minWidth = 0, float maxWidth = 0, bool hasMenu = false, string? widthStorage = null)
+    : DataColumn<TData>(initialWidth, minWidth, maxWidth, widthStorage) {
+    public override void BuildHeader(ImGui gui) {
+        gui.BuildText(header);
+        if (hasMenu) {
+            var rect = gui.statePosition;
+            Rect menuRect = new Rect(rect.Right - 1.7f, rect.Y, 1.5f, 1.5f);
+            if (gui.isBuilding) {
+                gui.DrawIcon(menuRect, Icon.DropDown, SchemeColor.BackgroundText);
+            }
 
-        private void BuildHeaderResizer(ImGui gui, DataColumn<TData> column, Rect rect) {
-            switch (gui.action) {
-                case ImGuiAction.Build:
-                    float center = rect.X + (rect.Width * 0.5f);
-                    if (gui.IsMouseDown(rect, SDL.SDL_BUTTON_LEFT)) {
-                        float unclampedWidth = gui.mousePosition.X - rect.Center.X + column.width;
-                        float clampedWidth = MathUtils.Clamp(unclampedWidth, column.minWidth, column.maxWidth);
-                        center = center - column.width + clampedWidth;
-                    }
-                    Rect viewRect = new Rect(center - 0.1f, rect.Y, 0.2f, rect.Height);
-                    gui.DrawRectangle(viewRect, SchemeColor.GreyAlt);
-                    break;
-                case ImGuiAction.MouseMove:
-                    _ = gui.ConsumeMouseOver(rect, RenderingUtils.cursorHorizontalResize);
-                    if (gui.IsMouseDown(rect, SDL.SDL_BUTTON_LEFT)) {
-                        gui.Rebuild();
-                    }
-
-                    break;
-                case ImGuiAction.MouseDown:
-                    _ = gui.ConsumeMouseDown(rect, cursor: RenderingUtils.cursorHorizontalResize);
-                    break;
-                case ImGuiAction.MouseUp:
-                    if (gui.ConsumeMouseUp(rect, false)) {
-                        float unclampedWidth = gui.mousePosition.X - rect.Center.X + column.width;
-                        column.width = MathUtils.Clamp(unclampedWidth, column.minWidth, column.maxWidth);
-                        contentGui?.Rebuild();
-                    }
-                    break;
+            if (gui.BuildButton(menuRect, SchemeColor.None, SchemeColor.Grey)) {
+                gui.ShowDropDown(menuRect, BuildMenu, new Padding(1f));
             }
         }
+    }
 
-        private void CalculateWidth(ImGui gui) {
-            float x = 0f;
-            foreach (var column in columns) {
+    public virtual void BuildMenu(ImGui gui) { }
+}
+
+public class DataGrid<TData> where TData : class {
+    public readonly List<DataColumn<TData>> columns;
+    private readonly Padding innerPadding = new Padding(0.2f);
+    public float width { get; private set; }
+    private readonly float spacing;
+    private Vector2 buildingStart;
+    private ImGui? contentGui;
+    public float headerHeight = 1.3f;
+
+    public DataGrid(params DataColumn<TData>[] columns) {
+        this.columns = new List<DataColumn<TData>>(columns);
+        spacing = innerPadding.left + innerPadding.right;
+    }
+
+
+    private void BuildHeaderResizer(ImGui gui, DataColumn<TData> column, Rect rect) {
+        switch (gui.action) {
+            case ImGuiAction.Build:
+                float center = rect.X + (rect.Width * 0.5f);
+                if (gui.IsMouseDown(rect, SDL.SDL_BUTTON_LEFT)) {
+                    float unclampedWidth = gui.mousePosition.X - rect.Center.X + column.width;
+                    float clampedWidth = MathUtils.Clamp(unclampedWidth, column.minWidth, column.maxWidth);
+                    center = center - column.width + clampedWidth;
+                }
+                Rect viewRect = new Rect(center - 0.1f, rect.Y, 0.2f, rect.Height);
+                gui.DrawRectangle(viewRect, SchemeColor.GreyAlt);
+                break;
+            case ImGuiAction.MouseMove:
+                _ = gui.ConsumeMouseOver(rect, RenderingUtils.cursorHorizontalResize);
+                if (gui.IsMouseDown(rect, SDL.SDL_BUTTON_LEFT)) {
+                    gui.Rebuild();
+                }
+
+                break;
+            case ImGuiAction.MouseDown:
+                _ = gui.ConsumeMouseDown(rect, cursor: RenderingUtils.cursorHorizontalResize);
+                break;
+            case ImGuiAction.MouseUp:
+                if (gui.ConsumeMouseUp(rect, false)) {
+                    float unclampedWidth = gui.mousePosition.X - rect.Center.X + column.width;
+                    column.width = MathUtils.Clamp(unclampedWidth, column.minWidth, column.maxWidth);
+                    contentGui?.Rebuild();
+                }
+                break;
+        }
+    }
+
+    private void CalculateWidth(ImGui gui) {
+        float x = 0f;
+        foreach (var column in columns) {
+            x += column.width + spacing;
+        }
+        width = MathF.Max(x + 0.2f - spacing, gui.width - 1f);
+    }
+
+    public void BuildHeader(ImGui gui) {
+        float spacing = innerPadding.left + innerPadding.right;
+        float x = 0f;
+        var topSeparator = gui.AllocateRect(0f, 0.1f);
+        float y = gui.statePosition.Y;
+        using (var group = gui.EnterFixedPositioning(0f, headerHeight, innerPadding)) {
+            for (int index = 0; index < columns.Count; index++) // Do not change to foreach
+            {
+                var column = columns[index];
+                if (column.width < column.minWidth) {
+                    column.width = column.minWidth;
+                }
+
+                Rect rect = new Rect(x, y, column.width, 0f);
+                @group.SetManualRectRaw(rect, RectAllocator.LeftRow);
+                column.BuildHeader(gui);
+                rect.Bottom = gui.statePosition.Y;
                 x += column.width + spacing;
-            }
-            width = MathF.Max(x + 0.2f - spacing, gui.width - 1f);
-        }
 
-        public void BuildHeader(ImGui gui) {
-            float spacing = innerPadding.left + innerPadding.right;
-            float x = 0f;
-            var topSeparator = gui.AllocateRect(0f, 0.1f);
-            float y = gui.statePosition.Y;
-            using (var group = gui.EnterFixedPositioning(0f, headerHeight, innerPadding)) {
-                for (int index = 0; index < columns.Count; index++) // Do not change to foreach
-                {
-                    var column = columns[index];
+                if (!column.isFixedSize) {
+                    BuildHeaderResizer(gui, column, new Rect(x - 0.7f, y, 1f, headerHeight + 0.9f));
+                }
+            }
+        }
+        CalculateWidth(gui);
+
+        var separator = gui.AllocateRect(x, 0.1f);
+        if (gui.isBuilding) {
+            topSeparator.Width = separator.Width = width;
+            gui.DrawRectangle(topSeparator, SchemeColor.GreyAlt);
+            gui.DrawRectangle(separator, SchemeColor.GreyAlt);
+            //DrawVerticalGrid(gui, topSeparator.Bottom, separator.Top, SchemeColor.GreyAlt);
+        }
+    }
+
+    public Rect BuildRow(ImGui gui, TData element, float startX = 0f) {
+        contentGui = gui;
+        float x = innerPadding.left;
+        var rowColor = SchemeColor.None;
+        var textColor = rowColor;
+
+        if (gui.ShouldBuildGroup(element, out var buildGroup)) {
+            using (var group = gui.EnterFixedPositioning(width, 0f, innerPadding, textColor)) {
+                foreach (var column in columns) {
                     if (column.width < column.minWidth) {
                         column.width = column.minWidth;
                     }
 
-                    Rect rect = new Rect(x, y, column.width, 0f);
-                    @group.SetManualRectRaw(rect, RectAllocator.LeftRow);
-                    column.BuildHeader(gui);
-                    rect.Bottom = gui.statePosition.Y;
+                    @group.SetManualRect(new Rect(x, 0, column.width, 0f), RectAllocator.LeftRow);
+                    column.BuildElement(gui, element);
                     x += column.width + spacing;
-
-                    if (!column.isFixedSize) {
-                        BuildHeaderResizer(gui, column, new Rect(x - 0.7f, y, 1f, headerHeight + 0.9f));
-                    }
                 }
             }
-            CalculateWidth(gui);
+            buildGroup.Complete();
+        }
 
-            var separator = gui.AllocateRect(x, 0.1f);
-            if (gui.isBuilding) {
-                topSeparator.Width = separator.Width = width;
-                gui.DrawRectangle(topSeparator, SchemeColor.GreyAlt);
-                gui.DrawRectangle(separator, SchemeColor.GreyAlt);
-                //DrawVerticalGrid(gui, topSeparator.Bottom, separator.Top, SchemeColor.GreyAlt);
+        CalculateWidth(gui);
+        var rect = gui.lastRect;
+        float bottom = gui.lastRect.Bottom;
+        if (gui.isBuilding) {
+            gui.DrawRectangle(new Rect(startX, bottom - 0.1f, width - startX, 0.1f), SchemeColor.Grey);
+        }
+
+        return rect;
+    }
+
+    public void BeginBuildingContent(ImGui gui) {
+        buildingStart = gui.statePosition.BottomLeft;
+        gui.spacing = innerPadding.top + innerPadding.bottom;
+    }
+
+    public Rect EndBuildingContent(ImGui gui) {
+        float bottom = gui.statePosition.Bottom;
+        return new Rect(buildingStart.X, buildingStart.Y, width, bottom - buildingStart.Y);
+    }
+
+    public bool BuildContent(ImGui gui, IReadOnlyList<TData> data, out (TData from, TData to) reorder, out Rect rect, Func<TData, bool>? filter = null) {
+        BeginBuildingContent(gui);
+        reorder = default;
+        bool hasReorder = false;
+        for (int i = 0; i < data.Count; i++) // do not change to foreach
+        {
+            var t = data[i];
+            if (filter != null && !filter(t)) {
+                continue;
+            }
+
+            var rowRect = BuildRow(gui, t);
+            if (!hasReorder && gui.DoListReordering(rowRect, rowRect, t, out var from, SchemeColor.PureBackground, false)) {
+                reorder = (@from, t);
+                hasReorder = true;
             }
         }
 
-        public Rect BuildRow(ImGui gui, TData element, float startX = 0f) {
-            contentGui = gui;
-            float x = innerPadding.left;
-            var rowColor = SchemeColor.None;
-            var textColor = rowColor;
-
-            if (gui.ShouldBuildGroup(element, out var buildGroup)) {
-                using (var group = gui.EnterFixedPositioning(width, 0f, innerPadding, textColor)) {
-                    foreach (var column in columns) {
-                        if (column.width < column.minWidth) {
-                            column.width = column.minWidth;
-                        }
-
-                        @group.SetManualRect(new Rect(x, 0, column.width, 0f), RectAllocator.LeftRow);
-                        column.BuildElement(gui, element);
-                        x += column.width + spacing;
-                    }
-                }
-                buildGroup.Complete();
-            }
-
-            CalculateWidth(gui);
-            var rect = gui.lastRect;
-            float bottom = gui.lastRect.Bottom;
-            if (gui.isBuilding) {
-                gui.DrawRectangle(new Rect(startX, bottom - 0.1f, width - startX, 0.1f), SchemeColor.Grey);
-            }
-
-            return rect;
-        }
-
-        public void BeginBuildingContent(ImGui gui) {
-            buildingStart = gui.statePosition.BottomLeft;
-            gui.spacing = innerPadding.top + innerPadding.bottom;
-        }
-
-        public Rect EndBuildingContent(ImGui gui) {
-            float bottom = gui.statePosition.Bottom;
-            return new Rect(buildingStart.X, buildingStart.Y, width, bottom - buildingStart.Y);
-        }
-
-        public bool BuildContent(ImGui gui, IReadOnlyList<TData> data, out (TData from, TData to) reorder, out Rect rect, Func<TData, bool>? filter = null) {
-            BeginBuildingContent(gui);
-            reorder = default;
-            bool hasReorder = false;
-            for (int i = 0; i < data.Count; i++) // do not change to foreach
-            {
-                var t = data[i];
-                if (filter != null && !filter(t)) {
-                    continue;
-                }
-
-                var rowRect = BuildRow(gui, t);
-                if (!hasReorder && gui.DoListReordering(rowRect, rowRect, t, out var from, SchemeColor.PureBackground, false)) {
-                    reorder = (@from, t);
-                    hasReorder = true;
-                }
-            }
-
-            rect = EndBuildingContent(gui);
-            return hasReorder;
-        }
+        rect = EndBuildingContent(gui);
+        return hasReorder;
     }
 }

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -7,327 +7,326 @@ using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
+namespace Yafc;
 
-    // Contained draws the milestone like this
-    // +----+
-    // |    |
-    // |  +-+
-    // |  | |
-    // +--+-+
-    // Normal draws the milestone like this
-    // +----+
-    // |    |
-    // |    |
-    // |   +-+
-    // +---| |
-    //     +-+
-    public enum MilestoneDisplay {
-        /// <summary>
-        /// Draw the highest locked milestone centered on the lower-right corner of the base icon.
-        /// </summary>
-        Normal,
-        /// <summary>
-        /// Draw the highest locked milestone with its lower-right corner aligned with the lower-right corner of the base icon.
-        /// </summary>
-        Contained,
-        /// <summary>
-        /// Draw the highest milestone, regardless of (un)lock state, centered on the lower-right corner of the base icon.
-        /// </summary>
-        Always,
-        /// <summary>
-        /// Draw the highest milestone, regardless of (un)lock state, with its lower-right corner aligned with the lower-right corner of the base icon.
-        /// </summary>
-        ContainedAlways,
-        /// <summary>
-        /// Do not draw a milestone icon.
-        /// </summary>
-        None
+// Contained draws the milestone like this
+// +----+
+// |    |
+// |  +-+
+// |  | |
+// +--+-+
+// Normal draws the milestone like this
+// +----+
+// |    |
+// |    |
+// |   +-+
+// +---| |
+//     +-+
+public enum MilestoneDisplay {
+    /// <summary>
+    /// Draw the highest locked milestone centered on the lower-right corner of the base icon.
+    /// </summary>
+    Normal,
+    /// <summary>
+    /// Draw the highest locked milestone with its lower-right corner aligned with the lower-right corner of the base icon.
+    /// </summary>
+    Contained,
+    /// <summary>
+    /// Draw the highest milestone, regardless of (un)lock state, centered on the lower-right corner of the base icon.
+    /// </summary>
+    Always,
+    /// <summary>
+    /// Draw the highest milestone, regardless of (un)lock state, with its lower-right corner aligned with the lower-right corner of the base icon.
+    /// </summary>
+    ContainedAlways,
+    /// <summary>
+    /// Do not draw a milestone icon.
+    /// </summary>
+    None
+}
+
+public enum GoodsWithAmountEvent {
+    None,
+    LeftButtonClick,
+    RightButtonClick,
+    TextEditing,
+}
+
+public enum Click {
+    None,
+    Left,
+    Right,
+}
+
+public static class ImmediateWidgets {
+    /// <summary>Draws the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.</summary>
+    /// <param name="obj">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
+    public static void BuildFactorioObjectIcon(this ImGui gui, FactorioObject? obj, IconDisplayStyle? displayStyle = null) {
+        displayStyle ??= IconDisplayStyle.Default;
+        if (obj == null) {
+            gui.BuildIcon(Icon.Empty, displayStyle.Size, SchemeColor.BackgroundTextFaint);
+            return;
+        }
+
+        var color = obj.IsAccessible() ? SchemeColor.Source : SchemeColor.SourceFaint;
+        if (displayStyle.UseScaleSetting) {
+            Rect rect = gui.AllocateRect(displayStyle.Size, displayStyle.Size, RectAlignment.Middle);
+            gui.DrawIcon(rect.Expand(displayStyle.Size * (Project.current.preferences.iconScale - 1) / 2), obj.icon, color);
+        }
+        else {
+            gui.BuildIcon(obj.icon, displayStyle.Size, color);
+        }
+        if (gui.isBuilding && displayStyle.MilestoneDisplay != MilestoneDisplay.None) {
+            bool contain = (displayStyle.MilestoneDisplay & MilestoneDisplay.Contained) != 0;
+            FactorioObject? milestone = Milestones.Instance.GetHighest(obj, displayStyle.MilestoneDisplay >= MilestoneDisplay.Always);
+            if (milestone != null) {
+                Vector2 psize = new Vector2(displayStyle.Size / 2f);
+                var delta = contain ? psize : psize / 2f;
+                Rect milestoneIcon = new Rect(gui.lastRect.BottomRight - delta, psize);
+                var icon = milestone == Database.voidEnergy ? DataUtils.HandIcon : milestone.icon;
+                gui.DrawIcon(milestoneIcon, icon, color);
+            }
+        }
     }
 
-    public enum GoodsWithAmountEvent {
-        None,
-        LeftButtonClick,
-        RightButtonClick,
-        TextEditing,
+    public static bool BuildFloatInput(this ImGui gui, DisplayAmount amount, TextBoxDisplayStyle displayStyle, bool setInitialFocus = false) {
+        if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, displayStyle, true, setInitialFocus)
+            && DataUtils.TryParseAmount(newText, out float newValue, amount.Unit)) {
+            amount.Value = newValue;
+            return true;
+        }
+
+        return false;
     }
 
-    public enum Click {
-        None,
-        Left,
-        Right,
-    }
-
-    public static class ImmediateWidgets {
-        /// <summary>Draws the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.</summary>
-        /// <param name="obj">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
-        public static void BuildFactorioObjectIcon(this ImGui gui, FactorioObject? obj, IconDisplayStyle? displayStyle = null) {
-            displayStyle ??= IconDisplayStyle.Default;
-            if (obj == null) {
-                gui.BuildIcon(Icon.Empty, displayStyle.Size, SchemeColor.BackgroundTextFaint);
-                return;
-            }
-
-            var color = obj.IsAccessible() ? SchemeColor.Source : SchemeColor.SourceFaint;
-            if (displayStyle.UseScaleSetting) {
-                Rect rect = gui.AllocateRect(displayStyle.Size, displayStyle.Size, RectAlignment.Middle);
-                gui.DrawIcon(rect.Expand(displayStyle.Size * (Project.current.preferences.iconScale - 1) / 2), obj.icon, color);
-            }
-            else {
-                gui.BuildIcon(obj.icon, displayStyle.Size, color);
-            }
-            if (gui.isBuilding && displayStyle.MilestoneDisplay != MilestoneDisplay.None) {
-                bool contain = (displayStyle.MilestoneDisplay & MilestoneDisplay.Contained) != 0;
-                FactorioObject? milestone = Milestones.Instance.GetHighest(obj, displayStyle.MilestoneDisplay >= MilestoneDisplay.Always);
-                if (milestone != null) {
-                    Vector2 psize = new Vector2(displayStyle.Size / 2f);
-                    var delta = contain ? psize : psize / 2f;
-                    Rect milestoneIcon = new Rect(gui.lastRect.BottomRight - delta, psize);
-                    var icon = milestone == Database.voidEnergy ? DataUtils.HandIcon : milestone.icon;
-                    gui.DrawIcon(milestoneIcon, icon, color);
-                }
-            }
+    public static Click BuildFactorioObjectButtonBackground(this ImGui gui, Rect rect, FactorioObject? obj, SchemeColor bgColor = SchemeColor.None, ObjectTooltipOptions tooltipOptions = default) {
+        SchemeColor overColor;
+        if (bgColor == SchemeColor.None) {
+            overColor = SchemeColor.Grey;
         }
-
-        public static bool BuildFloatInput(this ImGui gui, DisplayAmount amount, TextBoxDisplayStyle displayStyle, bool setInitialFocus = false) {
-            if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, displayStyle, true, setInitialFocus)
-                && DataUtils.TryParseAmount(newText, out float newValue, amount.Unit)) {
-                amount.Value = newValue;
-                return true;
-            }
-
-            return false;
+        else {
+            overColor = bgColor + 1;
         }
-
-        public static Click BuildFactorioObjectButtonBackground(this ImGui gui, Rect rect, FactorioObject? obj, SchemeColor bgColor = SchemeColor.None, ObjectTooltipOptions tooltipOptions = default) {
-            SchemeColor overColor;
-            if (bgColor == SchemeColor.None) {
-                overColor = SchemeColor.Grey;
-            }
-            else {
-                overColor = bgColor + 1;
-            }
-            if (MainScreen.Instance.IsSameObjectHovered(gui, obj)) {
-                bgColor = overColor;
-            }
-            var evt = gui.BuildButton(rect, bgColor, overColor, button: 0);
-            if (evt == ButtonEvent.MouseOver && obj != null) {
-                MainScreen.Instance.ShowTooltip(obj, gui, rect, tooltipOptions);
-            }
-            else if (evt == ButtonEvent.Click) {
-                if (gui.actionParameter == SDL.SDL_BUTTON_MIDDLE && obj != null) {
-                    if (obj.showInExplorers) {
-                        if (obj is Goods goods && obj.IsAccessible()) {
-                            NeverEnoughItemsPanel.Show(goods);
-                        }
-                        else {
-                            DependencyExplorer.Show(obj);
-                        }
-                    }
-                }
-                else if (gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
-                    return Click.Left;
-                }
-                else if (gui.actionParameter == SDL.SDL_BUTTON_RIGHT) {
-                    return Click.Right;
-                }
-            }
-
-            return Click.None;
+        if (MainScreen.Instance.IsSameObjectHovered(gui, obj)) {
+            bgColor = overColor;
         }
-
-        /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.</summary>
-        /// <param name="obj">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
-        public static Click BuildFactorioObjectButton(this ImGui gui, FactorioObject? obj, ButtonDisplayStyle displayStyle, ObjectTooltipOptions tooltipOptions = default) {
-            gui.BuildFactorioObjectIcon(obj, displayStyle);
-            return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj, displayStyle.BackgroundColor, tooltipOptions);
+        var evt = gui.BuildButton(rect, bgColor, overColor, button: 0);
+        if (evt == ButtonEvent.MouseOver && obj != null) {
+            MainScreen.Instance.ShowTooltip(obj, gui, rect, tooltipOptions);
         }
-
-        public static Click BuildFactorioObjectButtonWithText(this ImGui gui, FactorioObject? obj, string? extraText = null, IconDisplayStyle? iconDisplayStyle = null) {
-            iconDisplayStyle ??= IconDisplayStyle.Default;
-            using (gui.EnterRow()) {
-                gui.BuildFactorioObjectIcon(obj, iconDisplayStyle);
-                var color = gui.textColor;
-                if (obj != null && !obj.IsAccessible()) {
-                    color += 1;
-                }
-
-                if (Project.current.preferences.favorites.Contains(obj!)) { // null-forgiving: non-nullable collections are happy to report they don't contain null values.
-                    gui.BuildIcon(Icon.StarFull, 1f);
-                }
-
-                if (extraText != null) {
-                    gui.AllocateSpacing();
-                    gui.allocator = RectAllocator.RightRow;
-                    gui.BuildText(extraText, TextBlockDisplayStyle.Default(color));
-                }
-                _ = gui.RemainingRow();
-                gui.BuildText(obj == null ? "None" : obj.locName, TextBlockDisplayStyle.WrappedText with { Color = color });
-            }
-
-            return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj);
-        }
-
-        public static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, IComparer<T> ordering, string header, [NotNullWhen(true)] out T? selected, int maxCount = 10,
-            Predicate<T>? checkMark = null, Func<T, string>? extra = null) where T : FactorioObject {
-            gui.BuildText(header, Font.productionTableHeader);
-            IEnumerable<T> sortedList;
-            if (ordering == DataUtils.AlreadySortedRecipe) {
-                sortedList = list.AsEnumerable();
-            }
-            else {
-                sortedList = list.OrderBy(e => e, ordering ?? DataUtils.DefaultOrdering);
-            }
-            selected = null;
-            foreach (var elem in sortedList.Take(maxCount)) {
-                string? extraText = extra?.Invoke(elem);
-                if (gui.BuildFactorioObjectButtonWithText(elem, extraText) == Click.Left) {
-                    selected = elem;
-                }
-
-                if (checkMark != null && gui.isBuilding && checkMark(elem)) {
-                    gui.DrawIcon(Rect.Square(gui.lastRect.Right - 1f, gui.lastRect.Center.Y, 1.5f), Icon.Check, SchemeColor.Green);
-                }
-            }
-
-            return selected != null;
-        }
-
-        public static void BuildInlineObjectListAndButton<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T> selectItem, string header, int count = 6, bool multiple = false, Predicate<T>? checkMark = null, Func<T, string>? extra = null) where T : FactorioObject {
-            using (gui.EnterGroup(default, RectAllocator.Stretch)) {
-                if (gui.BuildInlineObjectList(list, ordering, header, out var selected, count, checkMark, extra)) {
-                    selectItem(selected);
-                    if (!multiple || !InputSystem.Instance.control) {
-                        _ = gui.CloseDropdown();
-                    }
-                }
-
-                if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown()) {
-                    if (multiple) {
-                        SelectMultiObjectPanel.Select(list, header, selectItem, ordering, checkMark);
+        else if (evt == ButtonEvent.Click) {
+            if (gui.actionParameter == SDL.SDL_BUTTON_MIDDLE && obj != null) {
+                if (obj.showInExplorers) {
+                    if (obj is Goods goods && obj.IsAccessible()) {
+                        NeverEnoughItemsPanel.Show(goods);
                     }
                     else {
-                        SelectSingleObjectPanel.Select(list, header, selectItem, ordering);
+                        DependencyExplorer.Show(obj);
                     }
                 }
             }
+            else if (gui.actionParameter == SDL.SDL_BUTTON_LEFT) {
+                return Click.Left;
+            }
+            else if (gui.actionParameter == SDL.SDL_BUTTON_RIGHT) {
+                return Click.Right;
+            }
         }
 
-        public static void BuildInlineObjectListAndButtonWithNone<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T?> selectItem, string header, int count = 6, Func<T, string>? extra = null) where T : FactorioObject {
-            using (gui.EnterGroup(default, RectAllocator.Stretch)) {
-                if (gui.BuildInlineObjectList(list, ordering, header, out var selected, count, null, extra)) {
-                    selectItem(selected);
+        return Click.None;
+    }
+
+    /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.</summary>
+    /// <param name="obj">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
+    public static Click BuildFactorioObjectButton(this ImGui gui, FactorioObject? obj, ButtonDisplayStyle displayStyle, ObjectTooltipOptions tooltipOptions = default) {
+        gui.BuildFactorioObjectIcon(obj, displayStyle);
+        return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj, displayStyle.BackgroundColor, tooltipOptions);
+    }
+
+    public static Click BuildFactorioObjectButtonWithText(this ImGui gui, FactorioObject? obj, string? extraText = null, IconDisplayStyle? iconDisplayStyle = null) {
+        iconDisplayStyle ??= IconDisplayStyle.Default;
+        using (gui.EnterRow()) {
+            gui.BuildFactorioObjectIcon(obj, iconDisplayStyle);
+            var color = gui.textColor;
+            if (obj != null && !obj.IsAccessible()) {
+                color += 1;
+            }
+
+            if (Project.current.preferences.favorites.Contains(obj!)) { // null-forgiving: non-nullable collections are happy to report they don't contain null values.
+                gui.BuildIcon(Icon.StarFull, 1f);
+            }
+
+            if (extraText != null) {
+                gui.AllocateSpacing();
+                gui.allocator = RectAllocator.RightRow;
+                gui.BuildText(extraText, TextBlockDisplayStyle.Default(color));
+            }
+            _ = gui.RemainingRow();
+            gui.BuildText(obj == null ? "None" : obj.locName, TextBlockDisplayStyle.WrappedText with { Color = color });
+        }
+
+        return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj);
+    }
+
+    public static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, IComparer<T> ordering, string header, [NotNullWhen(true)] out T? selected, int maxCount = 10,
+        Predicate<T>? checkMark = null, Func<T, string>? extra = null) where T : FactorioObject {
+        gui.BuildText(header, Font.productionTableHeader);
+        IEnumerable<T> sortedList;
+        if (ordering == DataUtils.AlreadySortedRecipe) {
+            sortedList = list.AsEnumerable();
+        }
+        else {
+            sortedList = list.OrderBy(e => e, ordering ?? DataUtils.DefaultOrdering);
+        }
+        selected = null;
+        foreach (var elem in sortedList.Take(maxCount)) {
+            string? extraText = extra?.Invoke(elem);
+            if (gui.BuildFactorioObjectButtonWithText(elem, extraText) == Click.Left) {
+                selected = elem;
+            }
+
+            if (checkMark != null && gui.isBuilding && checkMark(elem)) {
+                gui.DrawIcon(Rect.Square(gui.lastRect.Right - 1f, gui.lastRect.Center.Y, 1.5f), Icon.Check, SchemeColor.Green);
+            }
+        }
+
+        return selected != null;
+    }
+
+    public static void BuildInlineObjectListAndButton<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T> selectItem, string header, int count = 6, bool multiple = false, Predicate<T>? checkMark = null, Func<T, string>? extra = null) where T : FactorioObject {
+        using (gui.EnterGroup(default, RectAllocator.Stretch)) {
+            if (gui.BuildInlineObjectList(list, ordering, header, out var selected, count, checkMark, extra)) {
+                selectItem(selected);
+                if (!multiple || !InputSystem.Instance.control) {
                     _ = gui.CloseDropdown();
                 }
-                if (gui.BuildRedButton("Clear") && gui.CloseDropdown()) {
-                    selectItem(null);
+            }
+
+            if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown()) {
+                if (multiple) {
+                    SelectMultiObjectPanel.Select(list, header, selectItem, ordering, checkMark);
                 }
-
-                if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown()) {
-                    SelectSingleObjectPanel.SelectWithNone(list, header, selectItem, ordering);
+                else {
+                    SelectSingleObjectPanel.Select(list, header, selectItem, ordering);
                 }
             }
-        }
-
-        /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.
-        /// Also draws a label under the button, containing the supplied <paramref name="amount"/>.</summary>
-        /// <param name="goods">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
-        /// <param name="amount">Display this value and unit.</param>
-        /// <param name="useScale">If <see langword="true"/>, this icon will be displayed at <see cref="ProjectPreferences.iconScale"/>, instead of at 100% scale.</param>
-        public static Click BuildFactorioObjectWithAmount(this ImGui gui, FactorioObject? goods, DisplayAmount amount, ButtonDisplayStyle buttonDisplayStyle, TextBlockDisplayStyle? textDisplayStyle = null, ObjectTooltipOptions tooltipOptions = default) {
-            textDisplayStyle ??= new(Alignment: RectAlignment.Middle);
-            using (gui.EnterFixedPositioning(3f, 3f, default)) {
-                gui.allocator = RectAllocator.Stretch;
-                gui.spacing = 0f;
-                Click clicked = gui.BuildFactorioObjectButton(goods, buttonDisplayStyle, tooltipOptions);
-                if (goods != null) {
-                    gui.BuildText(DataUtils.FormatAmount(amount.Value, amount.Unit), textDisplayStyle);
-                    if (InputSystem.Instance.control && gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver) {
-                        ShowPrecisionValueTooltip(gui, amount, goods);
-                    }
-                }
-                return clicked;
-            }
-        }
-
-        public static void ShowPrecisionValueTooltip(ImGui gui, DisplayAmount amount, FactorioObject goods) {
-            string text;
-            switch (amount.Unit) {
-                case UnitOfMeasure.PerSecond:
-                case UnitOfMeasure.FluidPerSecond:
-                case UnitOfMeasure.ItemPerSecond:
-                    string perSecond = DataUtils.FormatAmountRaw(amount.Value, 1f, "/s", DataUtils.PreciseFormat);
-                    string perMinute = DataUtils.FormatAmountRaw(amount.Value, 60f, "/m", DataUtils.PreciseFormat);
-                    string perHour = DataUtils.FormatAmountRaw(amount.Value, 3600f, "/h", DataUtils.PreciseFormat);
-                    text = perSecond + "\n" + perMinute + "\n" + perHour;
-                    if (goods is Item item) {
-                        text += DataUtils.FormatAmount(MathF.Abs(item.stackSize / amount.Value), UnitOfMeasure.Second, "\n", " per stack");
-                    }
-
-                    break;
-                default:
-                    text = DataUtils.FormatAmount(amount.Value, amount.Unit, precise: true);
-                    break;
-            }
-            gui.ShowTooltip(gui.lastRect, x => {
-                _ = x.BuildFactorioObjectButtonWithText(goods);
-                x.BuildText(text, TextBlockDisplayStyle.WrappedText);
-            }, 10f);
-        }
-
-        /// <summary>Shows a dropdown containing the (partial) <paramref name="list"/> of elements, with an action for when an element is selected.</summary>
-        /// <param name="count">Maximum number of elements in the list. If there are more another popup can be opened by the user to show the full list.</param>
-        /// <param name="width">Width of the popup. Make sure the header text fits!</param>
-        public static void BuildObjectSelectDropDown<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T> selectItem, string header, float width = 20f, int count = 6, bool multiple = false, Predicate<T>? checkMark = null, Func<T, string>? extra = null) where T : FactorioObject
-            => gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton(list, ordering, selectItem, header, count, multiple, checkMark, extra), width);
-
-        /// <summary>Shows a dropdown containing the (partial) <paramref name="list"/> of elements, with an action for when an element is selected. An additional "Clear" or "None" option will also be displayed.</summary>
-        /// <param name="count">Maximum number of elements in the list. If there are more another popup can be opened by the user to show the full list.</param>
-        /// <param name="width">Width of the popup. Make sure the header text fits!</param>
-        public static void BuildObjectSelectDropDownWithNone<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T?> selectItem, string header, float width = 20f, int count = 6, Func<T, string>? extra = null) where T : FactorioObject
-            => gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButtonWithNone(list, ordering, selectItem, header, count, extra), width);
-
-        /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.
-        /// Also draws an editable textbox under the button, containing the supplied <paramref name="amount"/>.</summary>
-        /// <param name="obj">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
-        /// <param name="useScale">If <see langword="true"/>, this icon will be displayed at <see cref="ProjectPreferences.iconScale"/>, instead of at 100% scale.</param>
-        /// <param name="amount">Display this value and unit. If the user edits the value, the new value will be stored in <see cref="DisplayAmount.Value"/> before returning.</param>
-        /// <param name="allowScroll">If <see langword="true"/>, the default, the user can adjust the value by using the scroll wheel while hovering over the editable text.
-        /// If <see langword="false"/>, the scroll wheel will be ignored when hovering.</param>
-        public static GoodsWithAmountEvent BuildFactorioObjectWithEditableAmount(this ImGui gui, FactorioObject? obj, DisplayAmount amount, ButtonDisplayStyle buttonDisplayStyle, bool allowScroll = true, ObjectTooltipOptions tooltipOptions = default) {
-            using var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f);
-            group.SetWidth(3f);
-            GoodsWithAmountEvent evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectButton(obj, buttonDisplayStyle, tooltipOptions);
-
-            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput)) {
-                return GoodsWithAmountEvent.TextEditing;
-            }
-
-            if (allowScroll && gui.action == ImGuiAction.MouseScroll && gui.ConsumeEvent(gui.lastRect)) {
-                float digit = MathF.Pow(10, MathF.Floor(MathF.Log10(amount.Value) - 2f));
-                amount.Value = MathF.Round((amount.Value / digit) + gui.actionParameter) * digit;
-                return GoodsWithAmountEvent.TextEditing;
-            }
-
-            return evt;
         }
     }
+
+    public static void BuildInlineObjectListAndButtonWithNone<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T?> selectItem, string header, int count = 6, Func<T, string>? extra = null) where T : FactorioObject {
+        using (gui.EnterGroup(default, RectAllocator.Stretch)) {
+            if (gui.BuildInlineObjectList(list, ordering, header, out var selected, count, null, extra)) {
+                selectItem(selected);
+                _ = gui.CloseDropdown();
+            }
+            if (gui.BuildRedButton("Clear") && gui.CloseDropdown()) {
+                selectItem(null);
+            }
+
+            if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown()) {
+                SelectSingleObjectPanel.SelectWithNone(list, header, selectItem, ordering);
+            }
+        }
+    }
+
+    /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.
+    /// Also draws a label under the button, containing the supplied <paramref name="amount"/>.</summary>
+    /// <param name="goods">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
+    /// <param name="amount">Display this value and unit.</param>
+    /// <param name="useScale">If <see langword="true"/>, this icon will be displayed at <see cref="ProjectPreferences.iconScale"/>, instead of at 100% scale.</param>
+    public static Click BuildFactorioObjectWithAmount(this ImGui gui, FactorioObject? goods, DisplayAmount amount, ButtonDisplayStyle buttonDisplayStyle, TextBlockDisplayStyle? textDisplayStyle = null, ObjectTooltipOptions tooltipOptions = default) {
+        textDisplayStyle ??= new(Alignment: RectAlignment.Middle);
+        using (gui.EnterFixedPositioning(3f, 3f, default)) {
+            gui.allocator = RectAllocator.Stretch;
+            gui.spacing = 0f;
+            Click clicked = gui.BuildFactorioObjectButton(goods, buttonDisplayStyle, tooltipOptions);
+            if (goods != null) {
+                gui.BuildText(DataUtils.FormatAmount(amount.Value, amount.Unit), textDisplayStyle);
+                if (InputSystem.Instance.control && gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver) {
+                    ShowPrecisionValueTooltip(gui, amount, goods);
+                }
+            }
+            return clicked;
+        }
+    }
+
+    public static void ShowPrecisionValueTooltip(ImGui gui, DisplayAmount amount, FactorioObject goods) {
+        string text;
+        switch (amount.Unit) {
+            case UnitOfMeasure.PerSecond:
+            case UnitOfMeasure.FluidPerSecond:
+            case UnitOfMeasure.ItemPerSecond:
+                string perSecond = DataUtils.FormatAmountRaw(amount.Value, 1f, "/s", DataUtils.PreciseFormat);
+                string perMinute = DataUtils.FormatAmountRaw(amount.Value, 60f, "/m", DataUtils.PreciseFormat);
+                string perHour = DataUtils.FormatAmountRaw(amount.Value, 3600f, "/h", DataUtils.PreciseFormat);
+                text = perSecond + "\n" + perMinute + "\n" + perHour;
+                if (goods is Item item) {
+                    text += DataUtils.FormatAmount(MathF.Abs(item.stackSize / amount.Value), UnitOfMeasure.Second, "\n", " per stack");
+                }
+
+                break;
+            default:
+                text = DataUtils.FormatAmount(amount.Value, amount.Unit, precise: true);
+                break;
+        }
+        gui.ShowTooltip(gui.lastRect, x => {
+            _ = x.BuildFactorioObjectButtonWithText(goods);
+            x.BuildText(text, TextBlockDisplayStyle.WrappedText);
+        }, 10f);
+    }
+
+    /// <summary>Shows a dropdown containing the (partial) <paramref name="list"/> of elements, with an action for when an element is selected.</summary>
+    /// <param name="count">Maximum number of elements in the list. If there are more another popup can be opened by the user to show the full list.</param>
+    /// <param name="width">Width of the popup. Make sure the header text fits!</param>
+    public static void BuildObjectSelectDropDown<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T> selectItem, string header, float width = 20f, int count = 6, bool multiple = false, Predicate<T>? checkMark = null, Func<T, string>? extra = null) where T : FactorioObject
+        => gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton(list, ordering, selectItem, header, count, multiple, checkMark, extra), width);
+
+    /// <summary>Shows a dropdown containing the (partial) <paramref name="list"/> of elements, with an action for when an element is selected. An additional "Clear" or "None" option will also be displayed.</summary>
+    /// <param name="count">Maximum number of elements in the list. If there are more another popup can be opened by the user to show the full list.</param>
+    /// <param name="width">Width of the popup. Make sure the header text fits!</param>
+    public static void BuildObjectSelectDropDownWithNone<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T?> selectItem, string header, float width = 20f, int count = 6, Func<T, string>? extra = null) where T : FactorioObject
+        => gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButtonWithNone(list, ordering, selectItem, header, count, extra), width);
+
+    /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.
+    /// Also draws an editable textbox under the button, containing the supplied <paramref name="amount"/>.</summary>
+    /// <param name="obj">Draw the icon for this object, or an empty box if this is <see langword="null"/>.</param>
+    /// <param name="useScale">If <see langword="true"/>, this icon will be displayed at <see cref="ProjectPreferences.iconScale"/>, instead of at 100% scale.</param>
+    /// <param name="amount">Display this value and unit. If the user edits the value, the new value will be stored in <see cref="DisplayAmount.Value"/> before returning.</param>
+    /// <param name="allowScroll">If <see langword="true"/>, the default, the user can adjust the value by using the scroll wheel while hovering over the editable text.
+    /// If <see langword="false"/>, the scroll wheel will be ignored when hovering.</param>
+    public static GoodsWithAmountEvent BuildFactorioObjectWithEditableAmount(this ImGui gui, FactorioObject? obj, DisplayAmount amount, ButtonDisplayStyle buttonDisplayStyle, bool allowScroll = true, ObjectTooltipOptions tooltipOptions = default) {
+        using var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f);
+        group.SetWidth(3f);
+        GoodsWithAmountEvent evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectButton(obj, buttonDisplayStyle, tooltipOptions);
+
+        if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput)) {
+            return GoodsWithAmountEvent.TextEditing;
+        }
+
+        if (allowScroll && gui.action == ImGuiAction.MouseScroll && gui.ConsumeEvent(gui.lastRect)) {
+            float digit = MathF.Pow(10, MathF.Floor(MathF.Log10(amount.Value) - 2f));
+            amount.Value = MathF.Round((amount.Value / digit) + gui.actionParameter) * digit;
+            return GoodsWithAmountEvent.TextEditing;
+        }
+
+        return evt;
+    }
+}
+
+/// <summary>
+/// Represents an amount to be displayed to the user, and possibly edited.
+/// </summary>
+/// <param name="Value">The initial value to be displayed to the user.</param>
+/// <param name="Unit">The <see cref="UnitOfMeasure"/> to be used when formatting <paramref name="Value"/> for display and when parsing user input.</param>
+public record DisplayAmount(float Value, UnitOfMeasure Unit = UnitOfMeasure.None) {
+    /// <summary>
+    /// Gets or sets the value. This is either the value to be displayed or the value after modification by the user.
+    /// </summary>
+    public float Value { get; set; } = Value;
 
     /// <summary>
-    /// Represents an amount to be displayed to the user, and possibly edited.
+    /// Creates a new <see cref="DisplayAmount"/> for basic numeric display. <see cref="Unit"/> will be set to <see cref="UnitOfMeasure.None"/>.
     /// </summary>
-    /// <param name="Value">The initial value to be displayed to the user.</param>
-    /// <param name="Unit">The <see cref="UnitOfMeasure"/> to be used when formatting <paramref name="Value"/> for display and when parsing user input.</param>
-    public record DisplayAmount(float Value, UnitOfMeasure Unit = UnitOfMeasure.None) {
-        /// <summary>
-        /// Gets or sets the value. This is either the value to be displayed or the value after modification by the user.
-        /// </summary>
-        public float Value { get; set; } = Value;
-
-        /// <summary>
-        /// Creates a new <see cref="DisplayAmount"/> for basic numeric display. <see cref="Unit"/> will be set to <see cref="UnitOfMeasure.None"/>.
-        /// </summary>
-        /// <param name="value">The initial value to be displayed to the user.</param>
-        public static implicit operator DisplayAmount(float value) => new(value);
-    }
+    /// <param name="value">The initial value to be displayed to the user.</param>
+    public static implicit operator DisplayAmount(float value) => new(value);
 }

--- a/Yafc/Widgets/MainScreenTabBar.cs
+++ b/Yafc/Widgets/MainScreenTabBar.cs
@@ -4,147 +4,146 @@ using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class MainScreenTabBar {
-        private readonly MainScreen screen;
-        private readonly ImGui tabs;
-        public float maxScroll { get; private set; }
+namespace Yafc;
+public class MainScreenTabBar {
+    private readonly MainScreen screen;
+    private readonly ImGui tabs;
+    public float maxScroll { get; private set; }
 
-        public MainScreenTabBar(MainScreen screen) {
-            this.screen = screen;
-            tabs = new ImGui(BuildContents, default, RectAllocator.LeftRow, true);
-        }
+    public MainScreenTabBar(MainScreen screen) {
+        this.screen = screen;
+        tabs = new ImGui(BuildContents, default, RectAllocator.LeftRow, true);
+    }
 
-        private void BuildContents(ImGui gui) {
-            gui.allocator = RectAllocator.LeftRow;
-            gui.spacing = 0f;
-            int changePage = 0;
-            ProjectPage? changePageTo = null;
-            ProjectPage? prevPage = null;
-            float right = 0f;
-            var project = screen.project;
-            for (int i = 0; i < project.displayPages.Count; i++) {
-                var pageGuid = project.displayPages[i];
-                var page = project.FindPage(pageGuid);
-                if (page == null) {
-                    continue;
-                }
-
-                if (changePage > 0 && changePageTo == null) {
-                    changePageTo = page;
-                }
-
-                bool isActive = screen.activePage == page;
-                bool isSecondary = screen.secondaryPage == page;
-                using (gui.EnterGroup(new Padding(0.5f, 0.2f, 0.2f, 0.5f))) {
-                    gui.spacing = 0.2f;
-                    if (page.icon != null) {
-                        gui.BuildIcon(page.icon.icon);
-                    }
-                    else {
-                        _ = gui.AllocateRect(0f, 1.5f);
-                    }
-
-                    gui.BuildText(page.name);
-                    if (gui.BuildButton(Icon.Close, size: 0.8f)) {
-                        if (isActive || isSecondary) {
-                            changePageTo = prevPage;
-                            changePage = isActive ? 1 : 2;
-                        }
-                        screen.ClosePage(pageGuid);
-                        i--;
-                    }
-                }
-
-                right = gui.lastRect.Right;
-
-                if (gui.DoListReordering(gui.lastRect, gui.lastRect, i, out int from)) {
-                    project.RecordUndo(true).displayPages.MoveListElementIndex(from, i);
-                }
-
-                if ((isActive || isSecondary) && gui.isBuilding) {
-                    gui.DrawRectangle(new Rect(gui.lastRect.X, gui.lastRect.Bottom - 0.4f, gui.lastRect.Width, 0.4f), isActive ? SchemeColor.Primary : SchemeColor.Secondary);
-                }
-
-                var evt = gui.BuildButton(gui.lastRect, isActive ? SchemeColor.Background : SchemeColor.BackgroundAlt, (isActive || isSecondary) ? SchemeColor.Background : SchemeColor.Grey, button: 0);
-                if (evt == ButtonEvent.Click) {
-                    if (gui.actionParameter == SDL.SDL_BUTTON_RIGHT) {
-                        gui.window?.HideTooltip(); // otherwise it's displayed over the dropdown
-                        gui.ShowDropDown(gui => PageRightClickDropdown(gui, page));
-                    }
-                    else {
-                        changePage = InputSystem.Instance.control ? 2 : 1;
-                        changePageTo = page;
-                    }
-                }
-                else if (evt == ButtonEvent.MouseOver) {
-                    screen.ShowTooltip(gui, page, false, gui.lastRect);
-                }
-
-                prevPage = page;
-
+    private void BuildContents(ImGui gui) {
+        gui.allocator = RectAllocator.LeftRow;
+        gui.spacing = 0f;
+        int changePage = 0;
+        ProjectPage? changePageTo = null;
+        ProjectPage? prevPage = null;
+        float right = 0f;
+        var project = screen.project;
+        for (int i = 0; i < project.displayPages.Count; i++) {
+            var pageGuid = project.displayPages[i];
+            var page = project.FindPage(pageGuid);
+            if (page == null) {
+                continue;
             }
 
-            gui.SetMinWidth(right);
+            if (changePage > 0 && changePageTo == null) {
+                changePageTo = page;
+            }
 
-            if (changePage > 0) {
-                if (changePage == 1) {
-                    if (changePageTo == screen.activePage) {
-                        ProjectPageSettingsPanel.Show(changePageTo);
-                    }
-                    else {
-                        screen.SetActivePage(changePageTo);
-                    }
+            bool isActive = screen.activePage == page;
+            bool isSecondary = screen.secondaryPage == page;
+            using (gui.EnterGroup(new Padding(0.5f, 0.2f, 0.2f, 0.5f))) {
+                gui.spacing = 0.2f;
+                if (page.icon != null) {
+                    gui.BuildIcon(page.icon.icon);
                 }
                 else {
-                    screen.SetSecondaryPage(changePageTo == screen.secondaryPage ? null : changePageTo);
+                    _ = gui.AllocateRect(0f, 1.5f);
                 }
-            }
-        }
 
-        private void PageRightClickDropdown(ImGui gui, ProjectPage page) {
-            var isSecondary = screen.secondaryPage == page;
-            var isActive = screen.activePage == page;
-            if (gui.BuildContextMenuButton("Edit properties")) {
-                gui.CloseDropdown();
-                ProjectPageSettingsPanel.Show(page);
-            }
-            if (!isSecondary && !isActive) {
-                if (gui.BuildContextMenuButton("Open as secondary", "Ctrl+Click")) {
-                    gui.CloseDropdown();
-                    screen.SetSecondaryPage(page);
-                }
-            }
-            else if (isSecondary) {
-                if (gui.BuildContextMenuButton("Close secondary", "Ctrl+Click")) {
-                    gui.CloseDropdown();
-                    screen.SetSecondaryPage(null);
-                }
-            }
-            if (gui.BuildContextMenuButton("Duplicate")) {
-                gui.CloseDropdown();
-                if (ProjectPageSettingsPanel.ClonePage(page) is { } copy) {
-                    screen.project.RecordUndo().pages.Add(copy);
-                    MainScreen.Instance.SetActivePage(copy);
-                }
-            }
-        }
-
-        public void Build(ImGui gui) {
-            var rect = gui.RemainingRow().AllocateRect(0f, 2.1f, RectAlignment.Full);
-            switch (gui.action) {
-                case ImGuiAction.Build:
-                    gui.DrawPanel(rect, tabs);
-                    var measuredSize = tabs.CalculateState(0f, gui.pixelsPerUnit);
-                    maxScroll = MathF.Max(0f, measuredSize.X - rect.Width);
-                    break;
-                case ImGuiAction.MouseScroll:
-                    if (gui.ConsumeEvent(rect)) {
-                        float clampedX = MathUtils.Clamp(-tabs.offset.X + (6f * gui.actionParameter), 0, maxScroll);
-                        tabs.offset = new Vector2(-clampedX, 0f);
+                gui.BuildText(page.name);
+                if (gui.BuildButton(Icon.Close, size: 0.8f)) {
+                    if (isActive || isSecondary) {
+                        changePageTo = prevPage;
+                        changePage = isActive ? 1 : 2;
                     }
-                    break;
+                    screen.ClosePage(pageGuid);
+                    i--;
+                }
             }
+
+            right = gui.lastRect.Right;
+
+            if (gui.DoListReordering(gui.lastRect, gui.lastRect, i, out int from)) {
+                project.RecordUndo(true).displayPages.MoveListElementIndex(from, i);
+            }
+
+            if ((isActive || isSecondary) && gui.isBuilding) {
+                gui.DrawRectangle(new Rect(gui.lastRect.X, gui.lastRect.Bottom - 0.4f, gui.lastRect.Width, 0.4f), isActive ? SchemeColor.Primary : SchemeColor.Secondary);
+            }
+
+            var evt = gui.BuildButton(gui.lastRect, isActive ? SchemeColor.Background : SchemeColor.BackgroundAlt, (isActive || isSecondary) ? SchemeColor.Background : SchemeColor.Grey, button: 0);
+            if (evt == ButtonEvent.Click) {
+                if (gui.actionParameter == SDL.SDL_BUTTON_RIGHT) {
+                    gui.window?.HideTooltip(); // otherwise it's displayed over the dropdown
+                    gui.ShowDropDown(gui => PageRightClickDropdown(gui, page));
+                }
+                else {
+                    changePage = InputSystem.Instance.control ? 2 : 1;
+                    changePageTo = page;
+                }
+            }
+            else if (evt == ButtonEvent.MouseOver) {
+                screen.ShowTooltip(gui, page, false, gui.lastRect);
+            }
+
+            prevPage = page;
+
+        }
+
+        gui.SetMinWidth(right);
+
+        if (changePage > 0) {
+            if (changePage == 1) {
+                if (changePageTo == screen.activePage) {
+                    ProjectPageSettingsPanel.Show(changePageTo);
+                }
+                else {
+                    screen.SetActivePage(changePageTo);
+                }
+            }
+            else {
+                screen.SetSecondaryPage(changePageTo == screen.secondaryPage ? null : changePageTo);
+            }
+        }
+    }
+
+    private void PageRightClickDropdown(ImGui gui, ProjectPage page) {
+        var isSecondary = screen.secondaryPage == page;
+        var isActive = screen.activePage == page;
+        if (gui.BuildContextMenuButton("Edit properties")) {
+            gui.CloseDropdown();
+            ProjectPageSettingsPanel.Show(page);
+        }
+        if (!isSecondary && !isActive) {
+            if (gui.BuildContextMenuButton("Open as secondary", "Ctrl+Click")) {
+                gui.CloseDropdown();
+                screen.SetSecondaryPage(page);
+            }
+        }
+        else if (isSecondary) {
+            if (gui.BuildContextMenuButton("Close secondary", "Ctrl+Click")) {
+                gui.CloseDropdown();
+                screen.SetSecondaryPage(null);
+            }
+        }
+        if (gui.BuildContextMenuButton("Duplicate")) {
+            gui.CloseDropdown();
+            if (ProjectPageSettingsPanel.ClonePage(page) is { } copy) {
+                screen.project.RecordUndo().pages.Add(copy);
+                MainScreen.Instance.SetActivePage(copy);
+            }
+        }
+    }
+
+    public void Build(ImGui gui) {
+        var rect = gui.RemainingRow().AllocateRect(0f, 2.1f, RectAlignment.Full);
+        switch (gui.action) {
+            case ImGuiAction.Build:
+                gui.DrawPanel(rect, tabs);
+                var measuredSize = tabs.CalculateState(0f, gui.pixelsPerUnit);
+                maxScroll = MathF.Max(0f, measuredSize.X - rect.Width);
+                break;
+            case ImGuiAction.MouseScroll:
+                if (gui.ConsumeEvent(rect)) {
+                    float clampedX = MathUtils.Clamp(-tabs.offset.X + (6f * gui.actionParameter), 0, maxScroll);
+                    tabs.offset = new Vector2(-clampedX, 0f);
+                }
+                break;
         }
     }
 }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -3,562 +3,561 @@ using System.Collections.Generic;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
+namespace Yafc;
+/// <summary>
+/// The location(s) where <see cref="ObjectTooltip"/> should display hints
+/// (currently only "ctrl+click to add recipe" hints)
+/// </summary>
+[Flags]
+public enum HintLocations {
     /// <summary>
-    /// The location(s) where <see cref="ObjectTooltip"/> should display hints
-    /// (currently only "ctrl+click to add recipe" hints)
+    /// Do not display any hints.
     /// </summary>
-    [Flags]
-    public enum HintLocations {
-        /// <summary>
-        /// Do not display any hints.
-        /// </summary>
-        None = 0,
-        /// <summary>
-        /// Display the ctrl+click recipe-selection hint associated with recipes that produce this <see cref="Goods"/>.
-        /// </summary>
-        OnProducingRecipes = 1,
-        /// <summary>
-        /// Display the ctrl+click recipe-selection hint associated with recipes that consume this <see cref="Goods"/>.
-        /// </summary>
-        OnConsumingRecipes = 2,
-        // NOTE: This is [Flags]. The next item, if applicable, should be 4.
+    None = 0,
+    /// <summary>
+    /// Display the ctrl+click recipe-selection hint associated with recipes that produce this <see cref="Goods"/>.
+    /// </summary>
+    OnProducingRecipes = 1,
+    /// <summary>
+    /// Display the ctrl+click recipe-selection hint associated with recipes that consume this <see cref="Goods"/>.
+    /// </summary>
+    OnConsumingRecipes = 2,
+    // NOTE: This is [Flags]. The next item, if applicable, should be 4.
+}
+
+public class ObjectTooltip : Tooltip {
+    public static readonly Padding contentPadding = new Padding(1f, 0.25f);
+
+    public ObjectTooltip() : base(new Padding(0f, 0f, 0f, 0.5f), 25f) { }
+
+    private IFactorioObjectWrapper target = null!; // null-forgiving: Set by SetFocus, aka ShowTooltip.
+    private ObjectTooltipOptions tooltipOptions;
+
+    private void BuildHeader(ImGui gui) {
+        using (gui.EnterGroup(new Padding(1f, 0.5f), RectAllocator.LeftAlign, spacing: 0f)) {
+            string name = target.text;
+            if (tooltipOptions.ShowTypeInHeader && target is not Goods) {
+                name = name + " (" + target.target.type + ")";
+            }
+
+            gui.BuildText(name, new TextBlockDisplayStyle(Font.header, true));
+            var milestoneMask = Milestones.Instance.GetMilestoneResult(target.target);
+            if (milestoneMask.HighestBitSet() > 0) {
+                float spacing = MathF.Min((22f / Milestones.Instance.currentMilestones.Length) - 1f, 0f);
+                using (gui.EnterRow(spacing)) {
+                    int maskBit = 1;
+                    foreach (var milestone in Milestones.Instance.currentMilestones) {
+                        if (milestoneMask[maskBit]) {
+                            gui.BuildIcon(milestone.icon, 1f, SchemeColor.Source);
+                        }
+
+                        maskBit++;
+                    }
+                }
+            }
+        }
+        if (gui.isBuilding) {
+            gui.DrawRectangle(gui.lastRect, SchemeColor.Primary);
+        }
     }
 
-    public class ObjectTooltip : Tooltip {
-        public static readonly Padding contentPadding = new Padding(1f, 0.25f);
-
-        public ObjectTooltip() : base(new Padding(0f, 0f, 0f, 0.5f), 25f) { }
-
-        private IFactorioObjectWrapper target = null!; // null-forgiving: Set by SetFocus, aka ShowTooltip.
-        private ObjectTooltipOptions tooltipOptions;
-
-        private void BuildHeader(ImGui gui) {
-            using (gui.EnterGroup(new Padding(1f, 0.5f), RectAllocator.LeftAlign, spacing: 0f)) {
-                string name = target.text;
-                if (tooltipOptions.ShowTypeInHeader && target is not Goods) {
-                    name = name + " (" + target.target.type + ")";
-                }
-
-                gui.BuildText(name, new TextBlockDisplayStyle(Font.header, true));
-                var milestoneMask = Milestones.Instance.GetMilestoneResult(target.target);
-                if (milestoneMask.HighestBitSet() > 0) {
-                    float spacing = MathF.Min((22f / Milestones.Instance.currentMilestones.Length) - 1f, 0f);
-                    using (gui.EnterRow(spacing)) {
-                        int maskBit = 1;
-                        foreach (var milestone in Milestones.Instance.currentMilestones) {
-                            if (milestoneMask[maskBit]) {
-                                gui.BuildIcon(milestone.icon, 1f, SchemeColor.Source);
-                            }
-
-                            maskBit++;
-                        }
-                    }
-                }
-            }
-            if (gui.isBuilding) {
-                gui.DrawRectangle(gui.lastRect, SchemeColor.Primary);
-            }
+    private void BuildSubHeader(ImGui gui, string text) {
+        using (gui.EnterGroup(contentPadding)) {
+            gui.BuildText(text, Font.subheader);
         }
 
-        private void BuildSubHeader(ImGui gui, string text) {
-            using (gui.EnterGroup(contentPadding)) {
-                gui.BuildText(text, Font.subheader);
-            }
+        if (gui.isBuilding) {
+            gui.DrawRectangle(gui.lastRect, SchemeColor.Grey);
+        }
+    }
 
-            if (gui.isBuilding) {
-                gui.DrawRectangle(gui.lastRect, SchemeColor.Grey);
-            }
+    private void BuildIconRow(ImGui gui, IReadOnlyList<FactorioObject> objects, int maxRows) {
+        const int itemsPerRow = 9;
+        int count = objects.Count;
+        if (count == 0) {
+            gui.BuildText("Nothing", TextBlockDisplayStyle.HintText);
+            return;
         }
 
-        private void BuildIconRow(ImGui gui, IReadOnlyList<FactorioObject> objects, int maxRows) {
-            const int itemsPerRow = 9;
-            int count = objects.Count;
-            if (count == 0) {
-                gui.BuildText("Nothing", TextBlockDisplayStyle.HintText);
-                return;
+        List<FactorioObject> arr = new List<FactorioObject>(count);
+        arr.AddRange(objects);
+        arr.Sort(DataUtils.DefaultOrdering);
+
+        if (count <= maxRows) {
+            for (int i = 0; i < count; i++) {
+                _ = gui.BuildFactorioObjectButtonWithText(arr[i]);
             }
 
-            List<FactorioObject> arr = new List<FactorioObject>(count);
-            arr.AddRange(objects);
-            arr.Sort(DataUtils.DefaultOrdering);
-
-            if (count <= maxRows) {
-                for (int i = 0; i < count; i++) {
-                    _ = gui.BuildFactorioObjectButtonWithText(arr[i]);
-                }
-
-                return;
-            }
-
-            int index = 0;
-            if (count - 1 < (maxRows - 1) * itemsPerRow) {
-                _ = gui.BuildFactorioObjectButtonWithText(arr[0]);
-                index++;
-            }
-
-            int rows = Math.Min(((count - 1 - index) / itemsPerRow) + 1, maxRows);
-            for (int i = 0; i < rows; i++) {
-                using (gui.EnterRow()) {
-                    for (int j = 0; j < itemsPerRow; j++) {
-                        if (arr.Count <= index) {
-                            return;
-                        }
-
-                        gui.BuildFactorioObjectIcon(arr[index++]);
-                    }
-                }
-            }
-
-            if (rows * itemsPerRow < count) {
-                gui.BuildText("... and " + (count - (rows * itemsPerRow)) + " more");
-            }
+            return;
         }
 
-        private void BuildItem(ImGui gui, IFactorioObjectWrapper item) {
+        int index = 0;
+        if (count - 1 < (maxRows - 1) * itemsPerRow) {
+            _ = gui.BuildFactorioObjectButtonWithText(arr[0]);
+            index++;
+        }
+
+        int rows = Math.Min(((count - 1 - index) / itemsPerRow) + 1, maxRows);
+        for (int i = 0; i < rows; i++) {
             using (gui.EnterRow()) {
-                gui.BuildFactorioObjectIcon(item.target);
-                gui.BuildText(item.text, TextBlockDisplayStyle.WrappedText);
+                for (int j = 0; j < itemsPerRow; j++) {
+                    if (arr.Count <= index) {
+                        return;
+                    }
+
+                    gui.BuildFactorioObjectIcon(arr[index++]);
+                }
             }
         }
 
-        protected override void BuildContents(ImGui gui) {
-            switch (target.target) {
-                case Technology technology:
-                    BuildTechnology(technology, gui);
-                    break;
-                case Recipe recipe:
-                    BuildRecipe(recipe, gui);
-                    break;
-                case Goods goods:
-                    BuildGoods(goods, gui);
-                    break;
-                case Entity entity:
-                    BuildEntity(entity, gui);
-                    break;
-                default:
-                    BuildCommon(target.target, gui);
-                    break;
+        if (rows * itemsPerRow < count) {
+            gui.BuildText("... and " + (count - (rows * itemsPerRow)) + " more");
+        }
+    }
+
+    private void BuildItem(ImGui gui, IFactorioObjectWrapper item) {
+        using (gui.EnterRow()) {
+            gui.BuildFactorioObjectIcon(item.target);
+            gui.BuildText(item.text, TextBlockDisplayStyle.WrappedText);
+        }
+    }
+
+    protected override void BuildContents(ImGui gui) {
+        switch (target.target) {
+            case Technology technology:
+                BuildTechnology(technology, gui);
+                break;
+            case Recipe recipe:
+                BuildRecipe(recipe, gui);
+                break;
+            case Goods goods:
+                BuildGoods(goods, gui);
+                break;
+            case Entity entity:
+                BuildEntity(entity, gui);
+                break;
+            default:
+                BuildCommon(target.target, gui);
+                break;
+        }
+    }
+
+    private void BuildCommon(FactorioObject target, ImGui gui) {
+        BuildHeader(gui);
+        using (gui.EnterGroup(contentPadding)) {
+            tooltipOptions.DrawBelowHeader?.Invoke(gui);
+
+            if (InputSystem.Instance.control) {
+                gui.BuildText(target.typeDotName);
+            }
+
+            if (target.locDescr != null) {
+                gui.BuildText(target.locDescr, TextBlockDisplayStyle.WrappedText);
+            }
+
+            if (!target.IsAccessible()) {
+                gui.BuildText("This " + target.type + " is inaccessible, or it is only accessible through mod or map script. Middle click to open dependency analyzer to investigate.", TextBlockDisplayStyle.WrappedText);
+            }
+            else if (!target.IsAutomatable()) {
+                gui.BuildText("This " + target.type + " cannot be fully automated. This means that it requires either manual crafting, or manual labor such as cutting trees", TextBlockDisplayStyle.WrappedText);
+            }
+            else {
+                gui.BuildText(CostAnalysis.GetDisplayCost(target), TextBlockDisplayStyle.WrappedText);
+            }
+
+            if (target.IsAccessibleWithCurrentMilestones() && !target.IsAutomatableWithCurrentMilestones()) {
+                gui.BuildText("This " + target.type + " cannot be fully automated at current milestones.", TextBlockDisplayStyle.WrappedText);
+            }
+
+            if (target.specialType != FactorioObjectSpecialType.Normal) {
+                gui.BuildText("Special: " + target.specialType);
             }
         }
+    }
 
-        private void BuildCommon(FactorioObject target, ImGui gui) {
-            BuildHeader(gui);
+    private static readonly Dictionary<EntityEnergyType, string> EnergyDescriptions = new Dictionary<EntityEnergyType, string>
+    {
+        {EntityEnergyType.Electric, "Power usage: "},
+        {EntityEnergyType.Heat, "Heat energy usage: "},
+        {EntityEnergyType.Labor, "Labor energy usage: "},
+        {EntityEnergyType.Void, "Free energy usage: "},
+        {EntityEnergyType.FluidFuel, "Fluid fuel energy usage: "},
+        {EntityEnergyType.FluidHeat, "Fluid heat energy usage: "},
+        {EntityEnergyType.SolidFuel, "Solid fuel energy usage: "},
+    };
+
+    private void BuildEntity(Entity entity, ImGui gui) {
+        BuildCommon(entity, gui);
+
+        if (entity.loot.Length > 0) {
+            BuildSubHeader(gui, "Loot");
             using (gui.EnterGroup(contentPadding)) {
-                tooltipOptions.DrawBelowHeader?.Invoke(gui);
-
-                if (InputSystem.Instance.control) {
-                    gui.BuildText(target.typeDotName);
-                }
-
-                if (target.locDescr != null) {
-                    gui.BuildText(target.locDescr, TextBlockDisplayStyle.WrappedText);
-                }
-
-                if (!target.IsAccessible()) {
-                    gui.BuildText("This " + target.type + " is inaccessible, or it is only accessible through mod or map script. Middle click to open dependency analyzer to investigate.", TextBlockDisplayStyle.WrappedText);
-                }
-                else if (!target.IsAutomatable()) {
-                    gui.BuildText("This " + target.type + " cannot be fully automated. This means that it requires either manual crafting, or manual labor such as cutting trees", TextBlockDisplayStyle.WrappedText);
-                }
-                else {
-                    gui.BuildText(CostAnalysis.GetDisplayCost(target), TextBlockDisplayStyle.WrappedText);
-                }
-
-                if (target.IsAccessibleWithCurrentMilestones() && !target.IsAutomatableWithCurrentMilestones()) {
-                    gui.BuildText("This " + target.type + " cannot be fully automated at current milestones.", TextBlockDisplayStyle.WrappedText);
-                }
-
-                if (target.specialType != FactorioObjectSpecialType.Normal) {
-                    gui.BuildText("Special: " + target.specialType);
+                foreach (var product in entity.loot) {
+                    BuildItem(gui, product);
                 }
             }
         }
 
-        private static readonly Dictionary<EntityEnergyType, string> EnergyDescriptions = new Dictionary<EntityEnergyType, string>
-        {
-            {EntityEnergyType.Electric, "Power usage: "},
-            {EntityEnergyType.Heat, "Heat energy usage: "},
-            {EntityEnergyType.Labor, "Labor energy usage: "},
-            {EntityEnergyType.Void, "Free energy usage: "},
-            {EntityEnergyType.FluidFuel, "Fluid fuel energy usage: "},
-            {EntityEnergyType.FluidHeat, "Fluid heat energy usage: "},
-            {EntityEnergyType.SolidFuel, "Solid fuel energy usage: "},
-        };
+        if (entity.mapGenerated) {
+            using (gui.EnterGroup(contentPadding)) {
+                gui.BuildText("Generates on map (estimated density: " + (entity.mapGenDensity <= 0f ? "unknown" : DataUtils.FormatAmount(entity.mapGenDensity, UnitOfMeasure.None)) + ")", TextBlockDisplayStyle.WrappedText);
+            }
+        }
 
-        private void BuildEntity(Entity entity, ImGui gui) {
-            BuildCommon(entity, gui);
-
-            if (entity.loot.Length > 0) {
-                BuildSubHeader(gui, "Loot");
+        if (entity is EntityCrafter crafter) {
+            if (crafter.recipes.Length > 0) {
+                BuildSubHeader(gui, "Crafts");
                 using (gui.EnterGroup(contentPadding)) {
-                    foreach (var product in entity.loot) {
-                        BuildItem(gui, product);
+                    BuildIconRow(gui, crafter.recipes, 2);
+                    if (crafter.craftingSpeed != 1f) {
+                        gui.BuildText(DataUtils.FormatAmount(crafter.craftingSpeed, UnitOfMeasure.Percent, "Crafting speed: "));
+                    }
+
+                    if (crafter.productivity != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(crafter.productivity, UnitOfMeasure.Percent, "Crafting productivity: "));
+                    }
+
+                    if (crafter.allowedEffects != AllowedEffects.None) {
+                        gui.BuildText("Module slots: " + crafter.moduleSlots);
+                        if (crafter.allowedEffects != AllowedEffects.All) {
+                            gui.BuildText("Only allowed effects: " + crafter.allowedEffects, TextBlockDisplayStyle.WrappedText);
+                        }
                     }
                 }
             }
 
-            if (entity.mapGenerated) {
+            if (crafter.inputs != null) {
+                BuildSubHeader(gui, "Allowed inputs:");
                 using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("Generates on map (estimated density: " + (entity.mapGenDensity <= 0f ? "unknown" : DataUtils.FormatAmount(entity.mapGenDensity, UnitOfMeasure.None)) + ")", TextBlockDisplayStyle.WrappedText);
-                }
-            }
-
-            if (entity is EntityCrafter crafter) {
-                if (crafter.recipes.Length > 0) {
-                    BuildSubHeader(gui, "Crafts");
-                    using (gui.EnterGroup(contentPadding)) {
-                        BuildIconRow(gui, crafter.recipes, 2);
-                        if (crafter.craftingSpeed != 1f) {
-                            gui.BuildText(DataUtils.FormatAmount(crafter.craftingSpeed, UnitOfMeasure.Percent, "Crafting speed: "));
-                        }
-
-                        if (crafter.productivity != 0f) {
-                            gui.BuildText(DataUtils.FormatAmount(crafter.productivity, UnitOfMeasure.Percent, "Crafting productivity: "));
-                        }
-
-                        if (crafter.allowedEffects != AllowedEffects.None) {
-                            gui.BuildText("Module slots: " + crafter.moduleSlots);
-                            if (crafter.allowedEffects != AllowedEffects.All) {
-                                gui.BuildText("Only allowed effects: " + crafter.allowedEffects, TextBlockDisplayStyle.WrappedText);
-                            }
-                        }
-                    }
-                }
-
-                if (crafter.inputs != null) {
-                    BuildSubHeader(gui, "Allowed inputs:");
-                    using (gui.EnterGroup(contentPadding)) {
-                        BuildIconRow(gui, crafter.inputs, 2);
-                    }
-                }
-            }
-
-            if (entity.energy != null) {
-                string energyUsage = EnergyDescriptions[entity.energy.type] + DataUtils.FormatAmount(entity.power, UnitOfMeasure.Megawatt);
-                if (entity.energy.drain > 0f) {
-                    energyUsage += " + " + DataUtils.FormatAmount(entity.energy.drain, UnitOfMeasure.Megawatt);
-                }
-
-                BuildSubHeader(gui, energyUsage);
-                using (gui.EnterGroup(contentPadding)) {
-                    if (entity.energy.type is EntityEnergyType.FluidFuel or EntityEnergyType.SolidFuel or EntityEnergyType.FluidHeat) {
-                        BuildIconRow(gui, entity.energy.fuels, 2);
-                    }
-
-                    if (entity.energy.emissions != 0f) {
-                        TextBlockDisplayStyle emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.BackgroundText);
-                        if (entity.energy.emissions < 0f) {
-                            emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Green);
-                            gui.BuildText("This building absorbs pollution", emissionStyle);
-                        }
-                        else if (entity.energy.emissions >= 20f) {
-                            emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Error);
-                            gui.BuildText("This building contributes to global warning!", emissionStyle);
-                        }
-                        gui.BuildText("Emissions: " + DataUtils.FormatAmount(entity.energy.emissions, UnitOfMeasure.None), emissionStyle);
-                    }
-                }
-            }
-
-            string? miscText = null;
-
-            switch (entity) {
-                case EntityBelt belt:
-                    miscText = "Belt throughput (Items): " + DataUtils.FormatAmount(belt.beltItemsPerSecond, UnitOfMeasure.PerSecond);
-                    break;
-                case EntityInserter inserter:
-                    miscText = "Swing time: " + DataUtils.FormatAmount(inserter.inserterSwingTime, UnitOfMeasure.Second);
-                    break;
-                case EntityBeacon beacon:
-                    miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.beaconEfficiency, UnitOfMeasure.Percent);
-                    break;
-                case EntityAccumulator accumulator:
-                    miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.accumulatorCapacity, UnitOfMeasure.Megajoule);
-                    break;
-                case EntityCrafter solarPanel:
-                    if (solarPanel.craftingSpeed > 0f && entity.factorioType == "solar-panel") {
-                        miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.craftingSpeed, UnitOfMeasure.Megawatt);
-                    }
-
-                    break;
-            }
-
-            if (miscText != null) {
-                using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText(miscText);
+                    BuildIconRow(gui, crafter.inputs, 2);
                 }
             }
         }
 
-        private void BuildGoods(Goods goods, ImGui gui) {
-            BuildCommon(goods, gui);
-            if (goods.showInExplorers) {
-                using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, TextBlockDisplayStyle.WrappedText);
-                }
+        if (entity.energy != null) {
+            string energyUsage = EnergyDescriptions[entity.energy.type] + DataUtils.FormatAmount(entity.power, UnitOfMeasure.Megawatt);
+            if (entity.energy.drain > 0f) {
+                energyUsage += " + " + DataUtils.FormatAmount(entity.energy.drain, UnitOfMeasure.Megawatt);
             }
 
-            if (goods.production.Length > 0) {
-                BuildSubHeader(gui, "Made with");
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, goods.production, 2);
-                    if (tooltipOptions.HintLocations.HasFlag(HintLocations.OnProducingRecipes)) {
-                        goods.production.SelectSingle(out string recipeTip);
-                        gui.BuildText(recipeTip, TextBlockDisplayStyle.HintText);
+            BuildSubHeader(gui, energyUsage);
+            using (gui.EnterGroup(contentPadding)) {
+                if (entity.energy.type is EntityEnergyType.FluidFuel or EntityEnergyType.SolidFuel or EntityEnergyType.FluidHeat) {
+                    BuildIconRow(gui, entity.energy.fuels, 2);
+                }
+
+                if (entity.energy.emissions != 0f) {
+                    TextBlockDisplayStyle emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.BackgroundText);
+                    if (entity.energy.emissions < 0f) {
+                        emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Green);
+                        gui.BuildText("This building absorbs pollution", emissionStyle);
                     }
-                }
-            }
-
-            if (goods.miscSources.Length > 0) {
-                BuildSubHeader(gui, "Sources");
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, goods.miscSources, 2);
-                }
-            }
-
-            if (goods.usages.Length > 0) {
-                BuildSubHeader(gui, "Needed for");
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, goods.usages, 4);
-                    if (tooltipOptions.HintLocations.HasFlag(HintLocations.OnConsumingRecipes)) {
-                        goods.usages.SelectSingle(out string recipeTip);
-                        gui.BuildText(recipeTip, TextBlockDisplayStyle.HintText);
+                    else if (entity.energy.emissions >= 20f) {
+                        emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Error);
+                        gui.BuildText("This building contributes to global warning!", emissionStyle);
                     }
-                }
-            }
-
-            if (goods.fuelFor.Length > 0) {
-                if (goods.fuelValue > 0f) {
-                    BuildSubHeader(gui, "Fuel value " + DataUtils.FormatAmount(goods.fuelValue, UnitOfMeasure.Megajoule) + " used for:");
-                }
-                else {
-                    BuildSubHeader(gui, "Can be used as fuel for:");
-                }
-
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, goods.fuelFor, 2);
-                }
-            }
-
-            if (goods is Item item) {
-                if (goods.fuelValue > 0f && item.fuelResult != null) {
-                    using (gui.EnterGroup(contentPadding)) {
-                        BuildItem(gui, item.fuelResult);
-                    }
-                }
-
-                if (item.placeResult != null) {
-                    BuildSubHeader(gui, "Place result");
-                    using (gui.EnterGroup(contentPadding)) {
-                        BuildItem(gui, item.placeResult);
-                    }
-                }
-
-                if (item is Module { moduleSpecification: ModuleSpecification moduleSpecification }) {
-                    BuildSubHeader(gui, "Module parameters");
-                    using (gui.EnterGroup(contentPadding)) {
-                        if (moduleSpecification.productivity != 0f) {
-                            gui.BuildText(DataUtils.FormatAmount(moduleSpecification.productivity, UnitOfMeasure.Percent, "Productivity: "));
-                        }
-
-                        if (moduleSpecification.speed != 0f) {
-                            gui.BuildText(DataUtils.FormatAmount(moduleSpecification.speed, UnitOfMeasure.Percent, "Speed: "));
-                        }
-
-                        if (moduleSpecification.consumption != 0f) {
-                            gui.BuildText(DataUtils.FormatAmount(moduleSpecification.consumption, UnitOfMeasure.Percent, "Consumption: "));
-                        }
-
-                        if (moduleSpecification.pollution != 0f) {
-                            gui.BuildText(DataUtils.FormatAmount(moduleSpecification.consumption, UnitOfMeasure.Percent, "Pollution: "));
-                        }
-                    }
-                    if (moduleSpecification.limitation != null) {
-                        BuildSubHeader(gui, "Module limitation");
-                        using (gui.EnterGroup(contentPadding)) {
-                            BuildIconRow(gui, moduleSpecification.limitation, 2);
-                        }
-                    }
-                }
-
-                using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("Stack size: " + item.stackSize);
+                    gui.BuildText("Emissions: " + DataUtils.FormatAmount(entity.energy.emissions, UnitOfMeasure.None), emissionStyle);
                 }
             }
         }
 
-        private void BuildRecipe(RecipeOrTechnology recipe, ImGui gui) {
-            BuildCommon(recipe, gui);
-            using (gui.EnterGroup(contentPadding, RectAllocator.LeftRow)) {
-                gui.BuildIcon(Icon.Time, 2f, SchemeColor.BackgroundText);
-                gui.BuildText(DataUtils.FormatAmount(recipe.time, UnitOfMeasure.Second));
+        string? miscText = null;
+
+        switch (entity) {
+            case EntityBelt belt:
+                miscText = "Belt throughput (Items): " + DataUtils.FormatAmount(belt.beltItemsPerSecond, UnitOfMeasure.PerSecond);
+                break;
+            case EntityInserter inserter:
+                miscText = "Swing time: " + DataUtils.FormatAmount(inserter.inserterSwingTime, UnitOfMeasure.Second);
+                break;
+            case EntityBeacon beacon:
+                miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.beaconEfficiency, UnitOfMeasure.Percent);
+                break;
+            case EntityAccumulator accumulator:
+                miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.accumulatorCapacity, UnitOfMeasure.Megajoule);
+                break;
+            case EntityCrafter solarPanel:
+                if (solarPanel.craftingSpeed > 0f && entity.factorioType == "solar-panel") {
+                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.craftingSpeed, UnitOfMeasure.Megawatt);
+                }
+
+                break;
+        }
+
+        if (miscText != null) {
+            using (gui.EnterGroup(contentPadding)) {
+                gui.BuildText(miscText);
+            }
+        }
+    }
+
+    private void BuildGoods(Goods goods, ImGui gui) {
+        BuildCommon(goods, gui);
+        if (goods.showInExplorers) {
+            using (gui.EnterGroup(contentPadding)) {
+                gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, TextBlockDisplayStyle.WrappedText);
+            }
+        }
+
+        if (goods.production.Length > 0) {
+            BuildSubHeader(gui, "Made with");
+            using (gui.EnterGroup(contentPadding)) {
+                BuildIconRow(gui, goods.production, 2);
+                if (tooltipOptions.HintLocations.HasFlag(HintLocations.OnProducingRecipes)) {
+                    goods.production.SelectSingle(out string recipeTip);
+                    gui.BuildText(recipeTip, TextBlockDisplayStyle.HintText);
+                }
+            }
+        }
+
+        if (goods.miscSources.Length > 0) {
+            BuildSubHeader(gui, "Sources");
+            using (gui.EnterGroup(contentPadding)) {
+                BuildIconRow(gui, goods.miscSources, 2);
+            }
+        }
+
+        if (goods.usages.Length > 0) {
+            BuildSubHeader(gui, "Needed for");
+            using (gui.EnterGroup(contentPadding)) {
+                BuildIconRow(gui, goods.usages, 4);
+                if (tooltipOptions.HintLocations.HasFlag(HintLocations.OnConsumingRecipes)) {
+                    goods.usages.SelectSingle(out string recipeTip);
+                    gui.BuildText(recipeTip, TextBlockDisplayStyle.HintText);
+                }
+            }
+        }
+
+        if (goods.fuelFor.Length > 0) {
+            if (goods.fuelValue > 0f) {
+                BuildSubHeader(gui, "Fuel value " + DataUtils.FormatAmount(goods.fuelValue, UnitOfMeasure.Megajoule) + " used for:");
+            }
+            else {
+                BuildSubHeader(gui, "Can be used as fuel for:");
             }
 
             using (gui.EnterGroup(contentPadding)) {
-                foreach (var ingredient in recipe.ingredients) {
-                    BuildItem(gui, ingredient);
-                }
-
-                if (recipe is Recipe rec) {
-                    float waste = rec.RecipeWaste();
-                    if (waste > 0.01f) {
-                        int wasteAmount = MathUtils.Round(waste * 100f);
-                        string wasteText = ". (Wasting " + wasteAmount + "% of YAFC cost)";
-                        TextBlockDisplayStyle style = TextBlockDisplayStyle.WrappedText with { Color = wasteAmount < 90 ? SchemeColor.BackgroundText : SchemeColor.Error };
-                        if (recipe.products.Length == 1) {
-                            gui.BuildText("YAFC analysis: There are better recipes to create " + recipe.products[0].goods.locName + wasteText, style);
-                        }
-                        else if (recipe.products.Length > 0) {
-                            gui.BuildText("YAFC analysis: There are better recipes to create each of the products" + wasteText, style);
-                        }
-                        else {
-                            gui.BuildText("YAFC analysis: This recipe wastes useful products. Don't do this recipe.", style);
-                        }
-                    }
-                }
-                if (recipe.flags.HasFlags(RecipeFlags.UsesFluidTemperature)) {
-                    gui.BuildText("Uses fluid temperature");
-                }
-
-                if (recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity)) {
-                    gui.BuildText("Uses mining productivity");
-                }
-
-                if (recipe.flags.HasFlags(RecipeFlags.ScaleProductionWithPower)) {
-                    gui.BuildText("Production scaled with power");
-                }
+                BuildIconRow(gui, goods.fuelFor, 2);
             }
+        }
 
-            if (recipe.products.Length > 0 && !(recipe.products.Length == 1 && recipe.products[0].IsSimple && recipe.products[0].goods is Item && recipe.products[0].amount == 1f)) {
-                BuildSubHeader(gui, "Products");
+        if (goods is Item item) {
+            if (goods.fuelValue > 0f && item.fuelResult != null) {
                 using (gui.EnterGroup(contentPadding)) {
-                    foreach (var product in recipe.products) {
-                        BuildItem(gui, product);
+                    BuildItem(gui, item.fuelResult);
+                }
+            }
+
+            if (item.placeResult != null) {
+                BuildSubHeader(gui, "Place result");
+                using (gui.EnterGroup(contentPadding)) {
+                    BuildItem(gui, item.placeResult);
+                }
+            }
+
+            if (item is Module { moduleSpecification: ModuleSpecification moduleSpecification }) {
+                BuildSubHeader(gui, "Module parameters");
+                using (gui.EnterGroup(contentPadding)) {
+                    if (moduleSpecification.productivity != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.productivity, UnitOfMeasure.Percent, "Productivity: "));
+                    }
+
+                    if (moduleSpecification.speed != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.speed, UnitOfMeasure.Percent, "Speed: "));
+                    }
+
+                    if (moduleSpecification.consumption != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.consumption, UnitOfMeasure.Percent, "Consumption: "));
+                    }
+
+                    if (moduleSpecification.pollution != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.consumption, UnitOfMeasure.Percent, "Pollution: "));
+                    }
+                }
+                if (moduleSpecification.limitation != null) {
+                    BuildSubHeader(gui, "Module limitation");
+                    using (gui.EnterGroup(contentPadding)) {
+                        BuildIconRow(gui, moduleSpecification.limitation, 2);
                     }
                 }
             }
 
-            BuildSubHeader(gui, "Made in");
             using (gui.EnterGroup(contentPadding)) {
-                BuildIconRow(gui, recipe.crafters, 2);
+                gui.BuildText("Stack size: " + item.stackSize);
+            }
+        }
+    }
+
+    private void BuildRecipe(RecipeOrTechnology recipe, ImGui gui) {
+        BuildCommon(recipe, gui);
+        using (gui.EnterGroup(contentPadding, RectAllocator.LeftRow)) {
+            gui.BuildIcon(Icon.Time, 2f, SchemeColor.BackgroundText);
+            gui.BuildText(DataUtils.FormatAmount(recipe.time, UnitOfMeasure.Second));
+        }
+
+        using (gui.EnterGroup(contentPadding)) {
+            foreach (var ingredient in recipe.ingredients) {
+                BuildItem(gui, ingredient);
             }
 
-            if (recipe.modules.Length > 0) {
-                BuildSubHeader(gui, "Allowed modules");
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, recipe.modules, 1);
-                }
-
-                var crafterCommonModules = AllowedEffects.All;
-                foreach (var crafter in recipe.crafters) {
-                    if (crafter.moduleSlots > 0) {
-                        crafterCommonModules &= crafter.allowedEffects;
+            if (recipe is Recipe rec) {
+                float waste = rec.RecipeWaste();
+                if (waste > 0.01f) {
+                    int wasteAmount = MathUtils.Round(waste * 100f);
+                    string wasteText = ". (Wasting " + wasteAmount + "% of YAFC cost)";
+                    TextBlockDisplayStyle style = TextBlockDisplayStyle.WrappedText with { Color = wasteAmount < 90 ? SchemeColor.BackgroundText : SchemeColor.Error };
+                    if (recipe.products.Length == 1) {
+                        gui.BuildText("YAFC analysis: There are better recipes to create " + recipe.products[0].goods.locName + wasteText, style);
                     }
-                }
-
-                foreach (var module in recipe.modules) {
-                    if (!EntityWithModules.CanAcceptModule(module.moduleSpecification, crafterCommonModules)) {
-                        using (gui.EnterGroup(contentPadding)) {
-                            gui.BuildText("Some crafters restrict module usage");
-                        }
-
-                        break;
-                    }
-                }
-            }
-
-            if (recipe is Recipe lockedRecipe && !lockedRecipe.enabled) {
-                BuildSubHeader(gui, "Unlocked by");
-                using (gui.EnterGroup(contentPadding)) {
-                    if (lockedRecipe.technologyUnlock.Length > 2) {
-                        BuildIconRow(gui, lockedRecipe.technologyUnlock, 1);
+                    else if (recipe.products.Length > 0) {
+                        gui.BuildText("YAFC analysis: There are better recipes to create each of the products" + wasteText, style);
                     }
                     else {
-                        foreach (var technology in lockedRecipe.technologyUnlock) {
-                            var ingredient = TechnologyScienceAnalysis.Instance.GetMaxTechnologyIngredient(technology);
-                            using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
-                                gui.spacing = 0f;
-                                if (ingredient != null) {
-                                    gui.BuildFactorioObjectIcon(ingredient.goods);
-                                    gui.BuildText(DataUtils.FormatAmount(ingredient.amount, UnitOfMeasure.None));
-                                }
+                        gui.BuildText("YAFC analysis: This recipe wastes useful products. Don't do this recipe.", style);
+                    }
+                }
+            }
+            if (recipe.flags.HasFlags(RecipeFlags.UsesFluidTemperature)) {
+                gui.BuildText("Uses fluid temperature");
+            }
 
-                                gui.allocator = RectAllocator.RemainingRow;
-                                _ = gui.BuildFactorioObjectButtonWithText(technology);
+            if (recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity)) {
+                gui.BuildText("Uses mining productivity");
+            }
+
+            if (recipe.flags.HasFlags(RecipeFlags.ScaleProductionWithPower)) {
+                gui.BuildText("Production scaled with power");
+            }
+        }
+
+        if (recipe.products.Length > 0 && !(recipe.products.Length == 1 && recipe.products[0].IsSimple && recipe.products[0].goods is Item && recipe.products[0].amount == 1f)) {
+            BuildSubHeader(gui, "Products");
+            using (gui.EnterGroup(contentPadding)) {
+                foreach (var product in recipe.products) {
+                    BuildItem(gui, product);
+                }
+            }
+        }
+
+        BuildSubHeader(gui, "Made in");
+        using (gui.EnterGroup(contentPadding)) {
+            BuildIconRow(gui, recipe.crafters, 2);
+        }
+
+        if (recipe.modules.Length > 0) {
+            BuildSubHeader(gui, "Allowed modules");
+            using (gui.EnterGroup(contentPadding)) {
+                BuildIconRow(gui, recipe.modules, 1);
+            }
+
+            var crafterCommonModules = AllowedEffects.All;
+            foreach (var crafter in recipe.crafters) {
+                if (crafter.moduleSlots > 0) {
+                    crafterCommonModules &= crafter.allowedEffects;
+                }
+            }
+
+            foreach (var module in recipe.modules) {
+                if (!EntityWithModules.CanAcceptModule(module.moduleSpecification, crafterCommonModules)) {
+                    using (gui.EnterGroup(contentPadding)) {
+                        gui.BuildText("Some crafters restrict module usage");
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        if (recipe is Recipe lockedRecipe && !lockedRecipe.enabled) {
+            BuildSubHeader(gui, "Unlocked by");
+            using (gui.EnterGroup(contentPadding)) {
+                if (lockedRecipe.technologyUnlock.Length > 2) {
+                    BuildIconRow(gui, lockedRecipe.technologyUnlock, 1);
+                }
+                else {
+                    foreach (var technology in lockedRecipe.technologyUnlock) {
+                        var ingredient = TechnologyScienceAnalysis.Instance.GetMaxTechnologyIngredient(technology);
+                        using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
+                            gui.spacing = 0f;
+                            if (ingredient != null) {
+                                gui.BuildFactorioObjectIcon(ingredient.goods);
+                                gui.BuildText(DataUtils.FormatAmount(ingredient.amount, UnitOfMeasure.None));
                             }
+
+                            gui.allocator = RectAllocator.RemainingRow;
+                            _ = gui.BuildFactorioObjectButtonWithText(technology);
                         }
                     }
                 }
             }
         }
+    }
 
-        private void BuildTechnology(Technology technology, ImGui gui) {
-            BuildRecipe(technology, gui);
-            if (technology.hidden && !technology.enabled) {
-                using (gui.EnterGroup(contentPadding)) {
-                    gui.BuildText("This technology is hidden from the list and cannot be researched.", TextBlockDisplayStyle.WrappedText);
-                }
-            }
-
-            if (technology.prerequisites.Length > 0) {
-                BuildSubHeader(gui, "Prerequisites");
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, technology.prerequisites, 1);
-                }
-            }
-
-            if (technology.unlockRecipes.Length > 0) {
-                BuildSubHeader(gui, "Unlocks recipes");
-                using (gui.EnterGroup(contentPadding)) {
-                    BuildIconRow(gui, technology.unlockRecipes, 2);
-                }
-            }
-
-            var packs = TechnologyScienceAnalysis.Instance.allSciencePacks[technology];
-            if (packs.Length > 0) {
-                BuildSubHeader(gui, "Total science required");
-                using (gui.EnterGroup(contentPadding)) {
-                    using var grid = gui.EnterInlineGrid(3f);
-                    foreach (var pack in packs) {
-                        grid.Next();
-                        _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount, ButtonDisplayStyle.ProductionTableUnscaled);
-                    }
-                }
+    private void BuildTechnology(Technology technology, ImGui gui) {
+        BuildRecipe(technology, gui);
+        if (technology.hidden && !technology.enabled) {
+            using (gui.EnterGroup(contentPadding)) {
+                gui.BuildText("This technology is hidden from the list and cannot be researched.", TextBlockDisplayStyle.WrappedText);
             }
         }
 
-        public void SetFocus(IFactorioObjectWrapper target, ImGui gui, Rect rect, ObjectTooltipOptions tooltipOptions) {
-            this.tooltipOptions = tooltipOptions;
-            this.target = target;
-            base.SetFocus(gui, rect);
+        if (technology.prerequisites.Length > 0) {
+            BuildSubHeader(gui, "Prerequisites");
+            using (gui.EnterGroup(contentPadding)) {
+                BuildIconRow(gui, technology.prerequisites, 1);
+            }
         }
 
-        public bool IsSameObjectHovered(ImGui gui, FactorioObject? factorioObject) => source == gui && factorioObject == target.target && gui.IsMouseOver(sourceRect);
+        if (technology.unlockRecipes.Length > 0) {
+            BuildSubHeader(gui, "Unlocks recipes");
+            using (gui.EnterGroup(contentPadding)) {
+                BuildIconRow(gui, technology.unlockRecipes, 2);
+            }
+        }
+
+        var packs = TechnologyScienceAnalysis.Instance.allSciencePacks[technology];
+        if (packs.Length > 0) {
+            BuildSubHeader(gui, "Total science required");
+            using (gui.EnterGroup(contentPadding)) {
+                using var grid = gui.EnterInlineGrid(3f);
+                foreach (var pack in packs) {
+                    grid.Next();
+                    _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount, ButtonDisplayStyle.ProductionTableUnscaled);
+                }
+            }
+        }
     }
 
-    public struct ObjectTooltipOptions {
-        /// <summary>
-        /// If <see langword="true"/> and the target object is not a <see cref="Goods"/>, this tooltip will specify the type of object.
-        /// e.g. "Radar" is the item, "Radar (Recipe)" is the recipe, and "Radar (Entity)" is the building.
-        /// </summary>
-        public bool ShowTypeInHeader { get; set; }
-        /// <summary>
-        /// Gets or sets flags indicating where hints should be displayed in the tooltip.
-        /// </summary>
-        public HintLocations HintLocations { get; set; }
-        /// <summary>
-        /// Gets or sets a value that, if not null, will be called after drawing the tooltip header.
-        /// </summary>
-        public DrawBelowHeader? DrawBelowHeader { get; set; }
-
-        // Reduce boilerplate by permitting unambiguous and relatively obvious implicit conversions.
-        public static implicit operator ObjectTooltipOptions(HintLocations hintLocations) => new() { HintLocations = hintLocations };
-        public static implicit operator ObjectTooltipOptions(DrawBelowHeader drawBelowHeader) => new() { DrawBelowHeader = drawBelowHeader };
+    public void SetFocus(IFactorioObjectWrapper target, ImGui gui, Rect rect, ObjectTooltipOptions tooltipOptions) {
+        this.tooltipOptions = tooltipOptions;
+        this.target = target;
+        base.SetFocus(gui, rect);
     }
 
-    /// <summary>
-    /// Called to draw additional information in the tooltip after drawing the tooltip header.
-    /// </summary>
-    public delegate void DrawBelowHeader(ImGui gui);
+    public bool IsSameObjectHovered(ImGui gui, FactorioObject? factorioObject) => source == gui && factorioObject == target.target && gui.IsMouseOver(sourceRect);
 }
+
+public struct ObjectTooltipOptions {
+    /// <summary>
+    /// If <see langword="true"/> and the target object is not a <see cref="Goods"/>, this tooltip will specify the type of object.
+    /// e.g. "Radar" is the item, "Radar (Recipe)" is the recipe, and "Radar (Entity)" is the building.
+    /// </summary>
+    public bool ShowTypeInHeader { get; set; }
+    /// <summary>
+    /// Gets or sets flags indicating where hints should be displayed in the tooltip.
+    /// </summary>
+    public HintLocations HintLocations { get; set; }
+    /// <summary>
+    /// Gets or sets a value that, if not null, will be called after drawing the tooltip header.
+    /// </summary>
+    public DrawBelowHeader? DrawBelowHeader { get; set; }
+
+    // Reduce boilerplate by permitting unambiguous and relatively obvious implicit conversions.
+    public static implicit operator ObjectTooltipOptions(HintLocations hintLocations) => new() { HintLocations = hintLocations };
+    public static implicit operator ObjectTooltipOptions(DrawBelowHeader drawBelowHeader) => new() { DrawBelowHeader = drawBelowHeader };
+}
+
+/// <summary>
+/// Called to draw additional information in the tooltip after drawing the tooltip header.
+/// </summary>
+public delegate void DrawBelowHeader(ImGui gui);

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -3,107 +3,106 @@ using System.Numerics;
 using SDL2;
 using Yafc.UI;
 
-namespace Yafc {
-    // Pseudo screen is not an actual screen, it is a panel shown in the middle of the main screen
-    public abstract class PseudoScreen : IKeyboardFocus {
-        public readonly ImGui contents;
-        protected readonly float width;
-        protected bool opened;
-        /// <summary>
-        /// If not <see langword="null"/>, called after the panel is closed to let the inheriting object perform required (cleanup) actions.
-        /// </summary>
-        protected Action? cleanupCallback;
+namespace Yafc;
+// Pseudo screen is not an actual screen, it is a panel shown in the middle of the main screen
+public abstract class PseudoScreen : IKeyboardFocus {
+    public readonly ImGui contents;
+    protected readonly float width;
+    protected bool opened;
+    /// <summary>
+    /// If not <see langword="null"/>, called after the panel is closed to let the inheriting object perform required (cleanup) actions.
+    /// </summary>
+    protected Action? cleanupCallback;
 
-        protected PseudoScreen(float width = 40f) {
-            this.width = width;
-            contents = new ImGui(Build, ImGuiUtils.DefaultScreenPadding) {
-                boxColor = SchemeColor.PureBackground
-            };
-        }
-
-        public virtual void Open() => opened = true;
-        public abstract void Build(ImGui gui);
-
-        public void Build(ImGui gui, Vector2 screenSize) {
-            if (gui.isBuilding) {
-                var contentSize = contents.CalculateState(width, gui.pixelsPerUnit);
-                var position = (screenSize - contentSize) / 2;
-                Rect rect = new Rect(position, contentSize);
-                gui.DrawPanel(rect, contents);
-                gui.DrawRectangle(rect, SchemeColor.None, RectangleBorder.Full);
-            }
-        }
-
-        protected void BuildHeader(ImGui gui, string? text, bool closeButton = true) {
-            gui.BuildText(text, new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
-            if (closeButton) {
-                Rect closeButtonRect = new Rect(width - 3f, 0f, 3f, 2f);
-                if (gui.isBuilding) {
-                    bool isOver = gui.IsMouseOver(closeButtonRect);
-                    Rect closeButtonCenter = Rect.Square(closeButtonRect.Center, 1f);
-                    gui.DrawIcon(closeButtonCenter, Icon.Close, isOver ? SchemeColor.ErrorText : SchemeColor.BackgroundText);
-                }
-                if (gui.BuildButton(closeButtonRect, SchemeColor.None, SchemeColor.Error)) {
-                    Close();
-                }
-            }
-        }
-
-        /// <summary>Closes the pseudo screen</summary>
-        /// <remarks>NOTE: Do not abuse this virtual function for cleaning up, instead use <see cref="cleanupCallback"/>.</remarks>
-        protected virtual void Close() {
-            cleanupCallback?.Invoke();
-
-            opened = false;
-            InputSystem.Instance.SetDefaultKeyboardFocus(null);
-            InputSystem.Instance.SetKeyboardFocus(null);
-            MainScreen.Instance.ClosePseudoScreen(this);
-        }
-
-        public void Rebuild() => contents.Rebuild();
-
-        public virtual bool KeyDown(SDL.SDL_Keysym key) {
-            if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {
-                Close();
-            }
-            if (key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
-                ReturnPressed();
-            }
-
-            return true;
-        }
-
-        protected virtual void ReturnPressed() { }
-
-        public virtual bool TextInput(string input) => true;
-
-        public virtual bool KeyUp(SDL.SDL_Keysym key) => true;
-
-        public virtual void FocusChanged(bool focused) { }
-        public virtual void Activated() => Rebuild();
+    protected PseudoScreen(float width = 40f) {
+        this.width = width;
+        contents = new ImGui(Build, ImGuiUtils.DefaultScreenPadding) {
+            boxColor = SchemeColor.PureBackground
+        };
     }
 
+    public virtual void Open() => opened = true;
+    public abstract void Build(ImGui gui);
+
+    public void Build(ImGui gui, Vector2 screenSize) {
+        if (gui.isBuilding) {
+            var contentSize = contents.CalculateState(width, gui.pixelsPerUnit);
+            var position = (screenSize - contentSize) / 2;
+            Rect rect = new Rect(position, contentSize);
+            gui.DrawPanel(rect, contents);
+            gui.DrawRectangle(rect, SchemeColor.None, RectangleBorder.Full);
+        }
+    }
+
+    protected void BuildHeader(ImGui gui, string? text, bool closeButton = true) {
+        gui.BuildText(text, new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
+        if (closeButton) {
+            Rect closeButtonRect = new Rect(width - 3f, 0f, 3f, 2f);
+            if (gui.isBuilding) {
+                bool isOver = gui.IsMouseOver(closeButtonRect);
+                Rect closeButtonCenter = Rect.Square(closeButtonRect.Center, 1f);
+                gui.DrawIcon(closeButtonCenter, Icon.Close, isOver ? SchemeColor.ErrorText : SchemeColor.BackgroundText);
+            }
+            if (gui.BuildButton(closeButtonRect, SchemeColor.None, SchemeColor.Error)) {
+                Close();
+            }
+        }
+    }
+
+    /// <summary>Closes the pseudo screen</summary>
+    /// <remarks>NOTE: Do not abuse this virtual function for cleaning up, instead use <see cref="cleanupCallback"/>.</remarks>
+    protected virtual void Close() {
+        cleanupCallback?.Invoke();
+
+        opened = false;
+        InputSystem.Instance.SetDefaultKeyboardFocus(null);
+        InputSystem.Instance.SetKeyboardFocus(null);
+        MainScreen.Instance.ClosePseudoScreen(this);
+    }
+
+    public void Rebuild() => contents.Rebuild();
+
+    public virtual bool KeyDown(SDL.SDL_Keysym key) {
+        if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {
+            Close();
+        }
+        if (key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
+            ReturnPressed();
+        }
+
+        return true;
+    }
+
+    protected virtual void ReturnPressed() { }
+
+    public virtual bool TextInput(string input) => true;
+
+    public virtual bool KeyUp(SDL.SDL_Keysym key) => true;
+
+    public virtual void FocusChanged(bool focused) { }
+    public virtual void Activated() => Rebuild();
+}
+
+/// <summary>
+/// Represents a panel that can generate a result. (But doesn't have to, if the user selects a close or cancel button.)
+/// </summary>
+/// <typeparam name="T">The type of result the panel can generate.</typeparam>
+public abstract class PseudoScreenWithResult<T> : PseudoScreen {
+    protected PseudoScreenWithResult(float width = 40f) : base(width) { }
     /// <summary>
-    /// Represents a panel that can generate a result. (But doesn't have to, if the user selects a close or cancel button.)
+    /// If not <see langword="null"/>, called after the panel is closed. The parameters are <c>hasResult</c> and <c>result</c>: If a result is available, the first parameter will
+    /// be <see langword="true"/>, and the second parameter will have the result. The result may be <see langword="null"/>, depending on the kind of panel that was displayed.
     /// </summary>
-    /// <typeparam name="T">The type of result the panel can generate.</typeparam>
-    public abstract class PseudoScreenWithResult<T> : PseudoScreen {
-        protected PseudoScreenWithResult(float width = 40f) : base(width) { }
-        /// <summary>
-        /// If not <see langword="null"/>, called after the panel is closed. The parameters are <c>hasResult</c> and <c>result</c>: If a result is available, the first parameter will
-        /// be <see langword="true"/>, and the second parameter will have the result. The result may be <see langword="null"/>, depending on the kind of panel that was displayed.
-        /// </summary>
-        /// <remarks>Note that the <see cref="PseudoScreen.cleanupCallback"/> will be called after invoking this callback.</remarks>
-        protected Action<bool, T?>? completionCallback;
+    /// <remarks>Note that the <see cref="PseudoScreen.cleanupCallback"/> will be called after invoking this callback.</remarks>
+    protected Action<bool, T?>? completionCallback;
 
-        protected void CloseWithResult(T? result) {
-            completionCallback?.Invoke(true, result);
-            base.Close();
-        }
+    protected void CloseWithResult(T? result) {
+        completionCallback?.Invoke(true, result);
+        base.Close();
+    }
 
-        protected override void Close() {
-            completionCallback?.Invoke(false, default);
-            base.Close();
-        }
+    protected override void Close() {
+        completionCallback?.Invoke(false, default);
+        base.Close();
     }
 }

--- a/Yafc/Widgets/SearchableList.cs
+++ b/Yafc/Widgets/SearchableList.cs
@@ -2,51 +2,50 @@
 using System.Numerics;
 using Yafc.UI;
 
-namespace Yafc {
-    public class SearchableList<TData>(float height, Vector2 elementSize, VirtualScrollList<TData>.Drawer drawer, SearchableList<TData>.Filter filter, IComparer<TData>? comparer = null) : VirtualScrollList<TData>(height, elementSize, drawer) {
-        private readonly List<TData> list = [];
+namespace Yafc;
+public class SearchableList<TData>(float height, Vector2 elementSize, VirtualScrollList<TData>.Drawer drawer, SearchableList<TData>.Filter filter, IComparer<TData>? comparer = null) : VirtualScrollList<TData>(height, elementSize, drawer) {
+    private readonly List<TData> list = [];
 
-        public delegate bool Filter(TData data, SearchQuery searchTokens);
+    public delegate bool Filter(TData data, SearchQuery searchTokens);
 
-        private readonly Filter filterFunc = filter;
+    private readonly Filter filterFunc = filter;
 
-        private IEnumerable<TData> _data = [];
-        public new IEnumerable<TData> data {
-            get => _data;
-            set {
-                _data = value ?? [];
-                RefreshData();
-            }
+    private IEnumerable<TData> _data = [];
+    public new IEnumerable<TData> data {
+        get => _data;
+        set {
+            _data = value ?? [];
+            RefreshData();
         }
+    }
 
-        private SearchQuery _filter = default;
+    private SearchQuery _filter = default;
 
-        public SearchQuery filter {
-            get => _filter;
-            set {
-                _filter = value;
-                RefreshData();
-            }
+    public SearchQuery filter {
+        get => _filter;
+        set {
+            _filter = value;
+            RefreshData();
         }
+    }
 
-        private void RefreshData() {
-            list.Clear();
-            if (!_filter.empty) {
-                foreach (var element in _data) {
-                    if (filterFunc(element, _filter)) {
-                        list.Add(element);
-                    }
+    private void RefreshData() {
+        list.Clear();
+        if (!_filter.empty) {
+            foreach (var element in _data) {
+                if (filterFunc(element, _filter)) {
+                    list.Add(element);
                 }
             }
-            else {
-                list.AddRange(_data);
-            }
-
-            if (comparer != null) {
-                list.Sort(comparer);
-            }
-
-            base.data = list;
         }
+        else {
+            list.AddRange(_data);
+        }
+
+        if (comparer != null) {
+            list.Sort(comparer);
+        }
+
+        base.data = list;
     }
 }

--- a/Yafc/Windows/AboutScreen.cs
+++ b/Yafc/Windows/AboutScreen.cs
@@ -1,77 +1,76 @@
 ﻿using Yafc.UI;
 
-namespace Yafc {
-    public class AboutScreen : WindowUtility {
-        public const string Github = "https://github.com/have-fun-was-taken/yafc-ce";
+namespace Yafc;
+public class AboutScreen : WindowUtility {
+    public const string Github = "https://github.com/have-fun-was-taken/yafc-ce";
 
-        public AboutScreen(Window parent) : base(ImGuiUtils.DefaultScreenPadding) => Create("About YAFC-CE", 50, parent);
+    public AboutScreen(Window parent) : base(ImGuiUtils.DefaultScreenPadding) => Create("About YAFC-CE", 50, parent);
 
-        protected override void BuildContents(ImGui gui) {
-            gui.allocator = RectAllocator.Center;
-            gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
-            gui.BuildText("(Community Edition)", TextBlockDisplayStyle.Centered);
-            gui.BuildText("Copyright 2020-2021 ShadowTheAge", TextBlockDisplayStyle.Centered);
-            gui.BuildText("Copyright 2024 YAFC Community", TextBlockDisplayStyle.Centered);
-            gui.allocator = RectAllocator.LeftAlign;
-            gui.AllocateSpacing(1.5f);
-            gui.BuildText("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.", TextBlockDisplayStyle.WrappedText);
-            gui.BuildText("This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.", TextBlockDisplayStyle.WrappedText);
-            using (gui.EnterRow(0.3f)) {
-                gui.BuildText("Full license text:");
-                BuildLink(gui, "https://gnu.org/licenses/gpl-3.0.html");
-            }
-            using (gui.EnterRow(0.3f)) {
-                gui.BuildText("Github YAFC-CE page and documentation:");
-                BuildLink(gui, Github);
-            }
-            gui.AllocateSpacing(1.5f);
-            gui.BuildText("Free and open-source third-party libraries used:", Font.subheader);
-            BuildLink(gui, "https://dotnet.microsoft.com/", "Microsoft .NET core and libraries");
-            using (gui.EnterRow(0.3f)) {
-                BuildLink(gui, "https://libsdl.org/index.php", "Simple DirectMedia Layer 2.0");
-                gui.BuildText("and");
-                BuildLink(gui, "https://github.com/flibitijibibo/SDL2-CS", "SDL2-CS");
-            }
-            using (gui.EnterRow(0.3f)) {
-                gui.BuildText("Libraries for SDL2:");
-                BuildLink(gui, "http://libpng.org/pub/png/libpng.html", "libpng,");
-                BuildLink(gui, "http://libjpeg.sourceforge.net/", "libjpeg,");
-                BuildLink(gui, "https://freetype.org", "libfreetype");
-                gui.BuildText("and");
-                BuildLink(gui, "https://zlib.net/", "zlib");
-            }
-            using (gui.EnterRow(0.3f)) {
-                gui.BuildText("Google");
-                BuildLink(gui, "https://developers.google.com/optimization", "OR-Tools,");
-                BuildLink(gui, "https://fonts.google.com/specimen/Roboto", "Roboto font family");
-                gui.BuildText("and");
-                BuildLink(gui, "https://material.io/resources/icons", "Material Design Icon collection");
-            }
-
-            using (gui.EnterRow(0.3f)) {
-                BuildLink(gui, "https://lua.org/", "Lua 5.2");
-                gui.BuildText("plus");
-                BuildLink(gui, "https://github.com/pkulchenko/serpent", "Serpent library");
-                gui.BuildText("and small bits from");
-                BuildLink(gui, "https://github.com/NLua", "NLua");
-            }
-
-            using (gui.EnterRow(0.3f)) {
-                BuildLink(gui, "https://wiki.factorio.com/", "Documentation on Factorio Wiki");
-                gui.BuildText("and");
-                BuildLink(gui, "https://lua-api.factorio.com/latest/", "Factorio API reference");
-            }
-
-            gui.AllocateSpacing(1.5f);
-            gui.allocator = RectAllocator.Center;
-            gui.BuildText("Factorio name, content and materials are trademarks and copyrights of Wube Software");
-            BuildLink(gui, "https://factorio.com/");
+    protected override void BuildContents(ImGui gui) {
+        gui.allocator = RectAllocator.Center;
+        gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
+        gui.BuildText("(Community Edition)", TextBlockDisplayStyle.Centered);
+        gui.BuildText("Copyright 2020-2021 ShadowTheAge", TextBlockDisplayStyle.Centered);
+        gui.BuildText("Copyright 2024 YAFC Community", TextBlockDisplayStyle.Centered);
+        gui.allocator = RectAllocator.LeftAlign;
+        gui.AllocateSpacing(1.5f);
+        gui.BuildText("This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.", TextBlockDisplayStyle.WrappedText);
+        gui.BuildText("This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.", TextBlockDisplayStyle.WrappedText);
+        using (gui.EnterRow(0.3f)) {
+            gui.BuildText("Full license text:");
+            BuildLink(gui, "https://gnu.org/licenses/gpl-3.0.html");
+        }
+        using (gui.EnterRow(0.3f)) {
+            gui.BuildText("Github YAFC-CE page and documentation:");
+            BuildLink(gui, Github);
+        }
+        gui.AllocateSpacing(1.5f);
+        gui.BuildText("Free and open-source third-party libraries used:", Font.subheader);
+        BuildLink(gui, "https://dotnet.microsoft.com/", "Microsoft .NET core and libraries");
+        using (gui.EnterRow(0.3f)) {
+            BuildLink(gui, "https://libsdl.org/index.php", "Simple DirectMedia Layer 2.0");
+            gui.BuildText("and");
+            BuildLink(gui, "https://github.com/flibitijibibo/SDL2-CS", "SDL2-CS");
+        }
+        using (gui.EnterRow(0.3f)) {
+            gui.BuildText("Libraries for SDL2:");
+            BuildLink(gui, "http://libpng.org/pub/png/libpng.html", "libpng,");
+            BuildLink(gui, "http://libjpeg.sourceforge.net/", "libjpeg,");
+            BuildLink(gui, "https://freetype.org", "libfreetype");
+            gui.BuildText("and");
+            BuildLink(gui, "https://zlib.net/", "zlib");
+        }
+        using (gui.EnterRow(0.3f)) {
+            gui.BuildText("Google");
+            BuildLink(gui, "https://developers.google.com/optimization", "OR-Tools,");
+            BuildLink(gui, "https://fonts.google.com/specimen/Roboto", "Roboto font family");
+            gui.BuildText("and");
+            BuildLink(gui, "https://material.io/resources/icons", "Material Design Icon collection");
         }
 
-        private void BuildLink(ImGui gui, string url, string? text = null) {
-            if (gui.BuildLink(text ?? url)) {
-                Ui.VisitLink(url);
-            }
+        using (gui.EnterRow(0.3f)) {
+            BuildLink(gui, "https://lua.org/", "Lua 5.2");
+            gui.BuildText("plus");
+            BuildLink(gui, "https://github.com/pkulchenko/serpent", "Serpent library");
+            gui.BuildText("and small bits from");
+            BuildLink(gui, "https://github.com/NLua", "NLua");
+        }
+
+        using (gui.EnterRow(0.3f)) {
+            BuildLink(gui, "https://wiki.factorio.com/", "Documentation on Factorio Wiki");
+            gui.BuildText("and");
+            BuildLink(gui, "https://lua-api.factorio.com/latest/", "Factorio API reference");
+        }
+
+        gui.AllocateSpacing(1.5f);
+        gui.allocator = RectAllocator.Center;
+        gui.BuildText("Factorio name, content and materials are trademarks and copyrights of Wube Software");
+        BuildLink(gui, "https://factorio.com/");
+    }
+
+    private void BuildLink(ImGui gui, string url, string? text = null) {
+        if (gui.BuildLink(text ?? url)) {
+            Ui.VisitLink(url);
         }
     }
 }

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -4,192 +4,191 @@ using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class DependencyExplorer : PseudoScreen {
-        private readonly ScrollArea dependencies;
-        private readonly ScrollArea dependents;
-        private static readonly Padding listPad = new Padding(0.5f);
+namespace Yafc;
+public class DependencyExplorer : PseudoScreen {
+    private readonly ScrollArea dependencies;
+    private readonly ScrollArea dependents;
+    private static readonly Padding listPad = new Padding(0.5f);
 
-        private readonly List<FactorioObject> history = [];
-        private FactorioObject current;
+    private readonly List<FactorioObject> history = [];
+    private FactorioObject current;
 
-        private static readonly Dictionary<DependencyList.Flags, (string name, string missingText)> dependencyListTexts = new Dictionary<DependencyList.Flags, (string, string)>()
-        {
-            {DependencyList.Flags.Fuel, ("Fuel", "There is no fuel to power this entity")},
-            {DependencyList.Flags.Ingredient, ("Ingredient", "There are no ingredients to this recipe")},
-            {DependencyList.Flags.IngredientVariant, ("Ingredient", "There are no ingredient variants for this recipe")},
-            {DependencyList.Flags.CraftingEntity, ("Crafter", "There are no crafters that can craft this item")},
-            {DependencyList.Flags.Source, ("Source", "This item have no sources")},
-            {DependencyList.Flags.TechnologyUnlock, ("Research", "This recipe is disabled and there are no technologies to unlock it")},
-            {DependencyList.Flags.TechnologyPrerequisites, ("Research", "There are no technology prerequisites")},
-            {DependencyList.Flags.ItemToPlace, ("Item", "This entity cannot be placed")},
-            {DependencyList.Flags.SourceEntity, ("Source", "This recipe requires another entity")},
-            {DependencyList.Flags.Hidden, ("", "This technology is hidden")},
-        };
+    private static readonly Dictionary<DependencyList.Flags, (string name, string missingText)> dependencyListTexts = new Dictionary<DependencyList.Flags, (string, string)>()
+    {
+        {DependencyList.Flags.Fuel, ("Fuel", "There is no fuel to power this entity")},
+        {DependencyList.Flags.Ingredient, ("Ingredient", "There are no ingredients to this recipe")},
+        {DependencyList.Flags.IngredientVariant, ("Ingredient", "There are no ingredient variants for this recipe")},
+        {DependencyList.Flags.CraftingEntity, ("Crafter", "There are no crafters that can craft this item")},
+        {DependencyList.Flags.Source, ("Source", "This item have no sources")},
+        {DependencyList.Flags.TechnologyUnlock, ("Research", "This recipe is disabled and there are no technologies to unlock it")},
+        {DependencyList.Flags.TechnologyPrerequisites, ("Research", "There are no technology prerequisites")},
+        {DependencyList.Flags.ItemToPlace, ("Item", "This entity cannot be placed")},
+        {DependencyList.Flags.SourceEntity, ("Source", "This recipe requires another entity")},
+        {DependencyList.Flags.Hidden, ("", "This technology is hidden")},
+    };
 
 
-        public DependencyExplorer(FactorioObject current) : base(60f) {
-            dependencies = new ScrollArea(30f, DrawDependencies);
-            dependents = new ScrollArea(30f, DrawDependants);
-            this.current = current;
+    public DependencyExplorer(FactorioObject current) : base(60f) {
+        dependencies = new ScrollArea(30f, DrawDependencies);
+        dependents = new ScrollArea(30f, DrawDependants);
+        this.current = current;
+    }
+
+    public static void Show(FactorioObject target) {
+        _ = MainScreen.Instance.ShowPseudoScreen(new DependencyExplorer(target));
+    }
+
+    private void DrawFactorioObject(ImGui gui, FactorioId id) {
+        var fobj = Database.objects[id];
+        using (gui.EnterGroup(listPad, RectAllocator.LeftRow)) {
+            gui.BuildFactorioObjectIcon(fobj);
+            string text = fobj.locName + " (" + fobj.type + ")";
+            gui.RemainingRow(0.5f).BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint });
         }
-
-        public static void Show(FactorioObject target) {
-            _ = MainScreen.Instance.ShowPseudoScreen(new DependencyExplorer(target));
+        if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, fobj, tooltipOptions: new() { ShowTypeInHeader = true }) == Click.Left) {
+            Change(fobj);
         }
+    }
 
-        private void DrawFactorioObject(ImGui gui, FactorioId id) {
-            var fobj = Database.objects[id];
-            using (gui.EnterGroup(listPad, RectAllocator.LeftRow)) {
-                gui.BuildFactorioObjectIcon(fobj);
-                string text = fobj.locName + " (" + fobj.type + ")";
-                gui.RemainingRow(0.5f).BuildText(text, TextBlockDisplayStyle.WrappedText with { Color = fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint });
+    private void DrawDependencies(ImGui gui) {
+        gui.spacing = 0f;
+        foreach (var data in Dependencies.dependencyList[current]) {
+            if (!dependencyListTexts.TryGetValue(data.flags, out var dependencyType)) {
+                dependencyType = (data.flags.ToString(), "Missing " + data.flags);
             }
-            if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, fobj, tooltipOptions: new() { ShowTypeInHeader = true }) == Click.Left) {
-                Change(fobj);
-            }
-        }
 
-        private void DrawDependencies(ImGui gui) {
-            gui.spacing = 0f;
-            foreach (var data in Dependencies.dependencyList[current]) {
-                if (!dependencyListTexts.TryGetValue(data.flags, out var dependencyType)) {
-                    dependencyType = (data.flags.ToString(), "Missing " + data.flags);
+            if (data.elements.Length > 0) {
+                gui.AllocateSpacing(0.5f);
+                if (data.elements.Length == 1) {
+                    gui.BuildText("Require this " + dependencyType.name + ":");
+                }
+                else if (data.flags.HasFlags(DependencyList.Flags.RequireEverything)) {
+                    gui.BuildText("Require ALL of these " + dependencyType.name + "s:");
+                }
+                else {
+                    gui.BuildText("Require ANY of these " + dependencyType.name + "s:");
                 }
 
-                if (data.elements.Length > 0) {
-                    gui.AllocateSpacing(0.5f);
-                    if (data.elements.Length == 1) {
-                        gui.BuildText("Require this " + dependencyType.name + ":");
-                    }
-                    else if (data.flags.HasFlags(DependencyList.Flags.RequireEverything)) {
-                        gui.BuildText("Require ALL of these " + dependencyType.name + "s:");
-                    }
-                    else {
-                        gui.BuildText("Require ANY of these " + dependencyType.name + "s:");
-                    }
+                gui.AllocateSpacing(0.5f);
+                foreach (var id in data.elements.OrderByDescending(x => CostAnalysis.Instance.flow[x])) {
+                    DrawFactorioObject(gui, id);
+                }
+            }
+            else {
+                string text = dependencyType.missingText;
+                if (Database.rootAccessible.Contains(current)) {
+                    text += ", but it is inherently accessible";
+                }
+                else {
+                    text += ", and it is inaccessible";
+                }
 
-                    gui.AllocateSpacing(0.5f);
-                    foreach (var id in data.elements.OrderByDescending(x => CostAnalysis.Instance.flow[x])) {
-                        DrawFactorioObject(gui, id);
+                gui.BuildText(text, TextBlockDisplayStyle.WrappedText);
+            }
+        }
+    }
+
+    private void DrawDependants(ImGui gui) {
+        gui.spacing = 0f;
+        foreach (var reverseDependency in Dependencies.reverseDependencies[current].OrderByDescending(x => CostAnalysis.Instance.flow[x])) {
+            DrawFactorioObject(gui, reverseDependency);
+        }
+    }
+
+    private void SetFlag(ProjectPerItemFlags flag, bool set) {
+        Project.current.settings.SetFlag(current, flag, set);
+        Analysis.Do<Milestones>(Project.current);
+        Rebuild();
+        dependents.Rebuild();
+        dependencies.Rebuild();
+    }
+
+    public override void Build(ImGui gui) {
+        gui.allocator = RectAllocator.Center;
+        BuildHeader(gui, "Dependency explorer");
+        using (gui.EnterRow()) {
+            gui.BuildText("Currently inspecting:", Font.subheader);
+            if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
+                SelectSingleObjectPanel.Select(Database.objects.explorable, "Select something", Change);
+            }
+
+            gui.BuildText("(Click to change)", TextBlockDisplayStyle.HintText);
+        }
+        using (gui.EnterRow()) {
+            var settings = Project.current.settings;
+            if (current.IsAccessible()) {
+                if (current.IsAutomatable()) {
+                    gui.BuildText("Status: Automatable");
+                }
+                else {
+                    gui.BuildText("Status: Accessible, Not automatable");
+                }
+
+                if (settings.Flags(current).HasFlags(ProjectPerItemFlags.MarkedAccessible)) {
+                    gui.BuildText("Manually marked as accessible.");
+                    if (gui.BuildLink("Clear mark")) {
+                        SetFlag(ProjectPerItemFlags.MarkedAccessible, false);
+                        NeverEnoughItemsPanel.Refresh();
                     }
                 }
                 else {
-                    string text = dependencyType.missingText;
-                    if (Database.rootAccessible.Contains(current)) {
-                        text += ", but it is inherently accessible";
-                    }
-                    else {
-                        text += ", and it is inaccessible";
+                    if (gui.BuildLink("Mark as inaccessible")) {
+                        SetFlag(ProjectPerItemFlags.MarkedInaccessible, true);
+                        NeverEnoughItemsPanel.Refresh();
                     }
 
-                    gui.BuildText(text, TextBlockDisplayStyle.WrappedText);
+                    if (gui.BuildLink("Mark as accessible without milestones")) {
+                        SetFlag(ProjectPerItemFlags.MarkedAccessible, true);
+                        NeverEnoughItemsPanel.Refresh();
+                    }
                 }
             }
-        }
-
-        private void DrawDependants(ImGui gui) {
-            gui.spacing = 0f;
-            foreach (var reverseDependency in Dependencies.reverseDependencies[current].OrderByDescending(x => CostAnalysis.Instance.flow[x])) {
-                DrawFactorioObject(gui, reverseDependency);
-            }
-        }
-
-        private void SetFlag(ProjectPerItemFlags flag, bool set) {
-            Project.current.settings.SetFlag(current, flag, set);
-            Analysis.Do<Milestones>(Project.current);
-            Rebuild();
-            dependents.Rebuild();
-            dependencies.Rebuild();
-        }
-
-        public override void Build(ImGui gui) {
-            gui.allocator = RectAllocator.Center;
-            BuildHeader(gui, "Dependency explorer");
-            using (gui.EnterRow()) {
-                gui.BuildText("Currently inspecting:", Font.subheader);
-                if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
-                    SelectSingleObjectPanel.Select(Database.objects.explorable, "Select something", Change);
-                }
-
-                gui.BuildText("(Click to change)", TextBlockDisplayStyle.HintText);
-            }
-            using (gui.EnterRow()) {
-                var settings = Project.current.settings;
-                if (current.IsAccessible()) {
-                    if (current.IsAutomatable()) {
-                        gui.BuildText("Status: Automatable");
-                    }
-                    else {
-                        gui.BuildText("Status: Accessible, Not automatable");
-                    }
-
-                    if (settings.Flags(current).HasFlags(ProjectPerItemFlags.MarkedAccessible)) {
-                        gui.BuildText("Manually marked as accessible.");
-                        if (gui.BuildLink("Clear mark")) {
-                            SetFlag(ProjectPerItemFlags.MarkedAccessible, false);
-                            NeverEnoughItemsPanel.Refresh();
-                        }
-                    }
-                    else {
-                        if (gui.BuildLink("Mark as inaccessible")) {
-                            SetFlag(ProjectPerItemFlags.MarkedInaccessible, true);
-                            NeverEnoughItemsPanel.Refresh();
-                        }
-
-                        if (gui.BuildLink("Mark as accessible without milestones")) {
-                            SetFlag(ProjectPerItemFlags.MarkedAccessible, true);
-                            NeverEnoughItemsPanel.Refresh();
-                        }
+            else {
+                if (settings.Flags(current).HasFlags(ProjectPerItemFlags.MarkedInaccessible)) {
+                    gui.BuildText("Status: Marked as inaccessible");
+                    if (gui.BuildLink("Clear mark")) {
+                        SetFlag(ProjectPerItemFlags.MarkedInaccessible, false);
+                        NeverEnoughItemsPanel.Refresh();
                     }
                 }
                 else {
-                    if (settings.Flags(current).HasFlags(ProjectPerItemFlags.MarkedInaccessible)) {
-                        gui.BuildText("Status: Marked as inaccessible");
-                        if (gui.BuildLink("Clear mark")) {
-                            SetFlag(ProjectPerItemFlags.MarkedInaccessible, false);
-                            NeverEnoughItemsPanel.Refresh();
-                        }
-                    }
-                    else {
-                        gui.BuildText("Status: Not accessible. Wrong?");
-                        if (gui.BuildLink("Manually mark as accessible")) {
-                            SetFlag(ProjectPerItemFlags.MarkedAccessible, true);
-                            NeverEnoughItemsPanel.Refresh();
-                        }
+                    gui.BuildText("Status: Not accessible. Wrong?");
+                    if (gui.BuildLink("Manually mark as accessible")) {
+                        SetFlag(ProjectPerItemFlags.MarkedAccessible, true);
+                        NeverEnoughItemsPanel.Refresh();
                     }
                 }
             }
-            gui.AllocateSpacing(2f);
-            using var split = gui.EnterHorizontalSplit(2);
-            split.Next();
-            gui.BuildText("Dependencies:", Font.subheader);
-            dependencies.Build(gui);
-            split.Next();
-            gui.BuildText("Dependents:", Font.subheader);
-            dependents.Build(gui);
+        }
+        gui.AllocateSpacing(2f);
+        using var split = gui.EnterHorizontalSplit(2);
+        split.Next();
+        gui.BuildText("Dependencies:", Font.subheader);
+        dependencies.Build(gui);
+        split.Next();
+        gui.BuildText("Dependents:", Font.subheader);
+        dependents.Build(gui);
+    }
+
+    public void Change(FactorioObject target) {
+        history.Add(current);
+        if (history.Count > 100) {
+            history.RemoveRange(0, 20);
         }
 
-        public void Change(FactorioObject target) {
-            history.Add(current);
-            if (history.Count > 100) {
-                history.RemoveRange(0, 20);
-            }
+        current = target;
+        dependents.Rebuild();
+        dependencies.Rebuild();
+        Rebuild();
+    }
 
-            current = target;
-            dependents.Rebuild();
-            dependencies.Rebuild();
-            Rebuild();
+    public override bool KeyDown(SDL.SDL_Keysym key) {
+        if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_BACKSPACE && history.Count > 0) {
+            var last = history[^1];
+            Change(last);
+            history.RemoveRange(history.Count - 2, 2);
+            return true;
         }
-
-        public override bool KeyDown(SDL.SDL_Keysym key) {
-            if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_BACKSPACE && history.Count > 0) {
-                var last = history[^1];
-                Change(last);
-                history.RemoveRange(history.Count - 2, 2);
-                return true;
-            }
-            return base.KeyDown(key);
-        }
+        return base.KeyDown(key);
     }
 }

--- a/Yafc/Windows/ErrorListPanel.cs
+++ b/Yafc/Windows/ErrorListPanel.cs
@@ -1,42 +1,41 @@
 ﻿using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ErrorListPanel : PseudoScreen {
-        private readonly ErrorCollector collector;
-        private readonly ScrollArea verticalList;
-        private readonly (string error, ErrorSeverity severity)[] errors;
+namespace Yafc;
+public class ErrorListPanel : PseudoScreen {
+    private readonly ErrorCollector collector;
+    private readonly ScrollArea verticalList;
+    private readonly (string error, ErrorSeverity severity)[] errors;
 
-        private ErrorListPanel(ErrorCollector collector) : base(60f) {
-            verticalList = new ScrollArea(30f, BuildErrorList, default, true);
-            this.collector = collector;
-            errors = collector.GetArrErrors();
-        }
-
-        private void BuildErrorList(ImGui gui) {
-            foreach (var error in errors) {
-                gui.BuildText(error.error, TextBlockDisplayStyle.WrappedText with { Color = error.severity >= ErrorSeverity.MajorDataLoss ? SchemeColor.Error : SchemeColor.BackgroundText });
-            }
-        }
-
-        public static void Show(ErrorCollector collector) {
-            _ = MainScreen.Instance.ShowPseudoScreen(new ErrorListPanel(collector));
-        }
-        public override void Build(ImGui gui) {
-            if (collector.severity == ErrorSeverity.Critical) {
-                BuildHeader(gui, "Loading failed");
-            }
-            else if (collector.severity >= ErrorSeverity.MinorDataLoss) {
-                BuildHeader(gui, "Loading completed with errors");
-            }
-            else {
-                BuildHeader(gui, "Analysis warnings");
-            }
-
-            verticalList.Build(gui);
-
-        }
-
-        protected override void ReturnPressed() => Close();
+    private ErrorListPanel(ErrorCollector collector) : base(60f) {
+        verticalList = new ScrollArea(30f, BuildErrorList, default, true);
+        this.collector = collector;
+        errors = collector.GetArrErrors();
     }
+
+    private void BuildErrorList(ImGui gui) {
+        foreach (var error in errors) {
+            gui.BuildText(error.error, TextBlockDisplayStyle.WrappedText with { Color = error.severity >= ErrorSeverity.MajorDataLoss ? SchemeColor.Error : SchemeColor.BackgroundText });
+        }
+    }
+
+    public static void Show(ErrorCollector collector) {
+        _ = MainScreen.Instance.ShowPseudoScreen(new ErrorListPanel(collector));
+    }
+    public override void Build(ImGui gui) {
+        if (collector.severity == ErrorSeverity.Critical) {
+            BuildHeader(gui, "Loading failed");
+        }
+        else if (collector.severity >= ErrorSeverity.MinorDataLoss) {
+            BuildHeader(gui, "Loading completed with errors");
+        }
+        else {
+            BuildHeader(gui, "Analysis warnings");
+        }
+
+        verticalList.Build(gui);
+
+    }
+
+    protected override void ReturnPressed() => Close();
 }

--- a/Yafc/Windows/ImageSharePanel.cs
+++ b/Yafc/Windows/ImageSharePanel.cs
@@ -3,57 +3,56 @@ using System.Runtime.InteropServices;
 using SDL2;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ImageSharePanel : PseudoScreen {
-        private readonly MemoryDrawingSurface surface;
-        private readonly string header;
-        private readonly string name;
-        private static readonly string TempImageFile = Path.Combine(Path.GetTempPath(), "yafc_temp.png");
-        private bool copied;
+namespace Yafc;
+public class ImageSharePanel : PseudoScreen {
+    private readonly MemoryDrawingSurface surface;
+    private readonly string header;
+    private readonly string name;
+    private static readonly string TempImageFile = Path.Combine(Path.GetTempPath(), "yafc_temp.png");
+    private bool copied;
 
-        public ImageSharePanel(MemoryDrawingSurface surface, string name) {
-            copied = false;
-            this.surface = surface;
-            this.name = name;
-            ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface.surface);
-            header = name + " (" + surfaceData.w + "x" + surfaceData.h + ")";
-            cleanupCallback = surface.Dispose;
+    public ImageSharePanel(MemoryDrawingSurface surface, string name) {
+        copied = false;
+        this.surface = surface;
+        this.name = name;
+        ref var surfaceData = ref RenderingUtils.AsSdlSurface(surface.surface);
+        header = name + " (" + surfaceData.w + "x" + surfaceData.h + ")";
+        cleanupCallback = surface.Dispose;
 
-            _ = MainScreen.Instance.ShowPseudoScreen(this);
+        _ = MainScreen.Instance.ShowPseudoScreen(this);
+    }
+
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Image generated");
+        gui.BuildText(header, TextBlockDisplayStyle.WrappedText);
+        if (gui.BuildButton("Save as PNG")) {
+            SaveAsPng();
         }
 
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Image generated");
-            gui.BuildText(header, TextBlockDisplayStyle.WrappedText);
-            if (gui.BuildButton("Save as PNG")) {
-                SaveAsPng();
-            }
-
-            if (gui.BuildButton("Save to temp folder and open")) {
-                surface.SavePng(TempImageFile);
-                Ui.VisitLink("file:///" + TempImageFile);
-            }
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && gui.BuildButton(copied ? "Copied to clipboard" : "Copy to clipboard (Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_C) + ")", active: !copied)) {
-                WindowsClipboard.CopySurfaceToClipboard(surface);
-                copied = true;
-            }
+        if (gui.BuildButton("Save to temp folder and open")) {
+            surface.SavePng(TempImageFile);
+            Ui.VisitLink("file:///" + TempImageFile);
         }
 
-        public override bool KeyDown(SDL.SDL_Keysym key) {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_C && InputSystem.Instance.control) {
-                WindowsClipboard.CopySurfaceToClipboard(surface);
-                copied = true;
-                Rebuild();
-            }
-            return base.KeyDown(key);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && gui.BuildButton(copied ? "Copied to clipboard" : "Copy to clipboard (Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_C) + ")", active: !copied)) {
+            WindowsClipboard.CopySurfaceToClipboard(surface);
+            copied = true;
         }
+    }
 
-        private async void SaveAsPng() {
-            string? path = await new FilesystemScreen(header, "Save as PNG", "Save", null, FilesystemScreen.Mode.SelectOrCreateFile, name + ".png", MainScreen.Instance, null, "png");
-            if (path != null) {
-                surface?.SavePng(path);
-            }
+    public override bool KeyDown(SDL.SDL_Keysym key) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_C && InputSystem.Instance.control) {
+            WindowsClipboard.CopySurfaceToClipboard(surface);
+            copied = true;
+            Rebuild();
+        }
+        return base.KeyDown(key);
+    }
+
+    private async void SaveAsPng() {
+        string? path = await new FilesystemScreen(header, "Save as PNG", "Save", null, FilesystemScreen.Mode.SelectOrCreateFile, name + ".png", MainScreen.Instance, null, "png");
+        if (path != null) {
+            surface?.SavePng(path);
         }
     }
 }

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -13,737 +13,736 @@ using Serilog;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string, string)> {
-        private static readonly ILogger logger = Logging.GetLogger<WindowMain>();
-        ///<summary>Unique ID for the Summary page</summary>
-        public static readonly Guid SummaryGuid = Guid.Parse("9bdea333-4be2-4be3-b708-b36a64672a40");
-        public static MainScreen Instance { get; private set; } = null!; // null-forgiving: Set by the instance constructor
-        private readonly ObjectTooltip objectTooltip = new ObjectTooltip();
-        private readonly List<PseudoScreen> pseudoScreens = [];
-        private readonly VirtualScrollList<ProjectPage> allPages;
-        private readonly MainScreenTabBar tabBar;
-        private readonly FadeDrawer fadeDrawer = new FadeDrawer();
+namespace Yafc;
+public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string, string)> {
+    private static readonly ILogger logger = Logging.GetLogger<WindowMain>();
+    ///<summary>Unique ID for the Summary page</summary>
+    public static readonly Guid SummaryGuid = Guid.Parse("9bdea333-4be2-4be3-b708-b36a64672a40");
+    public static MainScreen Instance { get; private set; } = null!; // null-forgiving: Set by the instance constructor
+    private readonly ObjectTooltip objectTooltip = new ObjectTooltip();
+    private readonly List<PseudoScreen> pseudoScreens = [];
+    private readonly VirtualScrollList<ProjectPage> allPages;
+    private readonly MainScreenTabBar tabBar;
+    private readonly FadeDrawer fadeDrawer = new FadeDrawer();
 
-        private PseudoScreen? topScreen;
-        public Project project { get; private set; }
-        private ProjectPage? _activePage;
-        public ProjectPage? activePage => _activePage;
-        public ProjectPageView? activePageView => _activePageView;
-        private ProjectPageView? _activePageView;
-        private ProjectPage? _secondaryPage;
-        public ProjectPage? secondaryPage => _secondaryPage;
-        private ProjectPageView? secondaryPageView;
-        private readonly SummaryView summaryView;
+    private PseudoScreen? topScreen;
+    public Project project { get; private set; }
+    private ProjectPage? _activePage;
+    public ProjectPage? activePage => _activePage;
+    public ProjectPageView? activePageView => _activePageView;
+    private ProjectPageView? _activePageView;
+    private ProjectPage? _secondaryPage;
+    public ProjectPage? secondaryPage => _secondaryPage;
+    private ProjectPageView? secondaryPageView;
+    private readonly SummaryView summaryView;
 
-        private bool analysisUpdatePending;
-        private SearchQuery pageSearch;
-        private readonly PageListSearch pageListSearch = new();
-        private readonly ImGui searchGui;
-        private Rect searchBoxRect;
+    private bool analysisUpdatePending;
+    private SearchQuery pageSearch;
+    private readonly PageListSearch pageListSearch = new();
+    private readonly ImGui searchGui;
+    private Rect searchBoxRect;
 
-        private readonly Dictionary<Type, ProjectPageView> registeredPageViews = [];
-        private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = [];
+    private readonly Dictionary<Type, ProjectPageView> registeredPageViews = [];
+    private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = [];
 
-        public MainScreen(int display, Project project) : base(default) {
-            summaryView = new SummaryView(project);
-            RegisterPageView<ProductionTable>(new ProductionTableView());
-            RegisterPageView<AutoPlanner>(new AutoPlannerView());
-            RegisterPageView<ProductionSummary>(new ProductionSummaryView());
-            RegisterPageView<Summary>(summaryView);
-            searchGui = new ImGui(BuildSearch, new Padding(1f)) { boxShadow = RectangleBorder.Thin, boxColor = SchemeColor.Background };
-            Instance = this;
-            tabBar = new MainScreenTabBar(this);
-            allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, collapsible: true);
+    public MainScreen(int display, Project project) : base(default) {
+        summaryView = new SummaryView(project);
+        RegisterPageView<ProductionTable>(new ProductionTableView());
+        RegisterPageView<AutoPlanner>(new AutoPlannerView());
+        RegisterPageView<ProductionSummary>(new ProductionSummaryView());
+        RegisterPageView<Summary>(summaryView);
+        searchGui = new ImGui(BuildSearch, new Padding(1f)) { boxShadow = RectangleBorder.Thin, boxColor = SchemeColor.Background };
+        Instance = this;
+        tabBar = new MainScreenTabBar(this);
+        allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, collapsible: true);
 
-            Create("Yet Another Factorio Calculator CE v" + YafcLib.version.ToString(3), display, Preferences.Instance.initialMainScreenWidth,
-                Preferences.Instance.initialMainScreenHeight, Preferences.Instance.maximizeMainScreen, Preferences.Instance.forceSoftwareRenderer);
-            SetProject(project);
+        Create("Yet Another Factorio Calculator CE v" + YafcLib.version.ToString(3), display, Preferences.Instance.initialMainScreenWidth,
+            Preferences.Instance.initialMainScreenHeight, Preferences.Instance.maximizeMainScreen, Preferences.Instance.forceSoftwareRenderer);
+        SetProject(project);
+    }
+
+    [MemberNotNull(nameof(project))]
+    private void SetProject(Project project) {
+        if (this.project != null) {
+            this.project.metaInfoChanged -= ProjectOnMetaInfoChanged;
+            this.project.settings.changed -= ProjectSettingsChanged;
+        }
+        Project.current = project;
+        DataUtils.SetupForProject(project);
+        this.project = project;
+        if (project.justCreated) {
+            _ = ShowPseudoScreen(new MilestonesPanel());
         }
 
-        [MemberNotNull(nameof(project))]
-        private void SetProject(Project project) {
-            if (this.project != null) {
-                this.project.metaInfoChanged -= ProjectOnMetaInfoChanged;
-                this.project.settings.changed -= ProjectSettingsChanged;
-            }
-            Project.current = project;
-            DataUtils.SetupForProject(project);
-            this.project = project;
-            if (project.justCreated) {
-                _ = ShowPseudoScreen(new MilestonesPanel());
-            }
-
-            if (project.pages.Count == 0) {
-                ProjectPage firstPage = new ProjectPage(project, typeof(ProductionTable));
-                project.pages.Add(firstPage);
-            }
-
-            if (project.displayPages.Count == 0) {
-                project.displayPages.Add(project.pages[0].guid);
-            }
-
-            // Hack to activate all page solvers for the summary view
-            foreach (var page in project.pages) {
-                page.SetActive(true);
-                page.SetActive(false);
-            }
-
-            SetActivePage(project.FindPage(project.displayPages[0]));
-            project.metaInfoChanged += ProjectOnMetaInfoChanged;
-            project.settings.changed += ProjectSettingsChanged;
-            _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
+        if (project.pages.Count == 0) {
+            ProjectPage firstPage = new ProjectPage(project, typeof(ProductionTable));
+            project.pages.Add(firstPage);
         }
 
-        private void ProjectSettingsChanged(bool visualOnly) {
-            if (visualOnly) {
-                return;
+        if (project.displayPages.Count == 0) {
+            project.displayPages.Add(project.pages[0].guid);
+        }
+
+        // Hack to activate all page solvers for the summary view
+        foreach (var page in project.pages) {
+            page.SetActive(true);
+            page.SetActive(false);
+        }
+
+        SetActivePage(project.FindPage(project.displayPages[0]));
+        project.metaInfoChanged += ProjectOnMetaInfoChanged;
+        project.settings.changed += ProjectSettingsChanged;
+        _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
+    }
+
+    private void ProjectSettingsChanged(bool visualOnly) {
+        if (visualOnly) {
+            return;
+        }
+
+        if (topScreen == null) {
+            ReRunAnalysis();
+        }
+        else {
+            analysisUpdatePending = true;
+        }
+    }
+
+    private void ReRunAnalysis() {
+        analysisUpdatePending = false;
+        ErrorCollector collector = new ErrorCollector();
+        Analysis.ProcessAnalyses(this, project, collector);
+        rootGui.MarkEverythingForRebuild();
+        if (collector.severity > ErrorSeverity.None) {
+            ErrorListPanel.Show(collector);
+        }
+    }
+
+    private void BuildPage(ImGui gui, ProjectPage element, int index) {
+        using (gui.EnterGroup(new Padding(1f, 0.25f), RectAllocator.LeftRow)) {
+            if (element.icon != null) {
+                gui.BuildIcon(element.icon.icon);
             }
 
-            if (topScreen == null) {
-                ReRunAnalysis();
+            gui.RemainingRow().BuildText(element.name, TextBlockDisplayStyle.Default(element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint));
+        }
+        var evt = gui.BuildButton(gui.lastRect, SchemeColor.PureBackground, SchemeColor.Grey, button: 0);
+        if (evt) {
+            if (gui.actionParameter == SDL.SDL_BUTTON_MIDDLE) {
+                ProjectPageSettingsPanel.Show(element);
+                dropDown?.Close();
             }
             else {
-                analysisUpdatePending = true;
+                SetActivePage(element);
             }
         }
+        else if (evt == ButtonEvent.MouseOver) {
+            ShowTooltip(gui, element, true, gui.lastRect);
+        }
+    }
 
-        private void ReRunAnalysis() {
-            analysisUpdatePending = false;
-            ErrorCollector collector = new ErrorCollector();
-            Analysis.ProcessAnalyses(this, project, collector);
-            rootGui.MarkEverythingForRebuild();
-            if (collector.severity > ErrorSeverity.None) {
-                ErrorListPanel.Show(collector);
+    private void ProjectOnMetaInfoChanged() {
+        if (_activePage != null && project.FindPage(_activePage.guid) != _activePage) {
+            SetActivePage(null);
+        }
+    }
+
+    private void ChangePage(ref ProjectPage? activePage, ProjectPage? newPage, ref ProjectPageView? activePageView, ProjectPageView? newPageView) {
+        activePageView?.SetModel(null);
+        activePage?.SetActive(false);
+        activePage = newPage;
+        if (newPage != null) {
+            if (!project.displayPages.Contains(newPage.guid)) {
+                _ = project.RecordUndo(true);
+                project.displayPages.Insert(0, newPage.guid);
             }
+            newPage.SetActive(true);
+            newPageView ??= registeredPageViews[newPage.content.GetType()];
+            activePageView = newPageView;
+            activePageView.SetModel(newPage);
+            activePageView.SetSearchQuery(pageSearch);
+        }
+        else {
+            activePageView = null;
+        }
+        // Note: This call exists to get any open dropdowns to close. Normally, they inherently lose
+        // focus when you switch project pages because you had to move the mouse up to the tab bar and
+        // click on a page tab; now you can switch pages without doing that, so if you don't explicitly
+        // reset focus the dropdown from the old page will still get rendered on the new page.
+        InputSystem.Instance.SetMouseFocus(null);
+        Rebuild();
+    }
+
+    public void SetActivePage(ProjectPage? page) {
+        if (page != null && _secondaryPage == page) {
+            SetSecondaryPage(null);
         }
 
-        private void BuildPage(ImGui gui, ProjectPage element, int index) {
-            using (gui.EnterGroup(new Padding(1f, 0.25f), RectAllocator.LeftRow)) {
-                if (element.icon != null) {
-                    gui.BuildIcon(element.icon.icon);
-                }
+        ChangePage(ref _activePage, page, ref _activePageView, null);
+    }
 
-                gui.RemainingRow().BuildText(element.name, TextBlockDisplayStyle.Default(element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint));
-            }
-            var evt = gui.BuildButton(gui.lastRect, SchemeColor.PureBackground, SchemeColor.Grey, button: 0);
-            if (evt) {
-                if (gui.actionParameter == SDL.SDL_BUTTON_MIDDLE) {
-                    ProjectPageSettingsPanel.Show(element);
-                    dropDown?.Close();
-                }
-                else {
-                    SetActivePage(element);
-                }
-            }
-            else if (evt == ButtonEvent.MouseOver) {
-                ShowTooltip(gui, element, true, gui.lastRect);
-            }
+    public void SetSecondaryPage(ProjectPage? page) {
+        if (page == null || page == _activePage) {
+            ChangePage(ref _secondaryPage, null, ref secondaryPageView, null);
         }
-
-        private void ProjectOnMetaInfoChanged() {
-            if (_activePage != null && project.FindPage(_activePage.guid) != _activePage) {
-                SetActivePage(null);
+        else {
+            var contentType = page.content.GetType();
+            if (!secondaryPageViews.TryGetValue(contentType, out var view)) {
+                view = secondaryPageViews[contentType] = registeredPageViews[contentType].CreateSecondaryView();
             }
+
+            ChangePage(ref _secondaryPage, page, ref secondaryPageView, view);
         }
+    }
 
-        private void ChangePage(ref ProjectPage? activePage, ProjectPage? newPage, ref ProjectPageView? activePageView, ProjectPageView? newPageView) {
-            activePageView?.SetModel(null);
-            activePage?.SetActive(false);
-            activePage = newPage;
-            if (newPage != null) {
-                if (!project.displayPages.Contains(newPage.guid)) {
-                    _ = project.RecordUndo(true);
-                    project.displayPages.Insert(0, newPage.guid);
-                }
-                newPage.SetActive(true);
-                newPageView ??= registeredPageViews[newPage.content.GetType()];
-                activePageView = newPageView;
-                activePageView.SetModel(newPage);
-                activePageView.SetSearchQuery(pageSearch);
-            }
-            else {
-                activePageView = null;
-            }
-            // Note: This call exists to get any open dropdowns to close. Normally, they inherently lose
-            // focus when you switch project pages because you had to move the mouse up to the tab bar and
-            // click on a page tab; now you can switch pages without doing that, so if you don't explicitly
-            // reset focus the dropdown from the old page will still get rendered on the new page.
-            InputSystem.Instance.SetMouseFocus(null);
-            Rebuild();
-        }
+    public void RegisterPageView<T>(ProjectPageView pageView) where T : ProjectPageContents => registeredPageViews[typeof(T)] = pageView;
 
-        public void SetActivePage(ProjectPage? page) {
-            if (page != null && _secondaryPage == page) {
-                SetSecondaryPage(null);
-            }
+    public void RebuildProjectView() {
+        rootGui.MarkEverythingForRebuild();
+        _activePageView?.headerContent.MarkEverythingForRebuild();
+        _activePageView?.bodyContent.MarkEverythingForRebuild();
+        secondaryPageView?.headerContent.MarkEverythingForRebuild();
+        secondaryPageView?.bodyContent.MarkEverythingForRebuild();
+    }
 
-            ChangePage(ref _activePage, page, ref _activePageView, null);
-        }
-
-        public void SetSecondaryPage(ProjectPage? page) {
-            if (page == null || page == _activePage) {
-                ChangePage(ref _secondaryPage, null, ref secondaryPageView, null);
-            }
-            else {
-                var contentType = page.content.GetType();
-                if (!secondaryPageViews.TryGetValue(contentType, out var view)) {
-                    view = secondaryPageViews[contentType] = registeredPageViews[contentType].CreateSecondaryView();
-                }
-
-                ChangePage(ref _secondaryPage, page, ref secondaryPageView, view);
-            }
-        }
-
-        public void RegisterPageView<T>(ProjectPageView pageView) where T : ProjectPageContents => registeredPageViews[typeof(T)] = pageView;
-
-        public void RebuildProjectView() {
-            rootGui.MarkEverythingForRebuild();
-            _activePageView?.headerContent.MarkEverythingForRebuild();
-            _activePageView?.bodyContent.MarkEverythingForRebuild();
-            secondaryPageView?.headerContent.MarkEverythingForRebuild();
-            secondaryPageView?.bodyContent.MarkEverythingForRebuild();
-        }
-
-        protected override void BuildContent(ImGui gui) {
-            if (pseudoScreens.Count > 0) {
-                var top = pseudoScreens[0];
-                if (gui.isBuilding) {
-                    gui.DrawRenderable(new Rect(default, size), fadeDrawer, SchemeColor.None);
-                }
-
-                if (top != topScreen) {
-                    topScreen = top;
-                    _ = InputSystem.Instance.SetDefaultKeyboardFocus(top);
-                }
-                top.Build(gui, size);
-            }
-            else {
-                if (topScreen != null) {
-                    project.undo.Resume();
-                    _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
-                    topScreen = null;
-                    if (analysisUpdatePending) {
-                        ReRunAnalysis();
-                    }
-                }
-                BuildTabBar(gui);
-                BuildPage(gui);
-            }
-        }
-
-        /// <summary>
-        /// Draws the tab bar across the top of the window, including the pancake menu, add page button, and search pages dropdown.
-        /// </summary>
-        private void BuildTabBar(ImGui gui) {
-            using (gui.EnterRow()) {
-                gui.spacing = 0f;
-                if (gui.BuildButton(Icon.Menu)) {
-                    gui.ShowDropDown(gui.lastRect, SettingsDropdown, new Padding(0f, 0f, 0f, 0.5f));
-                }
-
-                if (gui.BuildButton(Icon.Plus).WithTooltip(gui, "Create production sheet (Ctrl+" +
-                    ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T) + ")")) {
-
-                    ProductionTableView.CreateProductionSheet();
-                }
-
-                gui.allocator = RectAllocator.RightRow;
-                var spaceForDropdown = gui.AllocateRect(2.1f, 2.1f);
-                tabBar.Build(gui);
-
-                gui.DrawIcon(spaceForDropdown.Expand(-0.3f), Icon.DropDown, SchemeColor.BackgroundText);
-                if (gui.BuildButton(spaceForDropdown, SchemeColor.None, SchemeColor.Grey)) {
-                    updatePageList();
-                    ShowDropDown(gui, spaceForDropdown, missingPagesDropdown, new Padding(0f, 0f, 0f, 0.5f), 30f);
-                }
-            }
-            gui.DrawRectangle(gui.lastRect, SchemeColor.PureBackground);
-
-            void updatePageList() {
-                List<ProjectPage> sortedAndFilteredPageList = pageListSearch.Search(project.pages).ToList();
-                sortedAndFilteredPageList.Sort((a, b) => a.visible == b.visible ? string.Compare(a.name, b.name, StringComparison.InvariantCultureIgnoreCase) : a.visible ? -1 : 1);
-                allPages.data = sortedAndFilteredPageList;
-            }
-
-            void missingPagesDropdown(ImGui gui) {
-                pageListSearch.Build(gui, updatePageList);
-                allPages.Build(gui);
-            }
-        }
-
-        private void BuildPage(ImGui gui) {
-            float usedHeaderSpace = gui.statePosition.Y;
-            var pageVisibleSize = size;
-            pageVisibleSize.Y -= usedHeaderSpace; // remaining size minus header
-            if (_activePageView != null) {
-                if (secondaryPageView != null) {
-                    var visibleSize = pageVisibleSize;
-                    visibleSize.Y /= 2f;
-                    _activePageView.Build(gui, visibleSize);
-                    secondaryPageView.Build(gui, visibleSize);
-                }
-                else {
-                    _activePageView.Build(gui, pageVisibleSize);
-                }
-
-                if (pageSearch.query != null && gui.isBuilding) {
-                    var searchSize = searchGui.CalculateState(30, gui.pixelsPerUnit);
-                    gui.DrawPanel(new Rect(pageVisibleSize.X - searchSize.X, usedHeaderSpace, searchSize.X, searchSize.Y), searchGui);
-                }
-            }
-            else {
-                if (gui.isBuilding && Database.objectsByTypeName.TryGetValue("Entity.compilatron", out var compilatron)) {
-                    gui.AllocateSpacing((pageVisibleSize.Y - 3f) / 2);
-                    gui.BuildIcon(compilatron.icon, 3f);
-                }
-            }
-        }
-
-        public ProjectPage AddProjectPage(string name, FactorioObject? icon, Type contentType, bool setActive, bool initNew) {
-            ProjectPage page = new ProjectPage(project, contentType) { name = name, icon = icon };
-            if (initNew) {
-                page.content.InitNew();
-            }
-
-            project.RecordUndo().pages.Add(page);
-            if (setActive) {
-                SetActivePage(page);
-            }
-
-            return page;
-        }
-
-        public void BuildSubHeader(ImGui gui, string text) {
-            using (gui.EnterGroup(ObjectTooltip.contentPadding)) {
-                gui.BuildText(text, Font.subheader);
-            }
-
+    protected override void BuildContent(ImGui gui) {
+        if (pseudoScreens.Count > 0) {
+            var top = pseudoScreens[0];
             if (gui.isBuilding) {
-                gui.DrawRectangle(gui.lastRect, SchemeColor.GreyAlt);
+                gui.DrawRenderable(new Rect(default, size), fadeDrawer, SchemeColor.None);
             }
-        }
 
-        private void ShowNeie() => SelectSingleObjectPanel.Select(Database.goods.explorable, "Open NEIE", NeverEnoughItemsPanel.Show);
-
-        private void SetSearch(SearchQuery searchQuery) {
-            pageSearch = searchQuery;
-            _activePageView?.SetSearchQuery(searchQuery);
-            secondaryPageView?.SetSearchQuery(searchQuery);
-            Rebuild();
-        }
-
-        private void ShowSearch() {
-            SetSearch(new SearchQuery(""));
-            if (searchBoxRect != default) {
-                searchGui.SetTextInputFocus(searchBoxRect, "");
+            if (top != topScreen) {
+                topScreen = top;
+                _ = InputSystem.Instance.SetDefaultKeyboardFocus(top);
             }
+            top.Build(gui, size);
         }
+        else {
+            if (topScreen != null) {
+                project.undo.Resume();
+                _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
+                topScreen = null;
+                if (analysisUpdatePending) {
+                    ReRunAnalysis();
+                }
+            }
+            BuildTabBar(gui);
+            BuildPage(gui);
+        }
+    }
 
-        private void BuildSearch(ImGui gui) {
-            gui.BuildText("Find on page:");
-            gui.AllocateSpacing();
+    /// <summary>
+    /// Draws the tab bar across the top of the window, including the pancake menu, add page button, and search pages dropdown.
+    /// </summary>
+    private void BuildTabBar(ImGui gui) {
+        using (gui.EnterRow()) {
+            gui.spacing = 0f;
+            if (gui.BuildButton(Icon.Menu)) {
+                gui.ShowDropDown(gui.lastRect, SettingsDropdown, new Padding(0f, 0f, 0f, 0.5f));
+            }
+
+            if (gui.BuildButton(Icon.Plus).WithTooltip(gui, "Create production sheet (Ctrl+" +
+                ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T) + ")")) {
+
+                ProductionTableView.CreateProductionSheet();
+            }
+
             gui.allocator = RectAllocator.RightRow;
-            if (gui.BuildButton(Icon.Close)) {
-                SetSearch(default);
-                return;
-            }
-            if (gui.BuildSearchBox(pageSearch, out pageSearch)) {
-                SetSearch(pageSearch);
-            }
+            var spaceForDropdown = gui.AllocateRect(2.1f, 2.1f);
+            tabBar.Build(gui);
 
-            if (searchBoxRect == default) {
-                gui.SetTextInputFocus(gui.lastRect, pageSearch.query);
-            }
-
-            searchBoxRect = gui.lastRect;
-        }
-
-        private void SettingsDropdown(ImGui gui) {
-            gui.boxColor = SchemeColor.Background;
-            if (gui.BuildContextMenuButton("Undo", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_Z)) && gui.CloseDropdown()) {
-                project.undo.PerformUndo();
-            }
-
-            if (gui.BuildContextMenuButton("Save", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_S)) && gui.CloseDropdown()) {
-                SaveProject().CaptureException();
-            }
-
-            if (gui.BuildContextMenuButton("Save As") && gui.CloseDropdown()) {
-                SaveProjectAs().CaptureException();
-            }
-
-            if (gui.BuildContextMenuButton("Find on page", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_F)) && gui.CloseDropdown()) {
-                ShowSearch();
-            }
-
-            if (gui.BuildContextMenuButton("Load another project (Same mods)") && gui.CloseDropdown()) {
-                LoadProjectLight();
-            }
-
-            if (gui.BuildContextMenuButton("Return to starting screen") && gui.CloseDropdown()) {
-                LoadProjectHeavy();
-            }
-
-            BuildSubHeader(gui, "Tools");
-            if (gui.BuildContextMenuButton("Milestones") && gui.CloseDropdown()) {
-                _ = ShowPseudoScreen(new MilestonesPanel());
-            }
-
-            if (gui.BuildContextMenuButton("Preferences") && gui.CloseDropdown()) {
-                PreferencesScreen.Show();
-            }
-
-            if (gui.BuildContextMenuButton("Summary") && gui.CloseDropdown()) {
-                ShowSummaryTab();
-            }
-
-            if (gui.BuildContextMenuButton("Summary (Legacy)") && gui.CloseDropdown()) {
-                ProjectPageSettingsPanel.Show(null, (name, icon) => Instance.AddProjectPage(name, icon, typeof(ProductionSummary), true, true));
-            }
-
-            if (gui.BuildContextMenuButton("Never Enough Items Explorer", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_N)) && gui.CloseDropdown()) {
-                ShowNeie();
-            }
-
-            if (gui.BuildContextMenuButton("Dependency Explorer") && gui.CloseDropdown()) {
-                SelectSingleObjectPanel.Select(Database.objects.explorable, "Open Dependency Explorer", DependencyExplorer.Show);
-            }
-
-            if (gui.BuildContextMenuButton("Import page from clipboard", disabled: !ImGuiUtils.HasClipboardText()) && gui.CloseDropdown()) {
-                ProjectPageSettingsPanel.LoadProjectPageFromClipboard();
-            }
-
-            BuildSubHeader(gui, "Extra");
-
-            if (gui.BuildContextMenuButton("Run Factorio")) {
-                string factorioPath = DataUtils.dataPath + "/../bin/x64/factorio";
-                string? args = string.IsNullOrEmpty(DataUtils.modsPath) ? null : "--mod-directory \"" + DataUtils.modsPath + "\"";
-                _ = Process.Start(new ProcessStartInfo(factorioPath, args!) { UseShellExecute = true }); // null-forgiving: ProcessStartInfo permits null args.
-                _ = gui.CloseDropdown();
-            }
-
-            if (gui.BuildContextMenuButton("Check for updates") && gui.CloseDropdown()) {
-                DoCheckForUpdates();
-            }
-
-            if (gui.BuildContextMenuButton("About YAFC") && gui.CloseDropdown()) {
-                _ = new AboutScreen(this);
+            gui.DrawIcon(spaceForDropdown.Expand(-0.3f), Icon.DropDown, SchemeColor.BackgroundText);
+            if (gui.BuildButton(spaceForDropdown, SchemeColor.None, SchemeColor.Grey)) {
+                updatePageList();
+                ShowDropDown(gui, spaceForDropdown, missingPagesDropdown, new Padding(0f, 0f, 0f, 0.5f), 30f);
             }
         }
+        gui.DrawRectangle(gui.lastRect, SchemeColor.PureBackground);
 
-        private bool saveConfirmationActive;
-        public override bool preventQuit => true;
-
-        protected override async void Close() {
-            if (!saveConfirmationActive && project.unsavedChangesCount > 0 && !await ConfirmUnsavedChanges()) {
-                return;
-            }
-
-            ForceClose();
+        void updatePageList() {
+            List<ProjectPage> sortedAndFilteredPageList = pageListSearch.Search(project.pages).ToList();
+            sortedAndFilteredPageList.Sort((a, b) => a.visible == b.visible ? string.Compare(a.name, b.name, StringComparison.InvariantCultureIgnoreCase) : a.visible ? -1 : 1);
+            allPages.data = sortedAndFilteredPageList;
         }
 
-        protected override void WindowMaximized() {
-            Preferences.Instance.maximizeMainScreen = true;
+        void missingPagesDropdown(ImGui gui) {
+            pageListSearch.Build(gui, updatePageList);
+            allPages.Build(gui);
+        }
+    }
+
+    private void BuildPage(ImGui gui) {
+        float usedHeaderSpace = gui.statePosition.Y;
+        var pageVisibleSize = size;
+        pageVisibleSize.Y -= usedHeaderSpace; // remaining size minus header
+        if (_activePageView != null) {
+            if (secondaryPageView != null) {
+                var visibleSize = pageVisibleSize;
+                visibleSize.Y /= 2f;
+                _activePageView.Build(gui, visibleSize);
+                secondaryPageView.Build(gui, visibleSize);
+            }
+            else {
+                _activePageView.Build(gui, pageVisibleSize);
+            }
+
+            if (pageSearch.query != null && gui.isBuilding) {
+                var searchSize = searchGui.CalculateState(30, gui.pixelsPerUnit);
+                gui.DrawPanel(new Rect(pageVisibleSize.X - searchSize.X, usedHeaderSpace, searchSize.X, searchSize.Y), searchGui);
+            }
+        }
+        else {
+            if (gui.isBuilding && Database.objectsByTypeName.TryGetValue("Entity.compilatron", out var compilatron)) {
+                gui.AllocateSpacing((pageVisibleSize.Y - 3f) / 2);
+                gui.BuildIcon(compilatron.icon, 3f);
+            }
+        }
+    }
+
+    public ProjectPage AddProjectPage(string name, FactorioObject? icon, Type contentType, bool setActive, bool initNew) {
+        ProjectPage page = new ProjectPage(project, contentType) { name = name, icon = icon };
+        if (initNew) {
+            page.content.InitNew();
+        }
+
+        project.RecordUndo().pages.Add(page);
+        if (setActive) {
+            SetActivePage(page);
+        }
+
+        return page;
+    }
+
+    public void BuildSubHeader(ImGui gui, string text) {
+        using (gui.EnterGroup(ObjectTooltip.contentPadding)) {
+            gui.BuildText(text, Font.subheader);
+        }
+
+        if (gui.isBuilding) {
+            gui.DrawRectangle(gui.lastRect, SchemeColor.GreyAlt);
+        }
+    }
+
+    private void ShowNeie() => SelectSingleObjectPanel.Select(Database.goods.explorable, "Open NEIE", NeverEnoughItemsPanel.Show);
+
+    private void SetSearch(SearchQuery searchQuery) {
+        pageSearch = searchQuery;
+        _activePageView?.SetSearchQuery(searchQuery);
+        secondaryPageView?.SetSearchQuery(searchQuery);
+        Rebuild();
+    }
+
+    private void ShowSearch() {
+        SetSearch(new SearchQuery(""));
+        if (searchBoxRect != default) {
+            searchGui.SetTextInputFocus(searchBoxRect, "");
+        }
+    }
+
+    private void BuildSearch(ImGui gui) {
+        gui.BuildText("Find on page:");
+        gui.AllocateSpacing();
+        gui.allocator = RectAllocator.RightRow;
+        if (gui.BuildButton(Icon.Close)) {
+            SetSearch(default);
+            return;
+        }
+        if (gui.BuildSearchBox(pageSearch, out pageSearch)) {
+            SetSearch(pageSearch);
+        }
+
+        if (searchBoxRect == default) {
+            gui.SetTextInputFocus(gui.lastRect, pageSearch.query);
+        }
+
+        searchBoxRect = gui.lastRect;
+    }
+
+    private void SettingsDropdown(ImGui gui) {
+        gui.boxColor = SchemeColor.Background;
+        if (gui.BuildContextMenuButton("Undo", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_Z)) && gui.CloseDropdown()) {
+            project.undo.PerformUndo();
+        }
+
+        if (gui.BuildContextMenuButton("Save", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_S)) && gui.CloseDropdown()) {
+            SaveProject().CaptureException();
+        }
+
+        if (gui.BuildContextMenuButton("Save As") && gui.CloseDropdown()) {
+            SaveProjectAs().CaptureException();
+        }
+
+        if (gui.BuildContextMenuButton("Find on page", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_F)) && gui.CloseDropdown()) {
+            ShowSearch();
+        }
+
+        if (gui.BuildContextMenuButton("Load another project (Same mods)") && gui.CloseDropdown()) {
+            LoadProjectLight();
+        }
+
+        if (gui.BuildContextMenuButton("Return to starting screen") && gui.CloseDropdown()) {
+            LoadProjectHeavy();
+        }
+
+        BuildSubHeader(gui, "Tools");
+        if (gui.BuildContextMenuButton("Milestones") && gui.CloseDropdown()) {
+            _ = ShowPseudoScreen(new MilestonesPanel());
+        }
+
+        if (gui.BuildContextMenuButton("Preferences") && gui.CloseDropdown()) {
+            PreferencesScreen.Show();
+        }
+
+        if (gui.BuildContextMenuButton("Summary") && gui.CloseDropdown()) {
+            ShowSummaryTab();
+        }
+
+        if (gui.BuildContextMenuButton("Summary (Legacy)") && gui.CloseDropdown()) {
+            ProjectPageSettingsPanel.Show(null, (name, icon) => Instance.AddProjectPage(name, icon, typeof(ProductionSummary), true, true));
+        }
+
+        if (gui.BuildContextMenuButton("Never Enough Items Explorer", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_N)) && gui.CloseDropdown()) {
+            ShowNeie();
+        }
+
+        if (gui.BuildContextMenuButton("Dependency Explorer") && gui.CloseDropdown()) {
+            SelectSingleObjectPanel.Select(Database.objects.explorable, "Open Dependency Explorer", DependencyExplorer.Show);
+        }
+
+        if (gui.BuildContextMenuButton("Import page from clipboard", disabled: !ImGuiUtils.HasClipboardText()) && gui.CloseDropdown()) {
+            ProjectPageSettingsPanel.LoadProjectPageFromClipboard();
+        }
+
+        BuildSubHeader(gui, "Extra");
+
+        if (gui.BuildContextMenuButton("Run Factorio")) {
+            string factorioPath = DataUtils.dataPath + "/../bin/x64/factorio";
+            string? args = string.IsNullOrEmpty(DataUtils.modsPath) ? null : "--mod-directory \"" + DataUtils.modsPath + "\"";
+            _ = Process.Start(new ProcessStartInfo(factorioPath, args!) { UseShellExecute = true }); // null-forgiving: ProcessStartInfo permits null args.
+            _ = gui.CloseDropdown();
+        }
+
+        if (gui.BuildContextMenuButton("Check for updates") && gui.CloseDropdown()) {
+            DoCheckForUpdates();
+        }
+
+        if (gui.BuildContextMenuButton("About YAFC") && gui.CloseDropdown()) {
+            _ = new AboutScreen(this);
+        }
+    }
+
+    private bool saveConfirmationActive;
+    public override bool preventQuit => true;
+
+    protected override async void Close() {
+        if (!saveConfirmationActive && project.unsavedChangesCount > 0 && !await ConfirmUnsavedChanges()) {
+            return;
+        }
+
+        ForceClose();
+    }
+
+    protected override void WindowMaximized() {
+        Preferences.Instance.maximizeMainScreen = true;
+        Preferences.Instance.Save();
+    }
+
+    protected override void WindowRestored() {
+        Preferences.Instance.maximizeMainScreen = false;
+        Preferences.Instance.Save();
+    }
+
+    protected override void WindowResize() {
+        base.WindowResize();
+        if (!IsMaximized) {
+            Preferences.Instance.initialMainScreenWidth = size.X;
+            Preferences.Instance.initialMainScreenHeight = size.Y;
             Preferences.Instance.Save();
         }
+    }
 
-        protected override void WindowRestored() {
-            Preferences.Instance.maximizeMainScreen = false;
-            Preferences.Instance.Save();
+    public void ForceClose() {
+        Preferences.Instance.Save();
+        base.Close();
+    }
+
+    private async Task<bool> ConfirmUnsavedChanges() {
+        string unsavedCount = "You have " + project.unsavedChangesCount + " unsaved changes";
+        if (!string.IsNullOrEmpty(project.attachedFileName)) {
+            unsavedCount += " to " + project.attachedFileName;
         }
 
-        protected override void WindowResize() {
-            base.WindowResize();
-            if (!IsMaximized) {
-                Preferences.Instance.initialMainScreenWidth = size.X;
-                Preferences.Instance.initialMainScreenHeight = size.Y;
-                Preferences.Instance.Save();
-            }
-        }
-
-        public void ForceClose() {
-            Preferences.Instance.Save();
-            base.Close();
-        }
-
-        private async Task<bool> ConfirmUnsavedChanges() {
-            string unsavedCount = "You have " + project.unsavedChangesCount + " unsaved changes";
-            if (!string.IsNullOrEmpty(project.attachedFileName)) {
-                unsavedCount += " to " + project.attachedFileName;
-            }
-
-            saveConfirmationActive = true;
-            var (hasChoice, choice) = await MessageBox.Show("Save unsaved changes?", unsavedCount, "Save", "Don't save");
-            saveConfirmationActive = false;
-            if (!hasChoice) {
-                return false;
-            }
-
-            if (choice) {
-                bool saved = await SaveProject();
-                if (!saved) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private class GithubReleaseInfo {
-            public string html_url { get; set; } = null!; // null-forgiving: Set by Deserialize
-            public string tag_name { get; set; } = null!; // null-forgiving: Set by Deserialize
-        }
-        private async void DoCheckForUpdates() {
-            try {
-                HttpClient client = new HttpClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "YAFC-CE (check for updates)");
-                string result = await client.GetStringAsync(new Uri("https://api.github.com/repos/have-fun-was-taken/yafc-ce/releases/latest"));
-                var release = JsonSerializer.Deserialize<GithubReleaseInfo>(result)!;
-                string version = release.tag_name.StartsWith("v", StringComparison.Ordinal) ? release.tag_name[1..] : release.tag_name;
-                if (new Version(version) > YafcLib.version) {
-                    var (_, answer) = await MessageBox.Show("New version available!", "There is a new version available: " + release.tag_name, "Visit release page", "Close");
-                    if (answer) {
-                        Ui.VisitLink(release.html_url);
-                    }
-
-                    return;
-                }
-                MessageBox.Show("No newer version", "You are running the latest version!", "Ok");
-            }
-            catch (Exception) {
-                MessageBox.Show((hasAnswer, answer) => {
-                    if (answer) {
-                        Ui.VisitLink(AboutScreen.Github + "/releases");
-                    }
-                }, "Network error", "There were an error while checking versions.", "Open releases url", "Close");
-            }
-        }
-
-        public void ShowTooltip(IFactorioObjectWrapper obj, ImGui source, Rect sourceRect, ObjectTooltipOptions tooltipOptions = default) {
-            objectTooltip.SetFocus(obj, source, sourceRect, tooltipOptions);
-            ShowTooltip(objectTooltip);
-        }
-
-        public bool ShowPseudoScreen(PseudoScreen screen) {
-            if (topScreen == null) {
-                Ui.DispatchInMainThread(x => fadeDrawer.CreateDownscaledImage(), null);
-            }
-            project.undo.Suspend();
-            screen.Rebuild();
-            pseudoScreens.Insert(0, screen);
-            screen.Open();
-            rootGui.Rebuild();
-            return true;
-        }
-
-        public void ClosePseudoScreen(PseudoScreen screen) {
-            _ = pseudoScreens.Remove(screen);
-            if (pseudoScreens.Count > 0) {
-                pseudoScreens[^1].Activated();
-            }
-
-            rootGui.Rebuild();
-        }
-
-        public void ClosePage(Guid page) => _ = project.RecordUndo(true).displayPages.Remove(page);
-
-        public void ShowSummaryTab() {
-
-            ProjectPage? summaryPage = project.FindPage(SummaryGuid);
-            if (summaryPage == null) {
-
-                summaryPage = new ProjectPage(project, typeof(Summary), SummaryGuid) {
-                    name = "Summary",
-                };
-                project.pages.Add(summaryPage);
-            }
-
-            SetActivePage(summaryPage);
-        }
-
-        public bool KeyDown(SDL.SDL_Keysym key) {
-            bool ctrl = (key.mod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
-            bool shift = (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
-            if (ctrl) {
-                switch (key.scancode) {
-                    case SDL.SDL_Scancode.SDL_SCANCODE_S:
-                        SaveProject().CaptureException();
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_Z:
-                        if ((key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0) {
-                            project.undo.PerformRedo();
-                        }
-                        else {
-                            project.undo.PerformUndo();
-                        }
-
-                        _activePageView?.Rebuild(false);
-                        secondaryPageView?.Rebuild(false);
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_Y:
-                        project.undo.PerformRedo();
-                        _activePageView?.Rebuild(false);
-                        secondaryPageView?.Rebuild(false);
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_N:
-                        ShowNeie();
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_F:
-                        ShowSearch();
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_T:
-                        ProductionTableView.CreateProductionSheet();
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_TAB:
-                        SetActivePage(project.VisibleNeighborOfPage(activePage, !shift));
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN:
-                        if (shift) {
-                            project.ReorderPages(activePage, project.VisibleNeighborOfPage(activePage, true));
-                        }
-                        else {
-                            SetActivePage(project.VisibleNeighborOfPage(activePage, true));
-                        }
-                        break;
-                    case SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP:
-                        if (shift) {
-                            project.ReorderPages(activePage, project.VisibleNeighborOfPage(activePage, false));
-                        }
-                        else {
-                            SetActivePage(project.VisibleNeighborOfPage(activePage, false));
-                        }
-                        break;
-                    default:
-                        if (_activePageView?.ControlKey(key.scancode) != true) {
-                            _ = (secondaryPageView?.ControlKey(key.scancode));
-                        }
-                        break;
-                }
-            }
-
-            if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE && pageSearch.query != null) {
-                SetSearch(default);
-            }
-
-            return true;
-        }
-
-        private async Task<bool> SaveProjectAs() {
-            string? projectPath = await new FilesystemScreen("Save project", "Save project as", "Save",
-                string.IsNullOrEmpty(project.attachedFileName) ? null : Path.GetDirectoryName(project.attachedFileName),
-                FilesystemScreen.Mode.SelectOrCreateFile, "project", this, null, "yafc");
-            if (projectPath != null) {
-                project.Save(projectPath);
-                Preferences.Instance.AddProject(DataUtils.dataPath, DataUtils.modsPath, projectPath, DataUtils.expensiveRecipes, DataUtils.netProduction);
-                return true;
-            }
-
+        saveConfirmationActive = true;
+        var (hasChoice, choice) = await MessageBox.Show("Save unsaved changes?", unsavedCount, "Save", "Don't save");
+        saveConfirmationActive = false;
+        if (!hasChoice) {
             return false;
         }
 
-        private Task<bool> SaveProject() {
-            if (!string.IsNullOrEmpty(project.attachedFileName)) {
-                project.Save(project.attachedFileName);
-                return Task.FromResult(true);
-            }
-
-            return SaveProjectAs();
-        }
-
-        private async void LoadProjectLight() {
-            if (project.unsavedChangesCount > 0 && !await ConfirmUnsavedChanges()) {
-                return;
-            }
-
-            string? path = await new FilesystemScreen("Load project", "Load another .yafc project", "Select",
-                string.IsNullOrEmpty(project.attachedFileName) ? null : Path.GetDirectoryName(project.attachedFileName), FilesystemScreen.Mode.SelectOrCreateFile, "project", this,
-                null, "yafc");
-            if (path == null) {
-                return;
-            }
-
-            ErrorCollector errors = new ErrorCollector();
-            try {
-                Project project = Project.ReadFromFile(path, errors);
-                Analysis.ProcessAnalyses(this, project, errors);
-                SetProject(project);
-            }
-            catch (Exception ex) {
-                errors.Exception(ex, "Critical loading exception", ErrorSeverity.Important);
-            }
-            if (errors.severity != ErrorSeverity.None) {
-                ErrorListPanel.Show(errors);
+        if (choice) {
+            bool saved = await SaveProject();
+            if (!saved) {
+                return false;
             }
         }
 
-        private async void LoadProjectHeavy() {
-            if (project.unsavedChangesCount > 0 && !await ConfirmUnsavedChanges()) {
-                return;
-            }
+        return true;
+    }
 
-            SetActivePage(null);
-            _ = new WelcomeScreen();
-            ForceClose();
-        }
-
-        public bool TextInput(string input) => true;
-
-        public bool KeyUp(SDL.SDL_Keysym key) => true;
-
-        public void FocusChanged(bool focused) { }
-
-        private class FadeDrawer : IRenderable {
-            private SDL.SDL_Rect srcRect;
-            private TextureHandle blurredFade;
-
-            public void CreateDownscaledImage() {
-                nint renderer = Instance.surface!.renderer; // null-forgiving: surface has been set earlier in the render loop.
-                blurredFade = blurredFade.Destroy();
-                var texture = Instance.surface.BeginRenderToTexture(out var size);
-                Instance.MainRender();
-                Instance.surface.EndRenderToTexture();
-                for (int i = 0; i < 2; i++) {
-                    SDL.SDL_Rect halfSize = new SDL.SDL_Rect() { w = size.w / 2, h = size.h / 2 };
-                    var halfTexture = Instance.surface.CreateTexture(SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, halfSize.w, halfSize.h);
-                    _ = SDL.SDL_SetRenderTarget(renderer, halfTexture.handle);
-                    var bgColor = SchemeColor.PureBackground.ToSdlColor();
-                    _ = SDL.SDL_SetRenderDrawColor(renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
-                    _ = SDL.SDL_RenderClear(renderer);
-                    _ = SDL.SDL_SetTextureBlendMode(texture.handle, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
-                    _ = SDL.SDL_SetTextureAlphaMod(texture.handle, 120);
-                    _ = SDL.SDL_RenderCopy(renderer, texture.handle, ref size, ref halfSize);
-                    _ = texture.Destroy();
-                    texture = halfTexture;
-                    size = halfSize;
+    private class GithubReleaseInfo {
+        public string html_url { get; set; } = null!; // null-forgiving: Set by Deserialize
+        public string tag_name { get; set; } = null!; // null-forgiving: Set by Deserialize
+    }
+    private async void DoCheckForUpdates() {
+        try {
+            HttpClient client = new HttpClient();
+            client.DefaultRequestHeaders.Add("User-Agent", "YAFC-CE (check for updates)");
+            string result = await client.GetStringAsync(new Uri("https://api.github.com/repos/have-fun-was-taken/yafc-ce/releases/latest"));
+            var release = JsonSerializer.Deserialize<GithubReleaseInfo>(result)!;
+            string version = release.tag_name.StartsWith("v", StringComparison.Ordinal) ? release.tag_name[1..] : release.tag_name;
+            if (new Version(version) > YafcLib.version) {
+                var (_, answer) = await MessageBox.Show("New version available!", "There is a new version available: " + release.tag_name, "Visit release page", "Close");
+                if (answer) {
+                    Ui.VisitLink(release.html_url);
                 }
-                _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
-                srcRect = size;
-                blurredFade = texture;
-            }
 
-            public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
-                if (blurredFade.valid) {
-                    _ = SDL.SDL_RenderCopy(surface.renderer, blurredFade.handle, ref srcRect, ref position);
-                }
-            }
-        }
-
-        public void Report((string, string) value) => logger.Information("Status: {primary}, {secondary}", value.Item1, value.Item2); // TODO
-
-        public bool IsSameObjectHovered(ImGui gui, FactorioObject? obj) => objectTooltip.IsSameObjectHovered(gui, obj);
-
-        public void ShowTooltip(ImGui gui, ProjectPage? page, bool isMiddleEdit, Rect rect) {
-            if (page == null || !registeredPageViews.TryGetValue(page.content.GetType(), out var pageView)) {
                 return;
             }
-
-            ShowTooltip(gui, rect, x => {
-                pageView.BuildPageTooltip(x, page.content);
-                if (isMiddleEdit) {
-                    x.BuildText("Middle mouse button to edit", TextBlockDisplayStyle.WrappedText with { Color = SchemeColor.BackgroundTextFaint });
-                }
-            });
+            MessageBox.Show("No newer version", "You are running the latest version!", "Ok");
         }
+        catch (Exception) {
+            MessageBox.Show((hasAnswer, answer) => {
+                if (answer) {
+                    Ui.VisitLink(AboutScreen.Github + "/releases");
+                }
+            }, "Network error", "There were an error while checking versions.", "Open releases url", "Close");
+        }
+    }
+
+    public void ShowTooltip(IFactorioObjectWrapper obj, ImGui source, Rect sourceRect, ObjectTooltipOptions tooltipOptions = default) {
+        objectTooltip.SetFocus(obj, source, sourceRect, tooltipOptions);
+        ShowTooltip(objectTooltip);
+    }
+
+    public bool ShowPseudoScreen(PseudoScreen screen) {
+        if (topScreen == null) {
+            Ui.DispatchInMainThread(x => fadeDrawer.CreateDownscaledImage(), null);
+        }
+        project.undo.Suspend();
+        screen.Rebuild();
+        pseudoScreens.Insert(0, screen);
+        screen.Open();
+        rootGui.Rebuild();
+        return true;
+    }
+
+    public void ClosePseudoScreen(PseudoScreen screen) {
+        _ = pseudoScreens.Remove(screen);
+        if (pseudoScreens.Count > 0) {
+            pseudoScreens[^1].Activated();
+        }
+
+        rootGui.Rebuild();
+    }
+
+    public void ClosePage(Guid page) => _ = project.RecordUndo(true).displayPages.Remove(page);
+
+    public void ShowSummaryTab() {
+
+        ProjectPage? summaryPage = project.FindPage(SummaryGuid);
+        if (summaryPage == null) {
+
+            summaryPage = new ProjectPage(project, typeof(Summary), SummaryGuid) {
+                name = "Summary",
+            };
+            project.pages.Add(summaryPage);
+        }
+
+        SetActivePage(summaryPage);
+    }
+
+    public bool KeyDown(SDL.SDL_Keysym key) {
+        bool ctrl = (key.mod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
+        bool shift = (key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
+        if (ctrl) {
+            switch (key.scancode) {
+                case SDL.SDL_Scancode.SDL_SCANCODE_S:
+                    SaveProject().CaptureException();
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_Z:
+                    if ((key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0) {
+                        project.undo.PerformRedo();
+                    }
+                    else {
+                        project.undo.PerformUndo();
+                    }
+
+                    _activePageView?.Rebuild(false);
+                    secondaryPageView?.Rebuild(false);
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_Y:
+                    project.undo.PerformRedo();
+                    _activePageView?.Rebuild(false);
+                    secondaryPageView?.Rebuild(false);
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_N:
+                    ShowNeie();
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_F:
+                    ShowSearch();
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_T:
+                    ProductionTableView.CreateProductionSheet();
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_TAB:
+                    SetActivePage(project.VisibleNeighborOfPage(activePage, !shift));
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN:
+                    if (shift) {
+                        project.ReorderPages(activePage, project.VisibleNeighborOfPage(activePage, true));
+                    }
+                    else {
+                        SetActivePage(project.VisibleNeighborOfPage(activePage, true));
+                    }
+                    break;
+                case SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP:
+                    if (shift) {
+                        project.ReorderPages(activePage, project.VisibleNeighborOfPage(activePage, false));
+                    }
+                    else {
+                        SetActivePage(project.VisibleNeighborOfPage(activePage, false));
+                    }
+                    break;
+                default:
+                    if (_activePageView?.ControlKey(key.scancode) != true) {
+                        _ = (secondaryPageView?.ControlKey(key.scancode));
+                    }
+                    break;
+            }
+        }
+
+        if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE && pageSearch.query != null) {
+            SetSearch(default);
+        }
+
+        return true;
+    }
+
+    private async Task<bool> SaveProjectAs() {
+        string? projectPath = await new FilesystemScreen("Save project", "Save project as", "Save",
+            string.IsNullOrEmpty(project.attachedFileName) ? null : Path.GetDirectoryName(project.attachedFileName),
+            FilesystemScreen.Mode.SelectOrCreateFile, "project", this, null, "yafc");
+        if (projectPath != null) {
+            project.Save(projectPath);
+            Preferences.Instance.AddProject(DataUtils.dataPath, DataUtils.modsPath, projectPath, DataUtils.expensiveRecipes, DataUtils.netProduction);
+            return true;
+        }
+
+        return false;
+    }
+
+    private Task<bool> SaveProject() {
+        if (!string.IsNullOrEmpty(project.attachedFileName)) {
+            project.Save(project.attachedFileName);
+            return Task.FromResult(true);
+        }
+
+        return SaveProjectAs();
+    }
+
+    private async void LoadProjectLight() {
+        if (project.unsavedChangesCount > 0 && !await ConfirmUnsavedChanges()) {
+            return;
+        }
+
+        string? path = await new FilesystemScreen("Load project", "Load another .yafc project", "Select",
+            string.IsNullOrEmpty(project.attachedFileName) ? null : Path.GetDirectoryName(project.attachedFileName), FilesystemScreen.Mode.SelectOrCreateFile, "project", this,
+            null, "yafc");
+        if (path == null) {
+            return;
+        }
+
+        ErrorCollector errors = new ErrorCollector();
+        try {
+            Project project = Project.ReadFromFile(path, errors);
+            Analysis.ProcessAnalyses(this, project, errors);
+            SetProject(project);
+        }
+        catch (Exception ex) {
+            errors.Exception(ex, "Critical loading exception", ErrorSeverity.Important);
+        }
+        if (errors.severity != ErrorSeverity.None) {
+            ErrorListPanel.Show(errors);
+        }
+    }
+
+    private async void LoadProjectHeavy() {
+        if (project.unsavedChangesCount > 0 && !await ConfirmUnsavedChanges()) {
+            return;
+        }
+
+        SetActivePage(null);
+        _ = new WelcomeScreen();
+        ForceClose();
+    }
+
+    public bool TextInput(string input) => true;
+
+    public bool KeyUp(SDL.SDL_Keysym key) => true;
+
+    public void FocusChanged(bool focused) { }
+
+    private class FadeDrawer : IRenderable {
+        private SDL.SDL_Rect srcRect;
+        private TextureHandle blurredFade;
+
+        public void CreateDownscaledImage() {
+            nint renderer = Instance.surface!.renderer; // null-forgiving: surface has been set earlier in the render loop.
+            blurredFade = blurredFade.Destroy();
+            var texture = Instance.surface.BeginRenderToTexture(out var size);
+            Instance.MainRender();
+            Instance.surface.EndRenderToTexture();
+            for (int i = 0; i < 2; i++) {
+                SDL.SDL_Rect halfSize = new SDL.SDL_Rect() { w = size.w / 2, h = size.h / 2 };
+                var halfTexture = Instance.surface.CreateTexture(SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, halfSize.w, halfSize.h);
+                _ = SDL.SDL_SetRenderTarget(renderer, halfTexture.handle);
+                var bgColor = SchemeColor.PureBackground.ToSdlColor();
+                _ = SDL.SDL_SetRenderDrawColor(renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
+                _ = SDL.SDL_RenderClear(renderer);
+                _ = SDL.SDL_SetTextureBlendMode(texture.handle, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+                _ = SDL.SDL_SetTextureAlphaMod(texture.handle, 120);
+                _ = SDL.SDL_RenderCopy(renderer, texture.handle, ref size, ref halfSize);
+                _ = texture.Destroy();
+                texture = halfTexture;
+                size = halfSize;
+            }
+            _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
+            srcRect = size;
+            blurredFade = texture;
+        }
+
+        public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
+            if (blurredFade.valid) {
+                _ = SDL.SDL_RenderCopy(surface.renderer, blurredFade.handle, ref srcRect, ref position);
+            }
+        }
+    }
+
+    public void Report((string, string) value) => logger.Information("Status: {primary}, {secondary}", value.Item1, value.Item2); // TODO
+
+    public bool IsSameObjectHovered(ImGui gui, FactorioObject? obj) => objectTooltip.IsSameObjectHovered(gui, obj);
+
+    public void ShowTooltip(ImGui gui, ProjectPage? page, bool isMiddleEdit, Rect rect) {
+        if (page == null || !registeredPageViews.TryGetValue(page.content.GetType(), out var pageView)) {
+            return;
+        }
+
+        ShowTooltip(gui, rect, x => {
+            pageView.BuildPageTooltip(x, page.content);
+            if (isMiddleEdit) {
+                x.BuildText("Middle mouse button to edit", TextBlockDisplayStyle.WrappedText with { Color = SchemeColor.BackgroundTextFaint });
+            }
+        });
     }
 }

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -2,51 +2,50 @@
 using System.Threading.Tasks;
 using Yafc.UI;
 
-namespace Yafc {
-    public class MessageBox : PseudoScreenWithResult<bool> {
-        private readonly string title;
-        private readonly string message;
-        private readonly string yes;
-        private readonly string? no;
+namespace Yafc;
+public class MessageBox : PseudoScreenWithResult<bool> {
+    private readonly string title;
+    private readonly string message;
+    private readonly string yes;
+    private readonly string? no;
 
-        private MessageBox(string title, string message, string yes, string? no) : base(30f) {
-            this.title = title;
-            this.message = message;
-            this.yes = yes;
-            this.no = no;
-        }
-
-        public static void Show(Action<bool, bool>? result, string title, string message, string yes, string? no) {
-            MessageBox instance = new MessageBox(title, message, yes, no) { completionCallback = result };
-            _ = MainScreen.Instance.ShowPseudoScreen(instance);
-        }
-
-        public static void Show(string title, string message, string yes) => Show(null, title, message, yes, null);
-
-        public static Task<(bool haveChoice, bool choice)> Show(string title, string message, string yes, string? no) {
-            TaskCompletionSource<(bool, bool)> tcs = new TaskCompletionSource<(bool, bool)>();
-            Show((a, b) => tcs.TrySetResult((a, b)), title, message, yes, no);
-            return tcs.Task;
-        }
-
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, title);
-            if (message != null) {
-                gui.BuildText(message, TextBlockDisplayStyle.WrappedText);
-            }
-
-            gui.AllocateSpacing(2f);
-            using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
-                if (gui.BuildButton(yes)) {
-                    CloseWithResult(true);
-                }
-
-                if (no != null && gui.BuildButton(no, SchemeColor.Grey)) {
-                    CloseWithResult(false);
-                }
-            }
-        }
-
-        protected override void ReturnPressed() => CloseWithResult(true);
+    private MessageBox(string title, string message, string yes, string? no) : base(30f) {
+        this.title = title;
+        this.message = message;
+        this.yes = yes;
+        this.no = no;
     }
+
+    public static void Show(Action<bool, bool>? result, string title, string message, string yes, string? no) {
+        MessageBox instance = new MessageBox(title, message, yes, no) { completionCallback = result };
+        _ = MainScreen.Instance.ShowPseudoScreen(instance);
+    }
+
+    public static void Show(string title, string message, string yes) => Show(null, title, message, yes, null);
+
+    public static Task<(bool haveChoice, bool choice)> Show(string title, string message, string yes, string? no) {
+        TaskCompletionSource<(bool, bool)> tcs = new TaskCompletionSource<(bool, bool)>();
+        Show((a, b) => tcs.TrySetResult((a, b)), title, message, yes, no);
+        return tcs.Task;
+    }
+
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, title);
+        if (message != null) {
+            gui.BuildText(message, TextBlockDisplayStyle.WrappedText);
+        }
+
+        gui.AllocateSpacing(2f);
+        using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
+            if (gui.BuildButton(yes)) {
+                CloseWithResult(true);
+            }
+
+            if (no != null && gui.BuildButton(no, SchemeColor.Grey)) {
+                CloseWithResult(false);
+            }
+        }
+    }
+
+    protected override void ReturnPressed() => CloseWithResult(true);
 }

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -3,97 +3,96 @@ using System.Numerics;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class MilestonesEditor : PseudoScreen {
-        private static readonly MilestonesEditor Instance = new MilestonesEditor();
-        private readonly VirtualScrollList<FactorioObject> milestoneList;
+namespace Yafc;
+public class MilestonesEditor : PseudoScreen {
+    private static readonly MilestonesEditor Instance = new MilestonesEditor();
+    private readonly VirtualScrollList<FactorioObject> milestoneList;
 
-        public MilestonesEditor() : base(50) {
-            milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
-            cleanupCallback = () => {
-                // Force rebuild the panel to update its contents and show the possibly-modified milestones.
-                MilestonesPanel.Rebuild();
+    public MilestonesEditor() : base(50) {
+        milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
+        cleanupCallback = () => {
+            // Force rebuild the panel to update its contents and show the possibly-modified milestones.
+            MilestonesPanel.Rebuild();
 
-                // Recalculate the project with the  possibly-modified milestones.
-                Milestones.Instance.Compute(Project.current, new());
-            };
-        }
+            // Recalculate the project with the  possibly-modified milestones.
+            Milestones.Instance.Compute(Project.current, new());
+        };
+    }
 
-        public override void Open() {
-            base.Open();
-            milestoneList.data = Project.current.settings.milestones;
-        }
+    public override void Open() {
+        base.Open();
+        milestoneList.data = Project.current.settings.milestones;
+    }
 
-        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
 
-        private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
-            using (gui.EnterRow()) {
-                var settings = Project.current.settings;
-                gui.BuildFactorioObjectIcon(element, new IconDisplayStyle(3f, MilestoneDisplay.None, false));
-                gui.BuildText(element.locName, maxWidth: width - 16.6f); // Experimentally determined width of the non-text parts of the editor.
-                if (gui.BuildButton(Icon.Close, size: 1f)) {
-                    _ = settings.RecordUndo().milestones.Remove(element);
-                    Rebuild();
-                    milestoneList.data = settings.milestones;
-                }
-            }
-            if (gui.DoListReordering(gui.lastRect, gui.lastRect, index, out int moveFrom)) {
-                Project.current.settings.RecordUndo().milestones.MoveListElementIndex(moveFrom, index);
-            }
-        }
-
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Milestone editor");
-            milestoneList.Build(gui);
-            gui.BuildText(
-                "Hint: You can reorder milestones. When an object is locked behind a milestone, the first inaccessible milestone will be shown. Also when there is a choice between different milestones, first will be chosen",
-                TextBlockDisplayStyle.WrappedText with { Color = SchemeColor.BackgroundTextFaint });
-            using (gui.EnterRow()) {
-                if (gui.BuildButton("Auto sort milestones", SchemeColor.Grey)) {
-                    ErrorCollector collector = new ErrorCollector();
-                    Milestones.Instance.ComputeWithParameters(Project.current, collector, Project.current.settings.milestones.ToArray(), true);
-                    if (collector.severity > ErrorSeverity.None) {
-                        ErrorListPanel.Show(collector);
-                    }
-
-                    milestoneList.RebuildContents();
-                }
-                if (gui.BuildButton("Add milestone")) {
-                    SelectMultiObjectPanel.Select(Database.objects.all.Except(Project.current.settings.milestones), "Add new milestone", AddMilestone);
-                }
-            }
-        }
-
-        private void AddMilestone(FactorioObject obj) {
+    private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
+        using (gui.EnterRow()) {
             var settings = Project.current.settings;
-            if (settings.milestones.Contains(obj)) {
-                MessageBox.Show("Cannot add milestone", "Milestone already exists", "Ok");
-                return;
+            gui.BuildFactorioObjectIcon(element, new IconDisplayStyle(3f, MilestoneDisplay.None, false));
+            gui.BuildText(element.locName, maxWidth: width - 16.6f); // Experimentally determined width of the non-text parts of the editor.
+            if (gui.BuildButton(Icon.Close, size: 1f)) {
+                _ = settings.RecordUndo().milestones.Remove(element);
+                Rebuild();
+                milestoneList.data = settings.milestones;
             }
-            var lockedMask = Milestones.Instance.GetMilestoneResult(obj);
-            if (lockedMask.IsClear()) {
-                settings.RecordUndo().milestones.Add(obj);
-            }
-            else {
-                int bestIndex = 0;
-                for (int i = 1; i < lockedMask.length; i++) {
-                    if (lockedMask[i]) {
-                        lockedMask[i] = false;
-                        var milestone = Milestones.Instance.currentMilestones[i - 1];
-                        int index = settings.milestones.IndexOf(milestone);
-                        if (index >= bestIndex) {
-                            bestIndex = index + 1;
-                        }
+        }
+        if (gui.DoListReordering(gui.lastRect, gui.lastRect, index, out int moveFrom)) {
+            Project.current.settings.RecordUndo().milestones.MoveListElementIndex(moveFrom, index);
+        }
+    }
 
-                        if (lockedMask.IsClear()) {
-                            break;
-                        }
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Milestone editor");
+        milestoneList.Build(gui);
+        gui.BuildText(
+            "Hint: You can reorder milestones. When an object is locked behind a milestone, the first inaccessible milestone will be shown. Also when there is a choice between different milestones, first will be chosen",
+            TextBlockDisplayStyle.WrappedText with { Color = SchemeColor.BackgroundTextFaint });
+        using (gui.EnterRow()) {
+            if (gui.BuildButton("Auto sort milestones", SchemeColor.Grey)) {
+                ErrorCollector collector = new ErrorCollector();
+                Milestones.Instance.ComputeWithParameters(Project.current, collector, Project.current.settings.milestones.ToArray(), true);
+                if (collector.severity > ErrorSeverity.None) {
+                    ErrorListPanel.Show(collector);
+                }
+
+                milestoneList.RebuildContents();
+            }
+            if (gui.BuildButton("Add milestone")) {
+                SelectMultiObjectPanel.Select(Database.objects.all.Except(Project.current.settings.milestones), "Add new milestone", AddMilestone);
+            }
+        }
+    }
+
+    private void AddMilestone(FactorioObject obj) {
+        var settings = Project.current.settings;
+        if (settings.milestones.Contains(obj)) {
+            MessageBox.Show("Cannot add milestone", "Milestone already exists", "Ok");
+            return;
+        }
+        var lockedMask = Milestones.Instance.GetMilestoneResult(obj);
+        if (lockedMask.IsClear()) {
+            settings.RecordUndo().milestones.Add(obj);
+        }
+        else {
+            int bestIndex = 0;
+            for (int i = 1; i < lockedMask.length; i++) {
+                if (lockedMask[i]) {
+                    lockedMask[i] = false;
+                    var milestone = Milestones.Instance.currentMilestones[i - 1];
+                    int index = settings.milestones.IndexOf(milestone);
+                    if (index >= bestIndex) {
+                        bestIndex = index + 1;
+                    }
+
+                    if (lockedMask.IsClear()) {
+                        break;
                     }
                 }
-                settings.RecordUndo().milestones.Insert(bestIndex, obj);
             }
-            Rebuild();
-            milestoneList.data = settings.milestones;
+            settings.RecordUndo().milestones.Insert(bestIndex, obj);
         }
+        Rebuild();
+        milestoneList.data = settings.milestones;
     }
 }

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -2,64 +2,63 @@
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class MilestonesWidget : VirtualScrollList<FactorioObject> {
-        public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer) => data = Project.current.settings.milestones;
+namespace Yafc;
+public class MilestonesWidget : VirtualScrollList<FactorioObject> {
+    public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer) => data = Project.current.settings.milestones;
 
-        private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
-            var settings = Project.current.settings;
-            bool unlocked = settings.Flags(element).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
-            if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.Milestone(unlocked ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
-                if (!unlocked) {
-                    var massUnlock = Milestones.Instance.GetMilestoneResult(element);
-                    int subIndex = 0;
-                    settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, true);
-                    foreach (var milestone in settings.milestones) {
-                        subIndex++;
-                        if (massUnlock[subIndex]) {
-                            settings.SetFlag(milestone, ProjectPerItemFlags.MilestoneUnlocked, true);
-                        }
+    private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
+        var settings = Project.current.settings;
+        bool unlocked = settings.Flags(element).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
+        if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.Milestone(unlocked ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
+            if (!unlocked) {
+                var massUnlock = Milestones.Instance.GetMilestoneResult(element);
+                int subIndex = 0;
+                settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, true);
+                foreach (var milestone in settings.milestones) {
+                    subIndex++;
+                    if (massUnlock[subIndex]) {
+                        settings.SetFlag(milestone, ProjectPerItemFlags.MilestoneUnlocked, true);
                     }
                 }
-                else {
-                    settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, false);
-                }
             }
-            if (unlocked && gui.isBuilding) {
-                gui.DrawIcon(gui.lastRect, Icon.Check, SchemeColor.Error);
+            else {
+                settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, false);
+            }
+        }
+        if (unlocked && gui.isBuilding) {
+            gui.DrawIcon(gui.lastRect, Icon.Check, SchemeColor.Error);
+        }
+    }
+}
+
+public class MilestonesPanel : PseudoScreen {
+    private static MilestonesWidget? instance;
+    private readonly MilestonesWidget milestonesWidget = new();
+
+    public override void Build(ImGui gui) {
+        instance = milestonesWidget;
+        gui.spacing = 1f;
+        BuildHeader(gui, "Milestones");
+        gui.BuildText("Please select objects that you already have access to:");
+        gui.AllocateSpacing(2f);
+        milestonesWidget.Build(gui);
+        gui.AllocateSpacing(2f);
+        gui.BuildText("For your convenience, YAFC will show objects you DON'T have access to based on this selection", TextBlockDisplayStyle.WrappedText);
+        gui.BuildText("These are called 'Milestones'. By default all science packs are added as milestones, but this does not have to be this way! " +
+                      "You can define your own milestones: Any item, recipe, entity or technology may be added as a milestone. For example you can add advanced " +
+                      "electronic circuits as a milestone, and YAFC will display everything that is locked behind those circuits", TextBlockDisplayStyle.WrappedText);
+        using (gui.EnterRow()) {
+            if (gui.BuildButton("Edit milestones", SchemeColor.Grey)) {
+                MilestonesEditor.Show();
+            }
+
+            if (gui.RemainingRow().BuildButton("Done")) {
+                Close();
             }
         }
     }
 
-    public class MilestonesPanel : PseudoScreen {
-        private static MilestonesWidget? instance;
-        private readonly MilestonesWidget milestonesWidget = new();
+    protected override void ReturnPressed() => Close();
 
-        public override void Build(ImGui gui) {
-            instance = milestonesWidget;
-            gui.spacing = 1f;
-            BuildHeader(gui, "Milestones");
-            gui.BuildText("Please select objects that you already have access to:");
-            gui.AllocateSpacing(2f);
-            milestonesWidget.Build(gui);
-            gui.AllocateSpacing(2f);
-            gui.BuildText("For your convenience, YAFC will show objects you DON'T have access to based on this selection", TextBlockDisplayStyle.WrappedText);
-            gui.BuildText("These are called 'Milestones'. By default all science packs are added as milestones, but this does not have to be this way! " +
-                          "You can define your own milestones: Any item, recipe, entity or technology may be added as a milestone. For example you can add advanced " +
-                          "electronic circuits as a milestone, and YAFC will display everything that is locked behind those circuits", TextBlockDisplayStyle.WrappedText);
-            using (gui.EnterRow()) {
-                if (gui.BuildButton("Edit milestones", SchemeColor.Grey)) {
-                    MilestonesEditor.Show();
-                }
-
-                if (gui.RemainingRow().BuildButton("Done")) {
-                    Close();
-                }
-            }
-        }
-
-        protected override void ReturnPressed() => Close();
-
-        internal static new void Rebuild() => instance?.RebuildContents();
-    }
+    internal static new void Rebuild() => instance?.RebuildContents();
 }

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -3,411 +3,410 @@ using System.Collections.Generic;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class NeverEnoughItemsPanel : PseudoScreen, IComparer<NeverEnoughItemsPanel.RecipeEntry> {
-        private static readonly NeverEnoughItemsPanel Instance = new NeverEnoughItemsPanel();
-        private Goods current = null!; // null-forgiving: Set by Show.
-        private Goods? changing;
-        private float currentFlow;
-        private EntryStatus showRecipesRange = EntryStatus.Normal;
-        private readonly List<Goods> recent = [];
-        private bool atCurrentMilestones;
+namespace Yafc;
+public class NeverEnoughItemsPanel : PseudoScreen, IComparer<NeverEnoughItemsPanel.RecipeEntry> {
+    private static readonly NeverEnoughItemsPanel Instance = new NeverEnoughItemsPanel();
+    private Goods current = null!; // null-forgiving: Set by Show.
+    private Goods? changing;
+    private float currentFlow;
+    private EntryStatus showRecipesRange = EntryStatus.Normal;
+    private readonly List<Goods> recent = [];
+    private bool atCurrentMilestones;
 
-        private readonly ScrollArea productionList;
-        private readonly ScrollArea usageList;
+    private readonly ScrollArea productionList;
+    private readonly ScrollArea usageList;
 
-        private enum EntryStatus {
-            NotAccessible,
-            NotAccessibleWithCurrentMilestones,
-            Special,
-            Normal,
-            Useful
-        }
+    private enum EntryStatus {
+        NotAccessible,
+        NotAccessibleWithCurrentMilestones,
+        Special,
+        Normal,
+        Useful
+    }
 
-        private readonly struct RecipeEntry {
-            public readonly Recipe recipe;
-            public readonly float recipeFlow;
-            public readonly float flow;
-            public readonly float specificEfficiency;
-            public readonly EntryStatus entryStatus;
+    private readonly struct RecipeEntry {
+        public readonly Recipe recipe;
+        public readonly float recipeFlow;
+        public readonly float flow;
+        public readonly float specificEfficiency;
+        public readonly EntryStatus entryStatus;
 
-            public RecipeEntry(Recipe recipe, bool isProduction, Goods currentItem, bool atCurrentMilestones) {
-                this.recipe = recipe;
-                float amount = isProduction ? recipe.GetProductionPerRecipe(currentItem) : recipe.GetConsumptionPerRecipe(currentItem);
-                recipeFlow = recipe.ApproximateFlow(atCurrentMilestones);
-                flow = recipeFlow * amount;
-                specificEfficiency = isProduction ? recipe.Cost() / amount : 0f;
-                if (!recipe.IsAccessible()) {
-                    entryStatus = EntryStatus.NotAccessible;
+        public RecipeEntry(Recipe recipe, bool isProduction, Goods currentItem, bool atCurrentMilestones) {
+            this.recipe = recipe;
+            float amount = isProduction ? recipe.GetProductionPerRecipe(currentItem) : recipe.GetConsumptionPerRecipe(currentItem);
+            recipeFlow = recipe.ApproximateFlow(atCurrentMilestones);
+            flow = recipeFlow * amount;
+            specificEfficiency = isProduction ? recipe.Cost() / amount : 0f;
+            if (!recipe.IsAccessible()) {
+                entryStatus = EntryStatus.NotAccessible;
+            }
+            else if (!recipe.IsAccessibleWithCurrentMilestones()) {
+                entryStatus = EntryStatus.NotAccessibleWithCurrentMilestones;
+            }
+            else {
+                float waste = recipe.RecipeWaste(atCurrentMilestones);
+                if (recipe.specialType != FactorioObjectSpecialType.Normal && recipeFlow <= 0.01f) {
+                    entryStatus = EntryStatus.Special;
                 }
-                else if (!recipe.IsAccessibleWithCurrentMilestones()) {
-                    entryStatus = EntryStatus.NotAccessibleWithCurrentMilestones;
+                else if (waste > 0f) {
+                    entryStatus = EntryStatus.Normal;
                 }
                 else {
-                    float waste = recipe.RecipeWaste(atCurrentMilestones);
-                    if (recipe.specialType != FactorioObjectSpecialType.Normal && recipeFlow <= 0.01f) {
-                        entryStatus = EntryStatus.Special;
-                    }
-                    else if (waste > 0f) {
-                        entryStatus = EntryStatus.Normal;
-                    }
-                    else {
-                        entryStatus = EntryStatus.Useful;
-                    }
+                    entryStatus = EntryStatus.Useful;
                 }
             }
         }
+    }
 
-        private RecipeEntry[] productions = [];
-        private RecipeEntry[] usages = [];
+    private RecipeEntry[] productions = [];
+    private RecipeEntry[] usages = [];
 
-        private NeverEnoughItemsPanel() : base(76f) {
-            productionList = new ScrollArea(40f, BuildItemProduction, new Padding(0.5f));
-            usageList = new ScrollArea(40f, BuildItemUsages, new Padding(0.5f));
+    private NeverEnoughItemsPanel() : base(76f) {
+        productionList = new ScrollArea(40f, BuildItemProduction, new Padding(0.5f));
+        usageList = new ScrollArea(40f, BuildItemUsages, new Padding(0.5f));
+    }
+
+    /// <summary>
+    /// Call to make sure that any recent setting changes (e.g. object accessibility) are reflected in the NEIE display.
+    /// It is only necessary to call this from screens that could be displayed on top of the NEIE display.
+    /// </summary>
+    public static void Refresh() {
+        var item = Instance.current;
+        Instance.current = null!; // null-forgiving: We immediately reset this.
+        Instance.SetItem(item);
+    }
+
+    private void SetItem(Goods current) {
+        if (current == this.current) {
+            return;
         }
 
-        /// <summary>
-        /// Call to make sure that any recent setting changes (e.g. object accessibility) are reflected in the NEIE display.
-        /// It is only necessary to call this from screens that could be displayed on top of the NEIE display.
-        /// </summary>
-        public static void Refresh() {
-            var item = Instance.current;
-            Instance.current = null!; // null-forgiving: We immediately reset this.
-            Instance.SetItem(item);
+        _ = recent.Remove(current);
+        if (recent.Count > 18) {
+            recent.RemoveAt(0);
         }
 
-        private void SetItem(Goods current) {
-            if (current == this.current) {
-                return;
-            }
-
-            _ = recent.Remove(current);
-            if (recent.Count > 18) {
-                recent.RemoveAt(0);
-            }
-
-            if (this.current != null) {
-                recent.Add(this.current);
-            }
-
-            currentFlow = current.ApproximateFlow(atCurrentMilestones);
-            var refreshedProductions = new RecipeEntry[current.production.Length];
-            for (int i = 0; i < current.production.Length; i++) {
-                refreshedProductions[i] = new RecipeEntry(current.production[i], true, current, atCurrentMilestones);
-            }
-            Array.Sort(refreshedProductions, this);
-
-            var refreshedUsages = new RecipeEntry[current.usages.Length];
-            for (int i = 0; i < current.usages.Length; i++) {
-                refreshedUsages[i] = new RecipeEntry(current.usages[i], false, current, atCurrentMilestones);
-            }
-            Array.Sort(refreshedUsages, this);
-
-            this.current = current;
-            this.productions = refreshedProductions;
-            this.usages = refreshedUsages;
-
-            Rebuild();
-            productionList.Rebuild();
-            usageList.Rebuild();
+        if (this.current != null) {
+            recent.Add(this.current);
         }
 
-        private void DrawIngredients(ImGui gui, Recipe recipe) {
-            if (recipe.ingredients.Length > 8) {
-                DrawTooManyThings(gui, recipe.ingredients, 8);
-                return;
-            }
-            foreach (var ingredient in recipe.ingredients) {
-                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
-                    if (ingredient.variants != null) {
-                        gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton<Goods>(ingredient.variants, DataUtils.DefaultOrdering, SetItem, "Accepted fluid variants"));
-                    }
-                    else {
-                        changing = ingredient.goods;
-                    }
+        currentFlow = current.ApproximateFlow(atCurrentMilestones);
+        var refreshedProductions = new RecipeEntry[current.production.Length];
+        for (int i = 0; i < current.production.Length; i++) {
+            refreshedProductions[i] = new RecipeEntry(current.production[i], true, current, atCurrentMilestones);
+        }
+        Array.Sort(refreshedProductions, this);
+
+        var refreshedUsages = new RecipeEntry[current.usages.Length];
+        for (int i = 0; i < current.usages.Length; i++) {
+            refreshedUsages[i] = new RecipeEntry(current.usages[i], false, current, atCurrentMilestones);
+        }
+        Array.Sort(refreshedUsages, this);
+
+        this.current = current;
+        this.productions = refreshedProductions;
+        this.usages = refreshedUsages;
+
+        Rebuild();
+        productionList.Rebuild();
+        usageList.Rebuild();
+    }
+
+    private void DrawIngredients(ImGui gui, Recipe recipe) {
+        if (recipe.ingredients.Length > 8) {
+            DrawTooManyThings(gui, recipe.ingredients, 8);
+            return;
+        }
+        foreach (var ingredient in recipe.ingredients) {
+            if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
+                if (ingredient.variants != null) {
+                    gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton<Goods>(ingredient.variants, DataUtils.DefaultOrdering, SetItem, "Accepted fluid variants"));
+                }
+                else {
+                    changing = ingredient.goods;
                 }
             }
         }
+    }
 
-        private void DrawProducts(ImGui gui, Recipe recipe) {
-            if (recipe.products.Length > 7) {
-                DrawTooManyThings(gui, recipe.products, 7);
-                return;
-            }
-            for (int i = recipe.products.Length - 1; i >= 0; i--) {
-                var product = recipe.products[i];
-                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
-                    changing = product.goods;
-                }
+    private void DrawProducts(ImGui gui, Recipe recipe) {
+        if (recipe.products.Length > 7) {
+            DrawTooManyThings(gui, recipe.products, 7);
+            return;
+        }
+        for (int i = recipe.products.Length - 1; i >= 0; i--) {
+            var product = recipe.products[i];
+            if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
+                changing = product.goods;
             }
         }
+    }
 
-        private void DrawTooManyThings(ImGui gui, IEnumerable<IFactorioObjectWrapper> list, int maxElemCount) {
-            using var grid = gui.EnterInlineGrid(3f, 0f, maxElemCount);
-            foreach (var item in list) {
-                grid.Next();
-                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
-                    changing = item.target as Goods;
-                }
+    private void DrawTooManyThings(ImGui gui, IEnumerable<IFactorioObjectWrapper> list, int maxElemCount) {
+        using var grid = gui.EnterInlineGrid(3f, 0f, maxElemCount);
+        foreach (var item in list) {
+            grid.Next();
+            if (gui.BuildFactorioObjectWithAmount(item.target, item.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
+                changing = item.target as Goods;
             }
         }
+    }
 
-        private void CheckChanging() {
-            if (changing != null) {
-                SetItem(changing);
-                changing = null;
+    private void CheckChanging() {
+        if (changing != null) {
+            SetItem(changing);
+            changing = null;
+        }
+    }
+
+    private void DrawRecipeEntry(ImGui gui, RecipeEntry entry, bool production) {
+        var textColor = SchemeColor.BackgroundText;
+        var bgColor = SchemeColor.Background;
+        bool isBuilding = gui.isBuilding;
+        var recipe = entry.recipe;
+        float waste = recipe.RecipeWaste(atCurrentMilestones);
+        if (isBuilding) {
+            if (entry.entryStatus == EntryStatus.NotAccessible) {
+                bgColor = SchemeColor.None;
+                textColor = SchemeColor.BackgroundTextFaint;
+            }
+            else if (entry.flow > 0f) {
+                bgColor = SchemeColor.Secondary;
+                textColor = SchemeColor.SecondaryText;
             }
         }
-
-        private void DrawRecipeEntry(ImGui gui, RecipeEntry entry, bool production) {
-            var textColor = SchemeColor.BackgroundText;
-            var bgColor = SchemeColor.Background;
-            bool isBuilding = gui.isBuilding;
-            var recipe = entry.recipe;
-            float waste = recipe.RecipeWaste(atCurrentMilestones);
-            if (isBuilding) {
-                if (entry.entryStatus == EntryStatus.NotAccessible) {
-                    bgColor = SchemeColor.None;
-                    textColor = SchemeColor.BackgroundTextFaint;
+        using (gui.EnterGroup(new Padding(0.5f), production ? RectAllocator.LeftRow : RectAllocator.RightRow, textColor)) {
+            using (gui.EnterFixedPositioning(4f, 0f, default)) {
+                gui.allocator = RectAllocator.Stretch;
+                _ = gui.BuildFactorioObjectButton(entry.recipe, ButtonDisplayStyle.NeieLarge);
+                using (gui.EnterRow()) {
+                    gui.BuildIcon(Icon.Time);
+                    gui.BuildText(DataUtils.FormatAmount(entry.recipe.time, UnitOfMeasure.Second), TextBlockDisplayStyle.Centered);
                 }
-                else if (entry.flow > 0f) {
-                    bgColor = SchemeColor.Secondary;
-                    textColor = SchemeColor.SecondaryText;
+                float bh = CostAnalysis.GetBuildingHours(recipe, entry.recipeFlow);
+                if (bh > 20) {
+                    gui.BuildText(DataUtils.FormatAmount(bh, UnitOfMeasure.None, suffix: "bh"), TextBlockDisplayStyle.Centered);
+                    _ = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, "Building-hours.\nAmount of building-hours required for all researches assuming crafting speed of 1");
                 }
             }
-            using (gui.EnterGroup(new Padding(0.5f), production ? RectAllocator.LeftRow : RectAllocator.RightRow, textColor)) {
-                using (gui.EnterFixedPositioning(4f, 0f, default)) {
-                    gui.allocator = RectAllocator.Stretch;
-                    _ = gui.BuildFactorioObjectButton(entry.recipe, ButtonDisplayStyle.NeieLarge);
-                    using (gui.EnterRow()) {
-                        gui.BuildIcon(Icon.Time);
-                        gui.BuildText(DataUtils.FormatAmount(entry.recipe.time, UnitOfMeasure.Second), TextBlockDisplayStyle.Centered);
-                    }
-                    float bh = CostAnalysis.GetBuildingHours(recipe, entry.recipeFlow);
-                    if (bh > 20) {
-                        gui.BuildText(DataUtils.FormatAmount(bh, UnitOfMeasure.None, suffix: "bh"), TextBlockDisplayStyle.Centered);
-                        _ = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, "Building-hours.\nAmount of building-hours required for all researches assuming crafting speed of 1");
-                    }
+            gui.AllocateSpacing();
+            var textAlloc = production ? RectAllocator.LeftAlign : RectAllocator.RightAlign;
+            gui.allocator = textAlloc;
+            using (gui.EnterRow(0f, production ? RectAllocator.RightRow : RectAllocator.LeftRow)) {
+                bool favorite = Project.current.preferences.favorites.Contains(entry.recipe);
+                var iconRect = gui.AllocateRect(1f, 1f).Expand(0.25f);
+                gui.DrawIcon(iconRect, favorite ? Icon.StarFull : Icon.StarEmpty, SchemeColor.BackgroundText);
+                if (gui.BuildButton(iconRect, SchemeColor.None, SchemeColor.BackgroundAlt)) {
+                    Project.current.preferences.ToggleFavorite(entry.recipe);
                 }
-                gui.AllocateSpacing();
-                var textAlloc = production ? RectAllocator.LeftAlign : RectAllocator.RightAlign;
+
                 gui.allocator = textAlloc;
-                using (gui.EnterRow(0f, production ? RectAllocator.RightRow : RectAllocator.LeftRow)) {
-                    bool favorite = Project.current.preferences.favorites.Contains(entry.recipe);
-                    var iconRect = gui.AllocateRect(1f, 1f).Expand(0.25f);
-                    gui.DrawIcon(iconRect, favorite ? Icon.StarFull : Icon.StarEmpty, SchemeColor.BackgroundText);
-                    if (gui.BuildButton(iconRect, SchemeColor.None, SchemeColor.BackgroundAlt)) {
-                        Project.current.preferences.ToggleFavorite(entry.recipe);
+                gui.BuildText(recipe.locName, TextBlockDisplayStyle.WrappedText);
+            }
+            if (recipe.ingredients.Length + recipe.products.Length <= 8) {
+                using (gui.EnterRow()) {
+                    DrawIngredients(gui, entry.recipe);
+                    gui.allocator = RectAllocator.RightRow;
+                    DrawProducts(gui, entry.recipe);
+                    if (recipe.products.Length < 3 && recipe.ingredients.Length < 5) {
+                        gui.AllocateSpacing((3 - entry.recipe.products.Length) * 3f);
+                    }
+                    else if (recipe.products.Length < 3) {
+                        gui.allocator = RectAllocator.RemainingRow;
                     }
 
-                    gui.allocator = textAlloc;
-                    gui.BuildText(recipe.locName, TextBlockDisplayStyle.WrappedText);
-                }
-                if (recipe.ingredients.Length + recipe.products.Length <= 8) {
-                    using (gui.EnterRow()) {
-                        DrawIngredients(gui, entry.recipe);
-                        gui.allocator = RectAllocator.RightRow;
-                        DrawProducts(gui, entry.recipe);
-                        if (recipe.products.Length < 3 && recipe.ingredients.Length < 5) {
-                            gui.AllocateSpacing((3 - entry.recipe.products.Length) * 3f);
-                        }
-                        else if (recipe.products.Length < 3) {
-                            gui.allocator = RectAllocator.RemainingRow;
-                        }
-
-                        gui.BuildIcon(Icon.ArrowRight, 3f);
-                    }
-                }
-                else {
-                    using (gui.EnterRow()) {
-                        DrawIngredients(gui, entry.recipe);
-                    }
-
-                    using (gui.EnterRow()) {
-                        gui.BuildIcon(Icon.ArrowDownRight, 3f);
-                        gui.allocator = RectAllocator.RightRow;
-                        DrawProducts(gui, entry.recipe);
-                    }
+                    gui.BuildIcon(Icon.ArrowRight, 3f);
                 }
             }
+            else {
+                using (gui.EnterRow()) {
+                    DrawIngredients(gui, entry.recipe);
+                }
 
-            if (isBuilding) {
-                var rect = gui.lastRect;
-                if (entry.flow > 0f) {
-                    float percentFlow = MathUtils.Clamp(entry.flow / currentFlow, 0f, 1f);
-                    rect.Width *= percentFlow;
-                    gui.DrawRectangle(rect, SchemeColor.Primary);
-                }
-                else if (waste <= 0f) {
-                    bgColor = SchemeColor.Secondary;
-                }
-                else {
-                    rect.Width *= (1f - waste);
-                    gui.DrawRectangle(rect, SchemeColor.Secondary);
-                }
-                gui.DrawRectangle(gui.lastRect, bgColor);
-            }
-        }
-
-        private void DrawEntryFooter(ImGui gui, bool production) {
-            if (!production && current.fuelFor.Length > 0) {
-                using (gui.EnterGroup(new Padding(0.5f), RectAllocator.LeftAlign)) {
-                    gui.BuildText(current.fuelValue > 0f ? "Fuel value " + DataUtils.FormatAmount(current.fuelValue, UnitOfMeasure.Megajoule) + " can be used for:" : "Can be used to fuel:");
-                    using var grid = gui.EnterInlineGrid(3f);
-                    foreach (var fuelUsage in current.fuelFor) {
-                        grid.Next();
-                        _ = gui.BuildFactorioObjectButton(fuelUsage, ButtonDisplayStyle.NeieSmall);
-                    }
-                }
-                if (gui.isBuilding) {
-                    gui.DrawRectangle(gui.lastRect, SchemeColor.Primary);
+                using (gui.EnterRow()) {
+                    gui.BuildIcon(Icon.ArrowDownRight, 3f);
+                    gui.allocator = RectAllocator.RightRow;
+                    DrawProducts(gui, entry.recipe);
                 }
             }
         }
 
-        private void ChangeShowStatus(EntryStatus status) {
-            showRecipesRange = status;
-            Rebuild();
-            productionList.Rebuild();
-            usageList.Rebuild();
+        if (isBuilding) {
+            var rect = gui.lastRect;
+            if (entry.flow > 0f) {
+                float percentFlow = MathUtils.Clamp(entry.flow / currentFlow, 0f, 1f);
+                rect.Width *= percentFlow;
+                gui.DrawRectangle(rect, SchemeColor.Primary);
+            }
+            else if (waste <= 0f) {
+                bgColor = SchemeColor.Secondary;
+            }
+            else {
+                rect.Width *= (1f - waste);
+                gui.DrawRectangle(rect, SchemeColor.Secondary);
+            }
+            gui.DrawRectangle(gui.lastRect, bgColor);
         }
+    }
 
-        private void DrawEntryList(ImGui gui, ReadOnlySpan<RecipeEntry> entries, bool production) {
-            bool footerDrawn = false;
-            var prevEntryStatus = EntryStatus.Normal;
-            FactorioObject? prevLatestMilestone = null;
-            foreach (var entry in entries) {
-                var status = entry.entryStatus;
-
-                if (status < showRecipesRange) {
-                    DrawEntryFooter(gui, production);
-                    footerDrawn = true;
-                    gui.BuildText(entry.entryStatus == EntryStatus.Special ? "Show special recipes (barreling / voiding)" :
-                        entry.entryStatus == EntryStatus.NotAccessibleWithCurrentMilestones ? "There are more recipes, but they are locked based on current milestones" :
-                        "There are more recipes but they are inaccessible", TextBlockDisplayStyle.WrappedText);
-                    if (gui.BuildButton("Show more recipes")) {
-                        ChangeShowStatus(status);
-                    }
-
-                    break;
-                }
-
-                if (status < prevEntryStatus) {
-                    prevEntryStatus = status;
-                    using (gui.EnterRow()) {
-                        gui.BuildText(status == EntryStatus.Special ? "Special recipes:" : status == EntryStatus.NotAccessibleWithCurrentMilestones ? "Locked recipes:" : "Inaccessible recipes:");
-                        if (gui.BuildLink("hide")) {
-                            ChangeShowStatus(status + 1);
-                        }
-                    }
-                }
-
-                if (status == EntryStatus.NotAccessibleWithCurrentMilestones) {
-                    var latest = Milestones.Instance.GetHighest(entry.recipe, false);
-                    if (latest != prevLatestMilestone) {
-                        _ = gui.BuildFactorioObjectButtonWithText(latest, iconDisplayStyle: new(3, MilestoneDisplay.None, false));
-                        prevLatestMilestone = latest;
-                    }
-                }
-
-                if (gui.ShouldBuildGroup(entry.recipe, out var group)) {
-                    DrawRecipeEntry(gui, entry, production);
-                    group.Complete();
+    private void DrawEntryFooter(ImGui gui, bool production) {
+        if (!production && current.fuelFor.Length > 0) {
+            using (gui.EnterGroup(new Padding(0.5f), RectAllocator.LeftAlign)) {
+                gui.BuildText(current.fuelValue > 0f ? "Fuel value " + DataUtils.FormatAmount(current.fuelValue, UnitOfMeasure.Megajoule) + " can be used for:" : "Can be used to fuel:");
+                using var grid = gui.EnterInlineGrid(3f);
+                foreach (var fuelUsage in current.fuelFor) {
+                    grid.Next();
+                    _ = gui.BuildFactorioObjectButton(fuelUsage, ButtonDisplayStyle.NeieSmall);
                 }
             }
-            if (!footerDrawn) {
+            if (gui.isBuilding) {
+                gui.DrawRectangle(gui.lastRect, SchemeColor.Primary);
+            }
+        }
+    }
+
+    private void ChangeShowStatus(EntryStatus status) {
+        showRecipesRange = status;
+        Rebuild();
+        productionList.Rebuild();
+        usageList.Rebuild();
+    }
+
+    private void DrawEntryList(ImGui gui, ReadOnlySpan<RecipeEntry> entries, bool production) {
+        bool footerDrawn = false;
+        var prevEntryStatus = EntryStatus.Normal;
+        FactorioObject? prevLatestMilestone = null;
+        foreach (var entry in entries) {
+            var status = entry.entryStatus;
+
+            if (status < showRecipesRange) {
                 DrawEntryFooter(gui, production);
-            }
-
-            CheckChanging();
-        }
-
-        private void BuildItemProduction(ImGui gui) => DrawEntryList(gui, productions, true);
-
-        private void BuildItemUsages(ImGui gui) => DrawEntryList(gui, usages, false);
-
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Never Enough Items Explorer");
-            using (gui.EnterRow()) {
-                if (recent.Count == 0) {
-                    _ = gui.AllocateRect(0f, 3f);
+                footerDrawn = true;
+                gui.BuildText(entry.entryStatus == EntryStatus.Special ? "Show special recipes (barreling / voiding)" :
+                    entry.entryStatus == EntryStatus.NotAccessibleWithCurrentMilestones ? "There are more recipes, but they are locked based on current milestones" :
+                    "There are more recipes but they are inaccessible", TextBlockDisplayStyle.WrappedText);
+                if (gui.BuildButton("Show more recipes")) {
+                    ChangeShowStatus(status);
                 }
 
-                for (int i = recent.Count - 1; i >= 0; i--) {
-                    var elem = recent[i];
-                    if (gui.BuildFactorioObjectButton(elem, ButtonDisplayStyle.NeieSmall) == Click.Left) {
-                        changing = elem;
+                break;
+            }
+
+            if (status < prevEntryStatus) {
+                prevEntryStatus = status;
+                using (gui.EnterRow()) {
+                    gui.BuildText(status == EntryStatus.Special ? "Special recipes:" : status == EntryStatus.NotAccessibleWithCurrentMilestones ? "Locked recipes:" : "Inaccessible recipes:");
+                    if (gui.BuildLink("hide")) {
+                        ChangeShowStatus(status + 1);
                     }
                 }
             }
-            using (gui.EnterGroup(new Padding(0.5f), RectAllocator.LeftRow)) {
-                gui.spacing = 0.2f;
-                gui.BuildFactorioObjectIcon(current, ButtonDisplayStyle.NeieSmall);
-                gui.BuildText(current.locName, Font.subheader);
-                gui.allocator = RectAllocator.RightAlign;
-                gui.BuildText(CostAnalysis.GetDisplayCost(current));
-                string? amount = CostAnalysis.Instance.GetItemAmount(current);
-                if (amount != null) {
-                    gui.BuildText(amount, TextBlockDisplayStyle.WrappedText);
+
+            if (status == EntryStatus.NotAccessibleWithCurrentMilestones) {
+                var latest = Milestones.Instance.GetHighest(entry.recipe, false);
+                if (latest != prevLatestMilestone) {
+                    _ = gui.BuildFactorioObjectButtonWithText(latest, iconDisplayStyle: new(3, MilestoneDisplay.None, false));
+                    prevLatestMilestone = latest;
                 }
             }
 
-            if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, current, SchemeColor.Grey) == Click.Left) {
-                SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
+            if (gui.ShouldBuildGroup(entry.recipe, out var group)) {
+                DrawRecipeEntry(gui, entry, production);
+                group.Complete();
+            }
+        }
+        if (!footerDrawn) {
+            DrawEntryFooter(gui, production);
+        }
+
+        CheckChanging();
+    }
+
+    private void BuildItemProduction(ImGui gui) => DrawEntryList(gui, productions, true);
+
+    private void BuildItemUsages(ImGui gui) => DrawEntryList(gui, usages, false);
+
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Never Enough Items Explorer");
+        using (gui.EnterRow()) {
+            if (recent.Count == 0) {
+                _ = gui.AllocateRect(0f, 3f);
             }
 
-            using (var split = gui.EnterHorizontalSplit(2)) {
-                split.Next();
-                gui.BuildText("Production:", Font.subheader);
-                productionList.Build(gui);
-                split.Next();
-                gui.BuildText("Usages:", Font.subheader);
-                usageList.Build(gui);
-            }
-            CheckChanging();
-            using (gui.EnterRow()) {
-                if (gui.BuildLink("What do colored bars mean?")) {
-                    MessageBox.Show("How to read colored bars",
-                        "Blue bar means estimated production or consumption of the thing you selected. Blue bar at 50% means that that recipe produces(consumes) 50% of the product.\n\n" +
-                        "Orange bar means estimated recipe efficiency. If it is not full, the recipe looks inefficient to YAFC.\n\n" +
-                        "It is possible for a recipe to be efficient but not useful - for example a recipe that produces something that is not useful.\n\n" +
-                        "YAFC only estimates things that are required for science recipes. So buildings, belts, weapons, fuel - are not shown in estimations.", "Ok");
-                }
-                if (gui.BuildCheckBox("Current milestones info", atCurrentMilestones, out atCurrentMilestones, allocator: RectAllocator.RightRow)) {
-                    Refresh();
+            for (int i = recent.Count - 1; i >= 0; i--) {
+                var elem = recent[i];
+                if (gui.BuildFactorioObjectButton(elem, ButtonDisplayStyle.NeieSmall) == Click.Left) {
+                    changing = elem;
                 }
             }
         }
-
-        public static void Show(Goods goods) {
-            // This call handles any updates required by milestone changes. The milestones window can't
-            // easily handle that since the setting updates happen after the milestones screens are closed.
-            Refresh();
-
-            if (Instance.opened) {
-                Instance.changing = goods;
-                return;
+        using (gui.EnterGroup(new Padding(0.5f), RectAllocator.LeftRow)) {
+            gui.spacing = 0.2f;
+            gui.BuildFactorioObjectIcon(current, ButtonDisplayStyle.NeieSmall);
+            gui.BuildText(current.locName, Font.subheader);
+            gui.allocator = RectAllocator.RightAlign;
+            gui.BuildText(CostAnalysis.GetDisplayCost(current));
+            string? amount = CostAnalysis.Instance.GetItemAmount(current);
+            if (amount != null) {
+                gui.BuildText(amount, TextBlockDisplayStyle.WrappedText);
             }
-            Instance.SetItem(goods);
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
         }
-        int IComparer<RecipeEntry>.Compare(RecipeEntry x, RecipeEntry y) {
-            if (x.entryStatus != y.entryStatus) {
-                return y.entryStatus - x.entryStatus;
-            }
 
-            if (x.entryStatus == EntryStatus.NotAccessibleWithCurrentMilestones) {
-                var xMilestone = DataUtils.GetMilestoneOrder(x.recipe.id);
-                var yMilestone = DataUtils.GetMilestoneOrder(y.recipe.id);
-                if (xMilestone != yMilestone) {
-                    return xMilestone.CompareTo(yMilestone);
-                }
-            }
-            if (x.flow != y.flow) {
-                return y.flow.CompareTo(x.flow);
-            }
-
-            return x.recipe.RecipeWaste(atCurrentMilestones).CompareTo(y.recipe.RecipeWaste(atCurrentMilestones));
+        if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, current, SchemeColor.Grey) == Click.Left) {
+            SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
         }
+
+        using (var split = gui.EnterHorizontalSplit(2)) {
+            split.Next();
+            gui.BuildText("Production:", Font.subheader);
+            productionList.Build(gui);
+            split.Next();
+            gui.BuildText("Usages:", Font.subheader);
+            usageList.Build(gui);
+        }
+        CheckChanging();
+        using (gui.EnterRow()) {
+            if (gui.BuildLink("What do colored bars mean?")) {
+                MessageBox.Show("How to read colored bars",
+                    "Blue bar means estimated production or consumption of the thing you selected. Blue bar at 50% means that that recipe produces(consumes) 50% of the product.\n\n" +
+                    "Orange bar means estimated recipe efficiency. If it is not full, the recipe looks inefficient to YAFC.\n\n" +
+                    "It is possible for a recipe to be efficient but not useful - for example a recipe that produces something that is not useful.\n\n" +
+                    "YAFC only estimates things that are required for science recipes. So buildings, belts, weapons, fuel - are not shown in estimations.", "Ok");
+            }
+            if (gui.BuildCheckBox("Current milestones info", atCurrentMilestones, out atCurrentMilestones, allocator: RectAllocator.RightRow)) {
+                Refresh();
+            }
+        }
+    }
+
+    public static void Show(Goods goods) {
+        // This call handles any updates required by milestone changes. The milestones window can't
+        // easily handle that since the setting updates happen after the milestones screens are closed.
+        Refresh();
+
+        if (Instance.opened) {
+            Instance.changing = goods;
+            return;
+        }
+        Instance.SetItem(goods);
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
+    int IComparer<RecipeEntry>.Compare(RecipeEntry x, RecipeEntry y) {
+        if (x.entryStatus != y.entryStatus) {
+            return y.entryStatus - x.entryStatus;
+        }
+
+        if (x.entryStatus == EntryStatus.NotAccessibleWithCurrentMilestones) {
+            var xMilestone = DataUtils.GetMilestoneOrder(x.recipe.id);
+            var yMilestone = DataUtils.GetMilestoneOrder(y.recipe.id);
+            if (xMilestone != yMilestone) {
+                return xMilestone.CompareTo(yMilestone);
+            }
+        }
+        if (x.flow != y.flow) {
+            return y.flow.CompareTo(x.flow);
+        }
+
+        return x.recipe.RecipeWaste(atCurrentMilestones).CompareTo(y.recipe.RecipeWaste(atCurrentMilestones));
     }
 }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -2,173 +2,172 @@
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class PreferencesScreen : PseudoScreen {
-        private static readonly PreferencesScreen Instance = new PreferencesScreen();
+namespace Yafc;
+public class PreferencesScreen : PseudoScreen {
+    private static readonly PreferencesScreen Instance = new PreferencesScreen();
 
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Preferences");
-            gui.BuildText("Unit of time:", Font.subheader);
-            var prefs = Project.current.preferences;
-            var settings = Project.current.settings;
-            using (gui.EnterRow()) {
-                if (gui.BuildRadioButton("Second", prefs.time == 1)) {
-                    prefs.RecordUndo(true).time = 1;
-                }
-
-                if (gui.BuildRadioButton("Minute", prefs.time == 60)) {
-                    prefs.RecordUndo(true).time = 60;
-                }
-
-                if (gui.BuildRadioButton("Hour", prefs.time == 3600)) {
-                    prefs.RecordUndo(true).time = 3600;
-                }
-
-                if (gui.BuildRadioButton("Custom", prefs.time is not 1 and not 60 and not 3600)) {
-                    prefs.RecordUndo(true).time = 0;
-                }
-
-                if (gui.BuildIntegerInput(prefs.time, out int newTime)) {
-                    prefs.RecordUndo(true).time = newTime;
-                }
-            }
-            gui.AllocateSpacing(1f);
-            gui.BuildText("Item production/consumption:", Font.subheader);
-            BuildUnitPerTime(gui, false, prefs);
-            gui.BuildText("Fluid production/consumption:", Font.subheader);
-            BuildUnitPerTime(gui, true, prefs);
-
-            using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
-                gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
-                DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
-                    settings.RecordUndo().PollutionCostModifier = amount.Value;
-                    gui.Rebuild();
-                }
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Preferences");
+        gui.BuildText("Unit of time:", Font.subheader);
+        var prefs = Project.current.preferences;
+        var settings = Project.current.settings;
+        using (gui.EnterRow()) {
+            if (gui.BuildRadioButton("Second", prefs.time == 1)) {
+                prefs.RecordUndo(true).time = 1;
             }
 
-            using (gui.EnterRowWithHelpIcon("Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.")) {
-                gui.BuildText("Display scale for linkable icons", topOffset: 0.5f);
-                DisplayAmount amount = new(prefs.iconScale, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value > 0 && amount.Value <= 1) {
-                    prefs.RecordUndo().iconScale = amount.Value;
-                    gui.Rebuild();
-                }
+            if (gui.BuildRadioButton("Minute", prefs.time == 60)) {
+                prefs.RecordUndo(true).time = 60;
             }
 
-            ChooseObject(gui, "Default belt:", Database.allBelts, prefs.defaultBelt, s => {
-                prefs.RecordUndo().defaultBelt = s;
+            if (gui.BuildRadioButton("Hour", prefs.time == 3600)) {
+                prefs.RecordUndo(true).time = 3600;
+            }
+
+            if (gui.BuildRadioButton("Custom", prefs.time is not 1 and not 60 and not 3600)) {
+                prefs.RecordUndo(true).time = 0;
+            }
+
+            if (gui.BuildIntegerInput(prefs.time, out int newTime)) {
+                prefs.RecordUndo(true).time = newTime;
+            }
+        }
+        gui.AllocateSpacing(1f);
+        gui.BuildText("Item production/consumption:", Font.subheader);
+        BuildUnitPerTime(gui, false, prefs);
+        gui.BuildText("Fluid production/consumption:", Font.subheader);
+        BuildUnitPerTime(gui, true, prefs);
+
+        using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
+            gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
+            DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
+                settings.RecordUndo().PollutionCostModifier = amount.Value;
                 gui.Rebuild();
-            });
-            ChooseObject(gui, "Default inserter:", Database.allInserters, prefs.defaultInserter, s => {
-                prefs.RecordUndo().defaultInserter = s;
+            }
+        }
+
+        using (gui.EnterRowWithHelpIcon("Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.")) {
+            gui.BuildText("Display scale for linkable icons", topOffset: 0.5f);
+            DisplayAmount amount = new(prefs.iconScale, UnitOfMeasure.Percent);
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value > 0 && amount.Value <= 1) {
+                prefs.RecordUndo().iconScale = amount.Value;
                 gui.Rebuild();
-            });
-
-            using (gui.EnterRow()) {
-                gui.BuildText("Inserter capacity:", topOffset: 0.5f);
-                if (gui.BuildIntegerInput(prefs.inserterCapacity, out int newCapacity)) {
-                    prefs.RecordUndo().inserterCapacity = newCapacity;
-                }
-            }
-
-            using (gui.EnterRow()) {
-                gui.BuildText("Reactor layout:", topOffset: 0.5f);
-                if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
-                    int px = newSize.IndexOf("x", StringComparison.Ordinal);
-                    if (px < 0 && int.TryParse(newSize, out int value)) {
-                        settings.RecordUndo().reactorSizeX = value;
-                        settings.reactorSizeY = value;
-                    }
-                    else if (int.TryParse(newSize[..px], out int sizeX) && int.TryParse(newSize[(px + 1)..], out int sizeY)) {
-                        settings.RecordUndo().reactorSizeX = sizeX;
-                        settings.reactorSizeY = sizeY;
-                    }
-                }
-            }
-            ChooseObjectWithNone(gui, "Target technology for cost analysis: ", Database.technologies.all, prefs.targetTechnology, x => {
-                prefs.RecordUndo().targetTechnology = x;
-                gui.Rebuild();
-            }, width: 25f);
-
-            if (gui.BuildButton("Done")) {
-                Close();
-            }
-
-            if (prefs.justChanged) {
-                MainScreen.Instance.RebuildProjectView();
-            }
-
-            if (settings.justChanged) {
-                Project.current.RecalculateDisplayPages();
             }
         }
 
-        protected override void ReturnPressed() => Close();
+        ChooseObject(gui, "Default belt:", Database.allBelts, prefs.defaultBelt, s => {
+            prefs.RecordUndo().defaultBelt = s;
+            gui.Rebuild();
+        });
+        ChooseObject(gui, "Default inserter:", Database.allInserters, prefs.defaultInserter, s => {
+            prefs.RecordUndo().defaultInserter = s;
+            gui.Rebuild();
+        });
 
-        /// <summary>Add a GUI element that opens a popup to allow the user to choose from the <paramref name="list"/>, which triggers <paramref name="selectItem"/>.</summary>
-        /// <param name="text">Label to show.</param>
-        /// <param name="width">Width of the popup. Make sure it is wide enough to fit text!</param>
-        private static void ChooseObject<T>(ImGui gui, string text, T[] list, T? current, Action<T> selectItem, float width = 20f) where T : FactorioObject {
-            using (gui.EnterRow()) {
-                gui.BuildText(text, topOffset: 0.5f);
-                if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
-                    gui.BuildObjectSelectDropDown(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
-                }
+        using (gui.EnterRow()) {
+            gui.BuildText("Inserter capacity:", topOffset: 0.5f);
+            if (gui.BuildIntegerInput(prefs.inserterCapacity, out int newCapacity)) {
+                prefs.RecordUndo().inserterCapacity = newCapacity;
             }
         }
 
-        /// <summary>Add a GUI element that opens a popup to allow the user to choose from the <paramref name="list"/>, which triggers <paramref name="selectItem"/>.
-        /// An additional "clear" or "none" option will also be displayed.</summary>
-        /// <param name="text">Label to show.</param>
-        /// <param name="width">Width of the popup. Make sure it is wide enough to fit text!</param>
-        private static void ChooseObjectWithNone<T>(ImGui gui, string text, T[] list, T? current, Action<T?> selectItem, float width = 20f) where T : FactorioObject {
-            using (gui.EnterRow()) {
-                gui.BuildText(text, topOffset: 0.5f);
-                if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
-                    gui.BuildObjectSelectDropDownWithNone(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
+        using (gui.EnterRow()) {
+            gui.BuildText("Reactor layout:", topOffset: 0.5f);
+            if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
+                int px = newSize.IndexOf("x", StringComparison.Ordinal);
+                if (px < 0 && int.TryParse(newSize, out int value)) {
+                    settings.RecordUndo().reactorSizeX = value;
+                    settings.reactorSizeY = value;
+                }
+                else if (int.TryParse(newSize[..px], out int sizeX) && int.TryParse(newSize[(px + 1)..], out int sizeY)) {
+                    settings.RecordUndo().reactorSizeX = sizeX;
+                    settings.reactorSizeY = sizeY;
                 }
             }
         }
+        ChooseObjectWithNone(gui, "Target technology for cost analysis: ", Database.technologies.all, prefs.targetTechnology, x => {
+            prefs.RecordUndo().targetTechnology = x;
+            gui.Rebuild();
+        }, width: 25f);
 
-        private void BuildUnitPerTime(ImGui gui, bool fluid, ProjectPreferences preferences) {
-            DisplayAmount unit = fluid ? preferences.fluidUnit : preferences.itemUnit;
-            if (gui.BuildRadioButton("Simple Amount" + preferences.GetPerTimeUnit().suffix, unit == 0f)) {
-                unit = 0f;
-            }
-
-            using (gui.EnterRow()) {
-                if (gui.BuildRadioButton("Custom: 1 unit equals", unit != 0f)) {
-                    unit = 1f;
-                }
-
-                gui.AllocateSpacing();
-                gui.allocator = RectAllocator.RightRow;
-                if (!fluid) {
-                    if (gui.BuildButton("Set from belt")) {
-                        gui.BuildObjectSelectDropDown<EntityBelt>(Database.allBelts, DataUtils.DefaultOrdering, setBelt => {
-                            _ = preferences.RecordUndo(true);
-                            preferences.itemUnit = setBelt.beltItemsPerSecond;
-                        }, "Select belt", extra: b => DataUtils.FormatAmount(b.beltItemsPerSecond, UnitOfMeasure.PerSecond));
-                    }
-                }
-                gui.BuildText("per second");
-                _ = gui.BuildFloatInput(unit, TextBoxDisplayStyle.DefaultTextInput);
-            }
-            gui.AllocateSpacing(1f);
-
-            if (fluid) {
-                if (preferences.fluidUnit != unit.Value) {
-                    preferences.RecordUndo(true).fluidUnit = unit.Value;
-                }
-            }
-            else {
-                if (preferences.itemUnit != unit.Value) {
-                    preferences.RecordUndo(true).itemUnit = unit.Value;
-                }
-            }
+        if (gui.BuildButton("Done")) {
+            Close();
         }
 
-        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        if (prefs.justChanged) {
+            MainScreen.Instance.RebuildProjectView();
+        }
+
+        if (settings.justChanged) {
+            Project.current.RecalculateDisplayPages();
+        }
     }
+
+    protected override void ReturnPressed() => Close();
+
+    /// <summary>Add a GUI element that opens a popup to allow the user to choose from the <paramref name="list"/>, which triggers <paramref name="selectItem"/>.</summary>
+    /// <param name="text">Label to show.</param>
+    /// <param name="width">Width of the popup. Make sure it is wide enough to fit text!</param>
+    private static void ChooseObject<T>(ImGui gui, string text, T[] list, T? current, Action<T> selectItem, float width = 20f) where T : FactorioObject {
+        using (gui.EnterRow()) {
+            gui.BuildText(text, topOffset: 0.5f);
+            if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
+                gui.BuildObjectSelectDropDown(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
+            }
+        }
+    }
+
+    /// <summary>Add a GUI element that opens a popup to allow the user to choose from the <paramref name="list"/>, which triggers <paramref name="selectItem"/>.
+    /// An additional "clear" or "none" option will also be displayed.</summary>
+    /// <param name="text">Label to show.</param>
+    /// <param name="width">Width of the popup. Make sure it is wide enough to fit text!</param>
+    private static void ChooseObjectWithNone<T>(ImGui gui, string text, T[] list, T? current, Action<T?> selectItem, float width = 20f) where T : FactorioObject {
+        using (gui.EnterRow()) {
+            gui.BuildText(text, topOffset: 0.5f);
+            if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
+                gui.BuildObjectSelectDropDownWithNone(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
+            }
+        }
+    }
+
+    private void BuildUnitPerTime(ImGui gui, bool fluid, ProjectPreferences preferences) {
+        DisplayAmount unit = fluid ? preferences.fluidUnit : preferences.itemUnit;
+        if (gui.BuildRadioButton("Simple Amount" + preferences.GetPerTimeUnit().suffix, unit == 0f)) {
+            unit = 0f;
+        }
+
+        using (gui.EnterRow()) {
+            if (gui.BuildRadioButton("Custom: 1 unit equals", unit != 0f)) {
+                unit = 1f;
+            }
+
+            gui.AllocateSpacing();
+            gui.allocator = RectAllocator.RightRow;
+            if (!fluid) {
+                if (gui.BuildButton("Set from belt")) {
+                    gui.BuildObjectSelectDropDown<EntityBelt>(Database.allBelts, DataUtils.DefaultOrdering, setBelt => {
+                        _ = preferences.RecordUndo(true);
+                        preferences.itemUnit = setBelt.beltItemsPerSecond;
+                    }, "Select belt", extra: b => DataUtils.FormatAmount(b.beltItemsPerSecond, UnitOfMeasure.PerSecond));
+                }
+            }
+            gui.BuildText("per second");
+            _ = gui.BuildFloatInput(unit, TextBoxDisplayStyle.DefaultTextInput);
+        }
+        gui.AllocateSpacing(1f);
+
+        if (fluid) {
+            if (preferences.fluidUnit != unit.Value) {
+                preferences.RecordUndo(true).fluidUnit = unit.Value;
+            }
+        }
+        else {
+            if (preferences.itemUnit != unit.Value) {
+                preferences.RecordUndo(true).itemUnit = unit.Value;
+            }
+        }
+    }
+
+    public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
 }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -9,266 +9,265 @@ using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
+namespace Yafc;
 
-    public class ProjectPageSettingsPanel : PseudoScreen {
-        private readonly ProjectPage? editingPage;
-        private string name;
-        private FactorioObject? icon;
-        private readonly Action<string, FactorioObject?>? callback;
+public class ProjectPageSettingsPanel : PseudoScreen {
+    private readonly ProjectPage? editingPage;
+    private string name;
+    private FactorioObject? icon;
+    private readonly Action<string, FactorioObject?>? callback;
 
-        private ProjectPageSettingsPanel(ProjectPage? editingPage, Action<string, FactorioObject?>? callback) {
-            this.editingPage = editingPage;
-            name = editingPage?.name ?? "";
-            icon = editingPage?.icon;
-            this.callback = callback;
+    private ProjectPageSettingsPanel(ProjectPage? editingPage, Action<string, FactorioObject?>? callback) {
+        this.editingPage = editingPage;
+        name = editingPage?.name ?? "";
+        icon = editingPage?.icon;
+        this.callback = callback;
+    }
+
+    private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
+        _ = gui.BuildTextInput(name, out name, "Input name", setInitialFocus: editingPage == null);
+        if (gui.BuildFactorioObjectButton(icon, new ButtonDisplayStyle(4f, MilestoneDisplay.None, SchemeColor.Grey) with { UseScaleSetting = false }) == Click.Left) {
+            SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
         }
 
-        private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
-            _ = gui.BuildTextInput(name, out name, "Input name", setInitialFocus: editingPage == null);
-            if (gui.BuildFactorioObjectButton(icon, new ButtonDisplayStyle(4f, MilestoneDisplay.None, SchemeColor.Grey) with { UseScaleSetting = false }) == Click.Left) {
-                SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
+        if (icon == null && gui.isBuilding) {
+            gui.DrawText(gui.lastRect, "And select icon", RectAlignment.Middle);
+        }
+    }
+
+    public static void Show(ProjectPage? page, Action<string, FactorioObject?>? callback = null) {
+        _ = MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(page, callback));
+    }
+
+    public override void Build(ImGui gui) {
+        gui.spacing = 3f;
+        BuildHeader(gui, editingPage == null ? "Create new page" : "Edit page icon and name");
+        Build(gui, s => {
+            icon = s;
+            Rebuild();
+        });
+
+        using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
+            if (editingPage == null && gui.BuildButton("Create", active: !string.IsNullOrEmpty(name))) {
+                ReturnPressed();
             }
 
-            if (icon == null && gui.isBuilding) {
-                gui.DrawText(gui.lastRect, "And select icon", RectAlignment.Middle);
+            if (editingPage != null && gui.BuildButton("OK", active: !string.IsNullOrEmpty(name))) {
+                ReturnPressed();
+            }
+
+            if (gui.BuildButton("Cancel", SchemeColor.Grey)) {
+                Close();
+            }
+
+            if (editingPage != null && gui.BuildButton("Other tools", SchemeColor.Grey, active: !string.IsNullOrEmpty(name))) {
+                gui.ShowDropDown(OtherToolsDropdown);
+            }
+
+            gui.allocator = RectAllocator.LeftRow;
+            if (editingPage != null && gui.BuildRedButton("Delete page")) {
+                if (editingPage.canDelete) {
+                    Project.current.RemovePage(editingPage);
+                }
+                else {
+                    // Only hide if the (singleton) page cannot be deleted
+                    MainScreen.Instance.ClosePage(editingPage.guid);
+                }
+                Close();
+            }
+        }
+    }
+
+    protected override void ReturnPressed() {
+        if (string.IsNullOrEmpty(name)) {
+            // Prevent closing with an empty name
+            return;
+        }
+        if (editingPage is null) {
+            callback?.Invoke(name, icon);
+        }
+        else if (editingPage.name != name || editingPage.icon != icon) {
+            editingPage.RecordUndo(true).name = name!; // null-forgiving: The button is disabled if name is null or empty.
+            editingPage.icon = icon;
+        }
+        Close();
+    }
+
+    private void OtherToolsDropdown(ImGui gui) {
+        if (editingPage!.guid != MainScreen.SummaryGuid && gui.BuildContextMenuButton("Duplicate page")) { // null-forgiving: This dropdown is not shown when editingPage is null.
+            _ = gui.CloseDropdown();
+            var project = editingPage.owner;
+            if (ClonePage(editingPage) is { } serializedCopy) {
+                serializedCopy.icon = icon;
+                serializedCopy.name = name;
+                project.RecordUndo().pages.Add(serializedCopy);
+                MainScreen.Instance.SetActivePage(serializedCopy);
+                Close();
             }
         }
 
-        public static void Show(ProjectPage? page, Action<string, FactorioObject?>? callback = null) {
-            _ = MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(page, callback));
+        if (editingPage.guid != MainScreen.SummaryGuid && gui.BuildContextMenuButton("Share (export string to clipboard)")) {
+            _ = gui.CloseDropdown();
+            var data = JsonUtils.SaveToJson(editingPage);
+            using MemoryStream targetStream = new MemoryStream();
+            using (DeflateStream compress = new DeflateStream(targetStream, CompressionLevel.Optimal, true)) {
+                using (BinaryWriter writer = new BinaryWriter(compress, Encoding.UTF8, true)) {
+                    // write some magic chars and version as a marker
+                    writer.Write("YAFC\nProjectPage\n".AsSpan());
+                    writer.Write(YafcLib.version.ToString().AsSpan());
+                    writer.Write("\n\n\n".AsSpan());
+                }
+                data.CopyTo(compress);
+            }
+            string encoded = Convert.ToBase64String(targetStream.GetBuffer(), 0, (int)targetStream.Length);
+            _ = SDL.SDL_SetClipboardText(encoded);
         }
 
-        public override void Build(ImGui gui) {
-            gui.spacing = 3f;
-            BuildHeader(gui, editingPage == null ? "Create new page" : "Edit page icon and name");
-            Build(gui, s => {
-                icon = s;
-                Rebuild();
-            });
+        if (editingPage == MainScreen.Instance.activePage && gui.BuildContextMenuButton("Make full page screenshot")) {
+            var screenshot = MainScreen.Instance.activePageView!.GenerateFullPageScreenshot(); // null-forgiving: editingPage is not null, so neither is activePage, and activePage and activePageView become null or not-null together. (see MainScreen.ChangePage)
+            _ = new ImageSharePanel(screenshot, editingPage.name);
+            _ = gui.CloseDropdown();
+        }
 
-            using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
-                if (editingPage == null && gui.BuildButton("Create", active: !string.IsNullOrEmpty(name))) {
-                    ReturnPressed();
-                }
+        if (gui.BuildContextMenuButton("Export calculations (to clipboard)")) {
+            ExportPage(editingPage);
+            _ = gui.CloseDropdown();
+        }
+    }
 
-                if (editingPage != null && gui.BuildButton("OK", active: !string.IsNullOrEmpty(name))) {
-                    ReturnPressed();
-                }
+    public static ProjectPage? ClonePage(ProjectPage page) {
+        ErrorCollector collector = new ErrorCollector();
+        var serializedCopy = JsonUtils.Copy(page, page.owner, collector);
+        if (collector.severity > ErrorSeverity.None) {
+            ErrorListPanel.Show(collector);
+        }
 
-                if (gui.BuildButton("Cancel", SchemeColor.Grey)) {
-                    Close();
-                }
+        serializedCopy?.GenerateNewGuid();
+        return serializedCopy;
+    }
 
-                if (editingPage != null && gui.BuildButton("Other tools", SchemeColor.Grey, active: !string.IsNullOrEmpty(name))) {
-                    gui.ShowDropDown(OtherToolsDropdown);
-                }
+    private class ExportRow(RecipeRow row) {
+        public ExportRecipe? Header { get; } = row.recipe is null ? null : new ExportRecipe(row);
+        public IEnumerable<ExportRow> Children { get; } = row.subgroup?.recipes.Select(r => new ExportRow(r)) ?? [];
+    }
 
-                gui.allocator = RectAllocator.LeftRow;
-                if (editingPage != null && gui.BuildRedButton("Delete page")) {
-                    if (editingPage.canDelete) {
-                        Project.current.RemovePage(editingPage);
+    private class ExportRecipe {
+        public string Recipe { get; }
+        public string Building { get; }
+        public float BuildingCount { get; }
+        public IEnumerable<string> Modules { get; }
+        public string? Beacon { get; }
+        public int BeaconCount { get; }
+        public IEnumerable<string> BeaconModules { get; }
+        public ExportMaterial Fuel { get; }
+        public IEnumerable<ExportMaterial> Inputs { get; }
+        public IEnumerable<ExportMaterial> Outputs { get; }
+
+        public ExportRecipe(RecipeRow row) {
+            Recipe = row.recipe.name;
+            Building = row.entity?.name ?? "<No building selected>";
+            BuildingCount = row.buildingCount;
+            Fuel = new ExportMaterial(row.fuel?.name ?? "<No fuel selected>", row.FuelInformation.Amount);
+            Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.name ?? "Recipe disabled", i.Amount));
+            Outputs = row.Products.Select(p => new ExportMaterial(p.Goods?.name ?? "Recipe disabled", p.Amount));
+            Beacon = row.usedModules.beacon?.name;
+            BeaconCount = row.usedModules.beaconCount;
+
+            if (row.usedModules.modules is null) {
+                Modules = BeaconModules = [];
+            }
+            else {
+                List<string> modules = [];
+                List<string> beaconModules = [];
+
+                foreach (var (module, count, isBeacon) in row.usedModules.modules) {
+                    if (isBeacon) {
+                        beaconModules.AddRange(Enumerable.Repeat(module.name, count));
                     }
                     else {
-                        // Only hide if the (singleton) page cannot be deleted
-                        MainScreen.Instance.ClosePage(editingPage.guid);
+                        modules.AddRange(Enumerable.Repeat(module.name, count));
                     }
-                    Close();
-                }
-            }
-        }
-
-        protected override void ReturnPressed() {
-            if (string.IsNullOrEmpty(name)) {
-                // Prevent closing with an empty name
-                return;
-            }
-            if (editingPage is null) {
-                callback?.Invoke(name, icon);
-            }
-            else if (editingPage.name != name || editingPage.icon != icon) {
-                editingPage.RecordUndo(true).name = name!; // null-forgiving: The button is disabled if name is null or empty.
-                editingPage.icon = icon;
-            }
-            Close();
-        }
-
-        private void OtherToolsDropdown(ImGui gui) {
-            if (editingPage!.guid != MainScreen.SummaryGuid && gui.BuildContextMenuButton("Duplicate page")) { // null-forgiving: This dropdown is not shown when editingPage is null.
-                _ = gui.CloseDropdown();
-                var project = editingPage.owner;
-                if (ClonePage(editingPage) is { } serializedCopy) {
-                    serializedCopy.icon = icon;
-                    serializedCopy.name = name;
-                    project.RecordUndo().pages.Add(serializedCopy);
-                    MainScreen.Instance.SetActivePage(serializedCopy);
-                    Close();
-                }
-            }
-
-            if (editingPage.guid != MainScreen.SummaryGuid && gui.BuildContextMenuButton("Share (export string to clipboard)")) {
-                _ = gui.CloseDropdown();
-                var data = JsonUtils.SaveToJson(editingPage);
-                using MemoryStream targetStream = new MemoryStream();
-                using (DeflateStream compress = new DeflateStream(targetStream, CompressionLevel.Optimal, true)) {
-                    using (BinaryWriter writer = new BinaryWriter(compress, Encoding.UTF8, true)) {
-                        // write some magic chars and version as a marker
-                        writer.Write("YAFC\nProjectPage\n".AsSpan());
-                        writer.Write(YafcLib.version.ToString().AsSpan());
-                        writer.Write("\n\n\n".AsSpan());
-                    }
-                    data.CopyTo(compress);
-                }
-                string encoded = Convert.ToBase64String(targetStream.GetBuffer(), 0, (int)targetStream.Length);
-                _ = SDL.SDL_SetClipboardText(encoded);
-            }
-
-            if (editingPage == MainScreen.Instance.activePage && gui.BuildContextMenuButton("Make full page screenshot")) {
-                var screenshot = MainScreen.Instance.activePageView!.GenerateFullPageScreenshot(); // null-forgiving: editingPage is not null, so neither is activePage, and activePage and activePageView become null or not-null together. (see MainScreen.ChangePage)
-                _ = new ImageSharePanel(screenshot, editingPage.name);
-                _ = gui.CloseDropdown();
-            }
-
-            if (gui.BuildContextMenuButton("Export calculations (to clipboard)")) {
-                ExportPage(editingPage);
-                _ = gui.CloseDropdown();
-            }
-        }
-
-        public static ProjectPage? ClonePage(ProjectPage page) {
-            ErrorCollector collector = new ErrorCollector();
-            var serializedCopy = JsonUtils.Copy(page, page.owner, collector);
-            if (collector.severity > ErrorSeverity.None) {
-                ErrorListPanel.Show(collector);
-            }
-
-            serializedCopy?.GenerateNewGuid();
-            return serializedCopy;
-        }
-
-        private class ExportRow(RecipeRow row) {
-            public ExportRecipe? Header { get; } = row.recipe is null ? null : new ExportRecipe(row);
-            public IEnumerable<ExportRow> Children { get; } = row.subgroup?.recipes.Select(r => new ExportRow(r)) ?? [];
-        }
-
-        private class ExportRecipe {
-            public string Recipe { get; }
-            public string Building { get; }
-            public float BuildingCount { get; }
-            public IEnumerable<string> Modules { get; }
-            public string? Beacon { get; }
-            public int BeaconCount { get; }
-            public IEnumerable<string> BeaconModules { get; }
-            public ExportMaterial Fuel { get; }
-            public IEnumerable<ExportMaterial> Inputs { get; }
-            public IEnumerable<ExportMaterial> Outputs { get; }
-
-            public ExportRecipe(RecipeRow row) {
-                Recipe = row.recipe.name;
-                Building = row.entity?.name ?? "<No building selected>";
-                BuildingCount = row.buildingCount;
-                Fuel = new ExportMaterial(row.fuel?.name ?? "<No fuel selected>", row.FuelInformation.Amount);
-                Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.name ?? "Recipe disabled", i.Amount));
-                Outputs = row.Products.Select(p => new ExportMaterial(p.Goods?.name ?? "Recipe disabled", p.Amount));
-                Beacon = row.usedModules.beacon?.name;
-                BeaconCount = row.usedModules.beaconCount;
-
-                if (row.usedModules.modules is null) {
-                    Modules = BeaconModules = [];
-                }
-                else {
-                    List<string> modules = [];
-                    List<string> beaconModules = [];
-
-                    foreach (var (module, count, isBeacon) in row.usedModules.modules) {
-                        if (isBeacon) {
-                            beaconModules.AddRange(Enumerable.Repeat(module.name, count));
-                        }
-                        else {
-                            modules.AddRange(Enumerable.Repeat(module.name, count));
-                        }
-                    }
-
-                    Modules = modules;
-                    BeaconModules = beaconModules;
-                }
-            }
-        }
-
-        private class ExportMaterial(string name, double countPerSecond) {
-            public string Name { get; } = name;
-            public double CountPerSecond { get; } = countPerSecond;
-        }
-
-        private static void ExportPage(ProjectPage page) {
-            using MemoryStream stream = new MemoryStream();
-            using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
-            JsonSerializer.Serialize(stream, ((ProductionTable)page.content).recipes.Select(rr => new ExportRow(rr)), new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-            _ = SDL.SDL_SetClipboardText(Encoding.UTF8.GetString(stream.GetBuffer()));
-        }
-
-        public static void LoadProjectPageFromClipboard() {
-            ErrorCollector collector = new ErrorCollector();
-            var project = Project.current;
-            ProjectPage? page = null;
-            try {
-                string text = SDL.SDL_GetClipboardText();
-                byte[] compressedBytes = Convert.FromBase64String(text.Trim());
-                using DeflateStream deflateStream = new DeflateStream(new MemoryStream(compressedBytes), CompressionMode.Decompress);
-                using MemoryStream ms = new MemoryStream();
-                deflateStream.CopyTo(ms);
-                byte[] bytes = ms.GetBuffer();
-                int index = 0;
-                if (DataUtils.ReadLine(bytes, ref index) != "YAFC" || DataUtils.ReadLine(bytes, ref index) != "ProjectPage") {
-                    throw new InvalidDataException();
                 }
 
-                Version version = new Version(DataUtils.ReadLine(bytes, ref index) ?? "");
-                if (version > YafcLib.version) {
-                    collector.Error("String was created with the newer version of YAFC (" + version + "). Data may be lost.", ErrorSeverity.Important);
-                }
+                Modules = modules;
+                BeaconModules = beaconModules;
+            }
+        }
+    }
 
-                _ = DataUtils.ReadLine(bytes, ref index); // reserved 1
-                if (DataUtils.ReadLine(bytes, ref index) != "") // reserved 2 but this time it is required to be empty
+    private class ExportMaterial(string name, double countPerSecond) {
+        public string Name { get; } = name;
+        public double CountPerSecond { get; } = countPerSecond;
+    }
+
+    private static void ExportPage(ProjectPage page) {
+        using MemoryStream stream = new MemoryStream();
+        using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+        JsonSerializer.Serialize(stream, ((ProductionTable)page.content).recipes.Select(rr => new ExportRow(rr)), new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        _ = SDL.SDL_SetClipboardText(Encoding.UTF8.GetString(stream.GetBuffer()));
+    }
+
+    public static void LoadProjectPageFromClipboard() {
+        ErrorCollector collector = new ErrorCollector();
+        var project = Project.current;
+        ProjectPage? page = null;
+        try {
+            string text = SDL.SDL_GetClipboardText();
+            byte[] compressedBytes = Convert.FromBase64String(text.Trim());
+            using DeflateStream deflateStream = new DeflateStream(new MemoryStream(compressedBytes), CompressionMode.Decompress);
+            using MemoryStream ms = new MemoryStream();
+            deflateStream.CopyTo(ms);
+            byte[] bytes = ms.GetBuffer();
+            int index = 0;
+            if (DataUtils.ReadLine(bytes, ref index) != "YAFC" || DataUtils.ReadLine(bytes, ref index) != "ProjectPage") {
+                throw new InvalidDataException();
+            }
+
+            Version version = new Version(DataUtils.ReadLine(bytes, ref index) ?? "");
+            if (version > YafcLib.version) {
+                collector.Error("String was created with the newer version of YAFC (" + version + "). Data may be lost.", ErrorSeverity.Important);
+            }
+
+            _ = DataUtils.ReadLine(bytes, ref index); // reserved 1
+            if (DataUtils.ReadLine(bytes, ref index) != "") // reserved 2 but this time it is required to be empty
 {
-                    throw new NotSupportedException("Share string was created with future version of YAFC (" + version + ") and is incompatible");
-                }
-
-                page = JsonUtils.LoadFromJson<ProjectPage>(new ReadOnlySpan<byte>(bytes, index, (int)ms.Length - index), project, collector);
-            }
-            catch (Exception ex) {
-                collector.Exception(ex, "Clipboard text does not contain valid YAFC share string", ErrorSeverity.Critical);
+                throw new NotSupportedException("Share string was created with future version of YAFC (" + version + ") and is incompatible");
             }
 
-            if (page != null) {
-                var existing = project.FindPage(page.guid);
-                if (existing != null) {
-                    MessageBox.Show((haveChoice, choice) => {
-                        if (!haveChoice) {
-                            return;
-                        }
+            page = JsonUtils.LoadFromJson<ProjectPage>(new ReadOnlySpan<byte>(bytes, index, (int)ms.Length - index), project, collector);
+        }
+        catch (Exception ex) {
+            collector.Exception(ex, "Clipboard text does not contain valid YAFC share string", ErrorSeverity.Critical);
+        }
 
-                        if (choice) {
-                            project.RemovePage(existing);
-                        }
-                        else {
-                            page.GenerateNewGuid();
-                        }
+        if (page != null) {
+            var existing = project.FindPage(page.guid);
+            if (existing != null) {
+                MessageBox.Show((haveChoice, choice) => {
+                    if (!haveChoice) {
+                        return;
+                    }
 
-                        project.RecordUndo().pages.Add(page);
-                        MainScreen.Instance.SetActivePage(page);
-                    }, "Page already exists",
-                    "Looks like this page already exists with name '" + existing.name + "'. Would you like to replace it or import as copy?", "Replace", "Import as copy");
-                }
-                else {
+                    if (choice) {
+                        project.RemovePage(existing);
+                    }
+                    else {
+                        page.GenerateNewGuid();
+                    }
+
                     project.RecordUndo().pages.Add(page);
                     MainScreen.Instance.SetActivePage(page);
-                }
+                }, "Page already exists",
+                "Looks like this page already exists with name '" + existing.name + "'. Would you like to replace it or import as copy?", "Replace", "Import as copy");
             }
+            else {
+                project.RecordUndo().pages.Add(page);
+                MainScreen.Instance.SetActivePage(page);
+            }
+        }
 
-            if (collector.severity > ErrorSeverity.None) {
-                ErrorListPanel.Show(collector);
-            }
+        if (collector.severity > ErrorSeverity.None) {
+            ErrorListPanel.Show(collector);
         }
     }
 }

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -4,59 +4,58 @@ using System.Numerics;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObject>> {
-        private readonly HashSet<FactorioObject> results = [];
-        private readonly Predicate<FactorioObject> checkMark;
-        private bool allowAutoClose = true;
+namespace Yafc;
+public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObject>> {
+    private readonly HashSet<FactorioObject> results = [];
+    private readonly Predicate<FactorioObject> checkMark;
+    private bool allowAutoClose = true;
 
-        private SelectMultiObjectPanel(Predicate<FactorioObject> checkMark) => this.checkMark = checkMark;
+    private SelectMultiObjectPanel(Predicate<FactorioObject> checkMark) => this.checkMark = checkMark;
 
-        /// <summary>
-        /// Opens a <see cref="SelectMultiObjectPanel"/> to allow the user to select one or more <see cref="FactorioObject"/>s.
-        /// </summary>
-        /// <param name="list">The items to be displayed in this panel.</param>
-        /// <param name="header">The string that describes to the user why they're selecting these items.</param>
-        /// <param name="selectItem">An action to be called for each selected item when the panel is closed.</param>
-        /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null, Predicate<T>? checkMark = null) where T : FactorioObject {
-            SelectMultiObjectPanel panel = new(o => checkMark?.Invoke((T)o) ?? false); // This casting is messy, but pushing T all the way around the call stack and type tree was messier.
-            panel.Select(list, header, selectItem!, ordering, (objs, mappedAction) => { // null-forgiving: selectItem will not be called with null, because allowNone is false.
-                foreach (var obj in objs!) { // null-forgiving: mapResult will not be called with null, because allowNone is false.
-                    mappedAction(obj);
-                }
-            }, false);
-        }
-
-        protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
-            SchemeColor bgColor = results.Contains(element) ? SchemeColor.Primary : SchemeColor.None;
-            Click click = gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(bgColor), new() { ShowTypeInHeader = showTypeInHeader });
-
-            if (checkMark(element)) {
-                gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);
+    /// <summary>
+    /// Opens a <see cref="SelectMultiObjectPanel"/> to allow the user to select one or more <see cref="FactorioObject"/>s.
+    /// </summary>
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for each selected item when the panel is closed.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null, Predicate<T>? checkMark = null) where T : FactorioObject {
+        SelectMultiObjectPanel panel = new(o => checkMark?.Invoke((T)o) ?? false); // This casting is messy, but pushing T all the way around the call stack and type tree was messier.
+        panel.Select(list, header, selectItem!, ordering, (objs, mappedAction) => { // null-forgiving: selectItem will not be called with null, because allowNone is false.
+            foreach (var obj in objs!) { // null-forgiving: mapResult will not be called with null, because allowNone is false.
+                mappedAction(obj);
             }
-
-            if (click == Click.Left) {
-                if (!results.Add(element)) {
-                    _ = results.Remove(element);
-                }
-                if (!InputSystem.Instance.control && allowAutoClose) {
-                    CloseWithResult(results);
-                }
-                allowAutoClose = false;
-            }
-        }
-
-        public override void Build(ImGui gui) {
-            base.Build(gui);
-            using (gui.EnterGroup(default, RectAllocator.Center)) {
-                if (gui.BuildButton("OK")) {
-                    CloseWithResult(results);
-                }
-                gui.BuildText("Hint: ctrl+click to select multiple", TextBlockDisplayStyle.HintText);
-            }
-        }
-
-        protected override void ReturnPressed() => CloseWithResult(results);
+        }, false);
     }
+
+    protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
+        SchemeColor bgColor = results.Contains(element) ? SchemeColor.Primary : SchemeColor.None;
+        Click click = gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(bgColor), new() { ShowTypeInHeader = showTypeInHeader });
+
+        if (checkMark(element)) {
+            gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);
+        }
+
+        if (click == Click.Left) {
+            if (!results.Add(element)) {
+                _ = results.Remove(element);
+            }
+            if (!InputSystem.Instance.control && allowAutoClose) {
+                CloseWithResult(results);
+            }
+            allowAutoClose = false;
+        }
+    }
+
+    public override void Build(ImGui gui) {
+        base.Build(gui);
+        using (gui.EnterGroup(default, RectAllocator.Center)) {
+            if (gui.BuildButton("OK")) {
+                CloseWithResult(results);
+            }
+            gui.BuildText("Hint: ctrl+click to select multiple", TextBlockDisplayStyle.HintText);
+        }
+    }
+
+    protected override void ReturnPressed() => CloseWithResult(results);
 }

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -5,106 +5,105 @@ using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
+namespace Yafc;
+/// <summary>
+/// Represents a panel that can generate a result by selecting zero or more <see cref="FactorioObject"/>s. (But doesn't have to, if the user selects a close or cancel button.)
+/// </summary>
+/// <typeparam name="T">The type of result the panel can generate.</typeparam>
+public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
+    private readonly SearchableList<FactorioObject?> list;
+    private string header = null!; // null-forgiving: set by Select
+    private Rect searchBox;
+    private string? noneTooltip;
     /// <summary>
-    /// Represents a panel that can generate a result by selecting zero or more <see cref="FactorioObject"/>s. (But doesn't have to, if the user selects a close or cancel button.)
+    /// If <see langword="true"/> and the object being hovered is not a <see cref="Goods"/>, the <see cref="ObjectTooltip"/> should specify the type of object.
+    /// See also <see cref="ObjectTooltipOptions.ShowTypeInHeader"/>.
     /// </summary>
-    /// <typeparam name="T">The type of result the panel can generate.</typeparam>
-    public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
-        private readonly SearchableList<FactorioObject?> list;
-        private string header = null!; // null-forgiving: set by Select
-        private Rect searchBox;
-        private string? noneTooltip;
-        /// <summary>
-        /// If <see langword="true"/> and the object being hovered is not a <see cref="Goods"/>, the <see cref="ObjectTooltip"/> should specify the type of object.
-        /// See also <see cref="ObjectTooltipOptions.ShowTypeInHeader"/>.
-        /// </summary>
-        protected bool showTypeInHeader { get; private set; }
+    protected bool showTypeInHeader { get; private set; }
 
-        protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject?>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
+    protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject?>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
 
-        /// <summary>
-        /// Opens a <see cref="SelectObjectPanel{T}"/> to allow the user to select zero or more <see cref="FactorioObject"/>s.
-        /// </summary>
-        /// <typeparam name="U"><see cref="FactorioObject"/> or one of its derived classes, to allow <paramref name="selectItem"/> and <paramref name="ordering"/> to have better type checking.</typeparam>
-        /// <param name="list">The items to be displayed in this panel.</param>
-        /// <param name="header">The string that describes to the user why they're selecting these items.</param>
-        /// <param name="selectItem">An action to be called for each selected item when the panel is closed. The parameter may be <see langword="null"/> if <paramref name="allowNone"/> is <see langword="true"/>.</param>
-        /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-        /// <param name="mapResult">An action that should convert the <typeparamref name="T"/>? result into zero or more <see cref="FactorioObject"/>s, and then call its second
-        /// parameter for each <see cref="FactorioObject"/>. The first parameter may be <see langword="null"/> if <paramref name="allowNone"/> is <see langword="true"/>.</param>
-        /// <param name="allowNone">If <see langword="true"/>, a "none" option will be displayed. Selection of this item will be conveyed by calling <paramref name="mapResult"/>
-        /// and <paramref name="selectItem"/> with <see langword="default"/> values for <typeparamref name="T"/> and <typeparamref name="U"/>.</param>
-        /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
-        protected void Select<U>(IEnumerable<U> list, string header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone, string? noneTooltip = null) where U : FactorioObject {
-            _ = MainScreen.Instance.ShowPseudoScreen(this);
-            this.noneTooltip = noneTooltip;
-            showTypeInHeader = typeof(U) == typeof(FactorioObject);
-            List<U?> data = new List<U?>(list);
-            ordering ??= DataUtils.DefaultOrdering;
-            data.Sort(ordering!); // null-forgiving: We don't have any nulls in the list yet.
-            if (allowNone) {
-                data.Insert(0, null);
-            }
+    /// <summary>
+    /// Opens a <see cref="SelectObjectPanel{T}"/> to allow the user to select zero or more <see cref="FactorioObject"/>s.
+    /// </summary>
+    /// <typeparam name="U"><see cref="FactorioObject"/> or one of its derived classes, to allow <paramref name="selectItem"/> and <paramref name="ordering"/> to have better type checking.</typeparam>
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for each selected item when the panel is closed. The parameter may be <see langword="null"/> if <paramref name="allowNone"/> is <see langword="true"/>.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    /// <param name="mapResult">An action that should convert the <typeparamref name="T"/>? result into zero or more <see cref="FactorioObject"/>s, and then call its second
+    /// parameter for each <see cref="FactorioObject"/>. The first parameter may be <see langword="null"/> if <paramref name="allowNone"/> is <see langword="true"/>.</param>
+    /// <param name="allowNone">If <see langword="true"/>, a "none" option will be displayed. Selection of this item will be conveyed by calling <paramref name="mapResult"/>
+    /// and <paramref name="selectItem"/> with <see langword="default"/> values for <typeparamref name="T"/> and <typeparamref name="U"/>.</param>
+    /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
+    protected void Select<U>(IEnumerable<U> list, string header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone, string? noneTooltip = null) where U : FactorioObject {
+        _ = MainScreen.Instance.ShowPseudoScreen(this);
+        this.noneTooltip = noneTooltip;
+        showTypeInHeader = typeof(U) == typeof(FactorioObject);
+        List<U?> data = new List<U?>(list);
+        ordering ??= DataUtils.DefaultOrdering;
+        data.Sort(ordering!); // null-forgiving: We don't have any nulls in the list yet.
+        if (allowNone) {
+            data.Insert(0, null);
+        }
 
-            this.list.filter = default;
-            this.list.data = data;
-            this.header = header;
-            Rebuild();
-            completionCallback = (hasResult, result) => {
-                if (hasResult) {
-                    mapResult(result, obj => {
-                        if (obj is U u) {
-                            if (ordering is DataUtils.FavoritesComparer<U> favoritesComparer) {
-                                favoritesComparer.AddToFavorite(u);
-                            }
-
-                            selectItem(u);
+        this.list.filter = default;
+        this.list.data = data;
+        this.header = header;
+        Rebuild();
+        completionCallback = (hasResult, result) => {
+            if (hasResult) {
+                mapResult(result, obj => {
+                    if (obj is U u) {
+                        if (ordering is DataUtils.FavoritesComparer<U> favoritesComparer) {
+                            favoritesComparer.AddToFavorite(u);
                         }
-                        else if (allowNone) {
-                            selectItem(null);
-                        }
-                    });
-                }
-            };
-        }
 
-        private void ElementDrawer(ImGui gui, FactorioObject? element, int index) {
-            if (element == null) {
-                ButtonEvent evt = gui.BuildRedButton(Icon.Close);
-                if (noneTooltip != null) {
-                    evt.WithTooltip(gui, noneTooltip);
-                }
-                if (evt) {
-                    CloseWithResult(default);
-                }
+                        selectItem(u);
+                    }
+                    else if (allowNone) {
+                        selectItem(null);
+                    }
+                });
             }
-            else {
-                NonNullElementDrawer(gui, element);
+        };
+    }
+
+    private void ElementDrawer(ImGui gui, FactorioObject? element, int index) {
+        if (element == null) {
+            ButtonEvent evt = gui.BuildRedButton(Icon.Close);
+            if (noneTooltip != null) {
+                evt.WithTooltip(gui, noneTooltip);
+            }
+            if (evt) {
+                CloseWithResult(default);
             }
         }
+        else {
+            NonNullElementDrawer(gui, element);
+        }
+    }
 
-        /// <summary>
-        /// Called to draw a <see cref="FactorioObject"/> that should be displayed in this panel, and to handle mouse-over and click events.
-        /// <paramref name="element"/> will not be null. If a "none" or "clear" option is present, <see cref="SelectObjectPanel{T}"/> takes care of that option.
-        /// </summary>
-        protected abstract void NonNullElementDrawer(ImGui gui, FactorioObject element);
+    /// <summary>
+    /// Called to draw a <see cref="FactorioObject"/> that should be displayed in this panel, and to handle mouse-over and click events.
+    /// <paramref name="element"/> will not be null. If a "none" or "clear" option is present, <see cref="SelectObjectPanel{T}"/> takes care of that option.
+    /// </summary>
+    protected abstract void NonNullElementDrawer(ImGui gui, FactorioObject element);
 
-        private bool ElementFilter(FactorioObject? data, SearchQuery query) => data?.Match(query) ?? true;
+    private bool ElementFilter(FactorioObject? data, SearchQuery query) => data?.Match(query) ?? true;
 
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, header);
-            if (gui.BuildSearchBox(list.filter, out var newFilter, "Start typing for search", setInitialFocus: true)) {
-                list.filter = newFilter;
-            }
-
-            searchBox = gui.lastRect;
-            list.Build(gui);
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, header);
+        if (gui.BuildSearchBox(list.filter, out var newFilter, "Start typing for search", setInitialFocus: true)) {
+            list.filter = newFilter;
         }
 
-        public override bool KeyDown(SDL.SDL_Keysym key) {
-            contents.SetTextInputFocus(searchBox, list.filter.query);
-            return base.KeyDown(key);
-        }
+        searchBox = gui.lastRect;
+        list.Build(gui);
+    }
+
+    public override bool KeyDown(SDL.SDL_Keysym key) {
+        contents.SetTextInputFocus(searchBox, list.filter.query);
+        return base.KeyDown(key);
     }
 }

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -3,40 +3,39 @@ using System.Collections.Generic;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
+namespace Yafc;
+/// <summary>
+/// Represents a panel that can generate a result by selecting zero or one <see cref="FactorioObject"/>s. (But doesn't have to, if the user selects a close or cancel button.)
+/// </summary>
+public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
+    private static readonly SelectSingleObjectPanel Instance = new SelectSingleObjectPanel();
+    public SelectSingleObjectPanel() : base() { }
+
     /// <summary>
-    /// Represents a panel that can generate a result by selecting zero or one <see cref="FactorioObject"/>s. (But doesn't have to, if the user selects a close or cancel button.)
+    /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>.
     /// </summary>
-    public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
-        private static readonly SelectSingleObjectPanel Instance = new SelectSingleObjectPanel();
-        public SelectSingleObjectPanel() : base() { }
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for the selected item when the panel is closed.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
+        => Instance.Select(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false); // null-forgiving: selectItem will not be called with null, because allowNone is false.
 
-        /// <summary>
-        /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>.
-        /// </summary>
-        /// <param name="list">The items to be displayed in this panel.</param>
-        /// <param name="header">The string that describes to the user why they're selecting these items.</param>
-        /// <param name="selectItem">An action to be called for the selected item when the panel is closed.</param>
-        /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
-            => Instance.Select(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false); // null-forgiving: selectItem will not be called with null, because allowNone is false.
+    /// <summary>
+    /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>, or to clear the current selection by selecting
+    /// an extra "none" or "clear" option.
+    /// </summary>
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for the selected item when the panel is closed. The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
+    public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
+        => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
 
-        /// <summary>
-        /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>, or to clear the current selection by selecting
-        /// an extra "none" or "clear" option.
-        /// </summary>
-        /// <param name="list">The items to be displayed in this panel.</param>
-        /// <param name="header">The string that describes to the user why they're selecting these items.</param>
-        /// <param name="selectItem">An action to be called for the selected item when the panel is closed. The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
-        /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-        /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
-        public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
-            => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
-
-        protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
-            if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ShowTypeInHeader = showTypeInHeader }) == Click.Left) {
-                CloseWithResult(element);
-            }
+    protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
+        if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ShowTypeInHeader = showTypeInHeader }) == Click.Left) {
+            CloseWithResult(element);
         }
     }
 }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -6,229 +6,228 @@ using Yafc.Blueprints;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ShoppingListScreen : PseudoScreen {
-        private enum DisplayState { Total, Built, Missing }
-        private readonly VirtualScrollList<(FactorioObject, float)> list;
-        private float shoppingCost, totalBuildings, totalModules;
-        private bool decomposed = false;
-        private static DisplayState displayState {
-            get => (DisplayState)(Preferences.Instance.shoppingDisplayState >> 1);
-            set {
-                Preferences.Instance.shoppingDisplayState = ((int)value) << 1 | (Preferences.Instance.shoppingDisplayState & 1);
-                Preferences.Instance.Save();
-            }
+namespace Yafc;
+public class ShoppingListScreen : PseudoScreen {
+    private enum DisplayState { Total, Built, Missing }
+    private readonly VirtualScrollList<(FactorioObject, float)> list;
+    private float shoppingCost, totalBuildings, totalModules;
+    private bool decomposed = false;
+    private static DisplayState displayState {
+        get => (DisplayState)(Preferences.Instance.shoppingDisplayState >> 1);
+        set {
+            Preferences.Instance.shoppingDisplayState = ((int)value) << 1 | (Preferences.Instance.shoppingDisplayState & 1);
+            Preferences.Instance.Save();
         }
-        private static bool assumeAdequate {
-            get => (Preferences.Instance.shoppingDisplayState & 1) != 0;
-            set {
-                Preferences.Instance.shoppingDisplayState = (Preferences.Instance.shoppingDisplayState & ~1) | (value ? 1 : 0);
-                Preferences.Instance.Save();
-            }
+    }
+    private static bool assumeAdequate {
+        get => (Preferences.Instance.shoppingDisplayState & 1) != 0;
+        set {
+            Preferences.Instance.shoppingDisplayState = (Preferences.Instance.shoppingDisplayState & ~1) | (value ? 1 : 0);
+            Preferences.Instance.Save();
         }
+    }
 
-        private readonly List<RecipeRow> recipes;
+    private readonly List<RecipeRow> recipes;
 
-        private ShoppingListScreen(List<RecipeRow> recipes) {
-            list = new VirtualScrollList<(FactorioObject, float)>(30f, new Vector2(float.PositiveInfinity, 2), ElementDrawer);
-            this.recipes = recipes;
-            RebuildData();
+    private ShoppingListScreen(List<RecipeRow> recipes) {
+        list = new VirtualScrollList<(FactorioObject, float)>(30f, new Vector2(float.PositiveInfinity, 2), ElementDrawer);
+        this.recipes = recipes;
+        RebuildData();
+    }
+
+    private void ElementDrawer(ImGui gui, (FactorioObject obj, float count) element, int index) {
+        using (gui.EnterRow()) {
+            gui.BuildFactorioObjectIcon(element.obj, new IconDisplayStyle(2, MilestoneDisplay.Contained, false));
+            gui.RemainingRow().BuildText(DataUtils.FormatAmount(element.count, UnitOfMeasure.None, "x") + ": " + element.obj.locName);
         }
+        _ = gui.BuildFactorioObjectButtonBackground(gui.lastRect, element.obj);
+    }
 
-        private void ElementDrawer(ImGui gui, (FactorioObject obj, float count) element, int index) {
-            using (gui.EnterRow()) {
-                gui.BuildFactorioObjectIcon(element.obj, new IconDisplayStyle(2, MilestoneDisplay.Contained, false));
-                gui.RemainingRow().BuildText(DataUtils.FormatAmount(element.count, UnitOfMeasure.None, "x") + ": " + element.obj.locName);
-            }
-            _ = gui.BuildFactorioObjectButtonBackground(gui.lastRect, element.obj);
-        }
+    public static void Show(List<RecipeRow> recipes) => _ = MainScreen.Instance.ShowPseudoScreen(new ShoppingListScreen(recipes));
 
-        public static void Show(List<RecipeRow> recipes) => _ = MainScreen.Instance.ShowPseudoScreen(new ShoppingListScreen(recipes));
+    private void RebuildData() {
+        decomposed = false;
 
-        private void RebuildData() {
-            decomposed = false;
-
-            // Count buildings and modules
-            Dictionary<FactorioObject, int> counts = [];
-            foreach (RecipeRow recipe in recipes) {
-                if (recipe.entity != null) {
-                    FactorioObject shopItem = recipe.entity.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity;
-                    _ = counts.TryGetValue(shopItem, out int prev);
-                    int builtCount = recipe.builtBuildings ?? (assumeAdequate ? MathUtils.Ceil(recipe.buildingCount) : 0);
-                    int displayCount = displayState switch {
-                        DisplayState.Total => MathUtils.Ceil(recipe.buildingCount),
-                        DisplayState.Built => builtCount,
-                        DisplayState.Missing => MathUtils.Ceil(Math.Max(recipe.buildingCount - builtCount, 0)),
-                        _ => throw new InvalidOperationException(nameof(displayState) + " has an unrecognized value.")
-                    };
-                    counts[shopItem] = prev + displayCount;
-                    if (recipe.usedModules.modules != null) {
-                        foreach ((Module module, int moduleCount, bool beacon) in recipe.usedModules.modules) {
-                            if (!beacon) {
-                                _ = counts.TryGetValue(module, out prev);
-                                counts[module] = prev + displayCount * moduleCount;
-                            }
+        // Count buildings and modules
+        Dictionary<FactorioObject, int> counts = [];
+        foreach (RecipeRow recipe in recipes) {
+            if (recipe.entity != null) {
+                FactorioObject shopItem = recipe.entity.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity;
+                _ = counts.TryGetValue(shopItem, out int prev);
+                int builtCount = recipe.builtBuildings ?? (assumeAdequate ? MathUtils.Ceil(recipe.buildingCount) : 0);
+                int displayCount = displayState switch {
+                    DisplayState.Total => MathUtils.Ceil(recipe.buildingCount),
+                    DisplayState.Built => builtCount,
+                    DisplayState.Missing => MathUtils.Ceil(Math.Max(recipe.buildingCount - builtCount, 0)),
+                    _ => throw new InvalidOperationException(nameof(displayState) + " has an unrecognized value.")
+                };
+                counts[shopItem] = prev + displayCount;
+                if (recipe.usedModules.modules != null) {
+                    foreach ((Module module, int moduleCount, bool beacon) in recipe.usedModules.modules) {
+                        if (!beacon) {
+                            _ = counts.TryGetValue(module, out prev);
+                            counts[module] = prev + displayCount * moduleCount;
                         }
                     }
                 }
             }
-            list.data = [.. counts.Where(x => x.Value > 0).Select(x => (x.Key, Value: (float)x.Value)).OrderByDescending(x => x.Value)];
-
-            // Summarize building requirements
-            float cost = 0f, buildings = 0f, modules = 0f;
-            decomposed = false;
-            foreach ((FactorioObject obj, float count) in list.data) {
-                if (obj is Module module) {
-                    modules += count;
-                }
-                else if (obj is Entity or Item) {
-                    buildings += count;
-                }
-                cost += obj.Cost() * count;
-            }
-            shoppingCost = cost;
-            totalBuildings = buildings;
-            totalModules = modules;
         }
+        list.data = [.. counts.Where(x => x.Value > 0).Select(x => (x.Key, Value: (float)x.Value)).OrderByDescending(x => x.Value)];
 
-        private static readonly (string, string?)[] displayStateOptions = [
-            ("Total buildings", "Display the total number of buildings required, ignoring the built building count."),
-            ("Built buildings", "Display the number of buildings that are reported in built building count."),
-            ("Missing buildings", "Display the number of additional buildings that need to be built.")];
-        private static readonly (string, string?)[] assumeAdequateOptions = [
-            ("No buildings", "When the built building count is not specified, behave as if it was set to 0."),
-            ("Enough buildings", "When the built building count is not specified, behave as if it matches the required building count.")];
-
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Shopping list");
-            gui.BuildText(
-                "Total cost of all objects: " + DataUtils.FormatAmount(shoppingCost, UnitOfMeasure.None, "¥") + ", buildings: " +
-                DataUtils.FormatAmount(totalBuildings, UnitOfMeasure.None) + ", modules: " + DataUtils.FormatAmount(totalModules, UnitOfMeasure.None), TextBlockDisplayStyle.Centered);
-            using (gui.EnterRow()) {
-                if (gui.BuildRadioGroup(displayStateOptions, (int)displayState, out int newSelected)) {
-                    displayState = (DisplayState)newSelected;
-                    RebuildData();
-                }
+        // Summarize building requirements
+        float cost = 0f, buildings = 0f, modules = 0f;
+        decomposed = false;
+        foreach ((FactorioObject obj, float count) in list.data) {
+            if (obj is Module module) {
+                modules += count;
             }
-            using (gui.EnterRow()) {
-                SchemeColor textColor = displayState == DisplayState.Total ? SchemeColor.PrimaryTextFaint : SchemeColor.PrimaryText;
-                gui.BuildText("When not specified, assume:", TextBlockDisplayStyle.Default(textColor), topOffset: .15f);
-                if (gui.BuildRadioGroup(assumeAdequateOptions, assumeAdequate ? 1 : 0, out int newSelected, enabled: displayState != DisplayState.Total)) {
-                    assumeAdequate = newSelected == 1;
-                    RebuildData();
-                }
+            else if (obj is Entity or Item) {
+                buildings += count;
             }
-            gui.AllocateSpacing(1f);
-            list.Build(gui);
-            using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
-                if (gui.BuildButton("Done")) {
-                    Close();
-                }
+            cost += obj.Cost() * count;
+        }
+        shoppingCost = cost;
+        totalBuildings = buildings;
+        totalModules = modules;
+    }
 
-                if (gui.BuildButton("Decompose", active: !decomposed)) {
-                    Decompose();
-                }
+    private static readonly (string, string?)[] displayStateOptions = [
+        ("Total buildings", "Display the total number of buildings required, ignoring the built building count."),
+        ("Built buildings", "Display the number of buildings that are reported in built building count."),
+        ("Missing buildings", "Display the number of additional buildings that need to be built.")];
+    private static readonly (string, string?)[] assumeAdequateOptions = [
+        ("No buildings", "When the built building count is not specified, behave as if it was set to 0."),
+        ("Enough buildings", "When the built building count is not specified, behave as if it matches the required building count.")];
 
-                if (gui.BuildButton("Export to blueprint", SchemeColor.Grey)) {
-                    gui.ShowDropDown(ExportBlueprintDropdown);
-                }
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Shopping list");
+        gui.BuildText(
+            "Total cost of all objects: " + DataUtils.FormatAmount(shoppingCost, UnitOfMeasure.None, "¥") + ", buildings: " +
+            DataUtils.FormatAmount(totalBuildings, UnitOfMeasure.None) + ", modules: " + DataUtils.FormatAmount(totalModules, UnitOfMeasure.None), TextBlockDisplayStyle.Centered);
+        using (gui.EnterRow()) {
+            if (gui.BuildRadioGroup(displayStateOptions, (int)displayState, out int newSelected)) {
+                displayState = (DisplayState)newSelected;
+                RebuildData();
             }
         }
+        using (gui.EnterRow()) {
+            SchemeColor textColor = displayState == DisplayState.Total ? SchemeColor.PrimaryTextFaint : SchemeColor.PrimaryText;
+            gui.BuildText("When not specified, assume:", TextBlockDisplayStyle.Default(textColor), topOffset: .15f);
+            if (gui.BuildRadioGroup(assumeAdequateOptions, assumeAdequate ? 1 : 0, out int newSelected, enabled: displayState != DisplayState.Total)) {
+                assumeAdequate = newSelected == 1;
+                RebuildData();
+            }
+        }
+        gui.AllocateSpacing(1f);
+        list.Build(gui);
+        using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
+            if (gui.BuildButton("Done")) {
+                Close();
+            }
 
-        private List<(T, int)> ExportGoods<T>() where T : Goods {
-            List<(T, int)> items = [];
-            foreach (var (element, amount) in list.data) {
-                int rounded = MathUtils.Round(amount);
-                if (rounded == 0) {
+            if (gui.BuildButton("Decompose", active: !decomposed)) {
+                Decompose();
+            }
+
+            if (gui.BuildButton("Export to blueprint", SchemeColor.Grey)) {
+                gui.ShowDropDown(ExportBlueprintDropdown);
+            }
+        }
+    }
+
+    private List<(T, int)> ExportGoods<T>() where T : Goods {
+        List<(T, int)> items = [];
+        foreach (var (element, amount) in list.data) {
+            int rounded = MathUtils.Round(amount);
+            if (rounded == 0) {
+                continue;
+            }
+
+            if (element is T g) {
+                items.Add((g, rounded));
+            }
+            else if (element is Entity e && e.itemsToPlace.Length > 0) {
+                items.Add(((T)(object)e.itemsToPlace[0], rounded));
+            }
+        }
+
+        return items;
+    }
+
+    private void ExportBlueprintDropdown(ImGui gui) {
+        gui.BuildText("Blueprint string will be copied to clipboard", TextBlockDisplayStyle.WrappedText);
+        if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator) && gui.BuildFactorioObjectButtonWithText(combinator) == Click.Left && gui.CloseDropdown()) {
+            _ = BlueprintUtilities.ExportConstantCombinators("Shopping list", ExportGoods<Goods>());
+        }
+
+        foreach (var container in Database.allContainers) {
+            if (container.logisticMode == "requester" && gui.BuildFactorioObjectButtonWithText(container) == Click.Left && gui.CloseDropdown()) {
+                _ = BlueprintUtilities.ExportRequesterChests("Shopping list", ExportGoods<Item>(), container);
+            }
+        }
+    }
+
+    private Recipe? FindSingleProduction(Recipe[] production) {
+        Recipe? current = null;
+        foreach (Recipe recipe in production) {
+            if (recipe.IsAccessible()) {
+                if (current != null) {
+                    return null;
+                }
+
+                current = recipe;
+            }
+        }
+
+        return current;
+    }
+
+    private void Decompose() {
+        decomposed = true;
+        Queue<FactorioObject> decompositionQueue = new Queue<FactorioObject>();
+        Dictionary<FactorioObject, float> decomposeResult = [];
+
+        void AddDecomposition(FactorioObject obj, float amount) {
+            if (!decomposeResult.TryGetValue(obj, out float prev)) {
+                decompositionQueue.Enqueue(obj);
+            }
+
+            decomposeResult[obj] = prev + amount;
+        }
+
+        foreach (var (item, count) in list.data) {
+            AddDecomposition(item, count);
+        }
+
+        int steps = 0;
+        while (decompositionQueue.Count > 0) {
+            var elem = decompositionQueue.Dequeue();
+            float amount = decomposeResult[elem];
+            if (elem is Entity e && e.itemsToPlace.Length == 1) {
+                AddDecomposition(e.itemsToPlace[0], amount);
+            }
+            else if (elem is Recipe rec) {
+                if (rec.HasIngredientVariants()) {
                     continue;
                 }
 
-                if (element is T g) {
-                    items.Add((g, rounded));
-                }
-                else if (element is Entity e && e.itemsToPlace.Length > 0) {
-                    items.Add(((T)(object)e.itemsToPlace[0], rounded));
+                foreach (var ingredient in rec.ingredients) {
+                    AddDecomposition(ingredient.goods, ingredient.amount * amount);
                 }
             }
-
-            return items;
-        }
-
-        private void ExportBlueprintDropdown(ImGui gui) {
-            gui.BuildText("Blueprint string will be copied to clipboard", TextBlockDisplayStyle.WrappedText);
-            if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator) && gui.BuildFactorioObjectButtonWithText(combinator) == Click.Left && gui.CloseDropdown()) {
-                _ = BlueprintUtilities.ExportConstantCombinators("Shopping list", ExportGoods<Goods>());
+            else if (elem is Goods g && (g.usages.Length <= 5 || (g is Item item && (item.factorioType != "item" || item.placeResult != null))) && (rec = FindSingleProduction(g.production)!) != null) {
+                AddDecomposition(g.production[0], amount / rec.GetProductionPerRecipe(g));
+            }
+            else {
+                continue;
             }
 
-            foreach (var container in Database.allContainers) {
-                if (container.logisticMode == "requester" && gui.BuildFactorioObjectButtonWithText(container) == Click.Left && gui.CloseDropdown()) {
-                    _ = BlueprintUtilities.ExportRequesterChests("Shopping list", ExportGoods<Item>(), container);
-                }
+            _ = decomposeResult.Remove(elem);
+            if (steps++ > 1000) {
+                break;
             }
         }
 
-        private Recipe? FindSingleProduction(Recipe[] production) {
-            Recipe? current = null;
-            foreach (Recipe recipe in production) {
-                if (recipe.IsAccessible()) {
-                    if (current != null) {
-                        return null;
-                    }
-
-                    current = recipe;
-                }
-            }
-
-            return current;
-        }
-
-        private void Decompose() {
-            decomposed = true;
-            Queue<FactorioObject> decompositionQueue = new Queue<FactorioObject>();
-            Dictionary<FactorioObject, float> decomposeResult = [];
-
-            void AddDecomposition(FactorioObject obj, float amount) {
-                if (!decomposeResult.TryGetValue(obj, out float prev)) {
-                    decompositionQueue.Enqueue(obj);
-                }
-
-                decomposeResult[obj] = prev + amount;
-            }
-
-            foreach (var (item, count) in list.data) {
-                AddDecomposition(item, count);
-            }
-
-            int steps = 0;
-            while (decompositionQueue.Count > 0) {
-                var elem = decompositionQueue.Dequeue();
-                float amount = decomposeResult[elem];
-                if (elem is Entity e && e.itemsToPlace.Length == 1) {
-                    AddDecomposition(e.itemsToPlace[0], amount);
-                }
-                else if (elem is Recipe rec) {
-                    if (rec.HasIngredientVariants()) {
-                        continue;
-                    }
-
-                    foreach (var ingredient in rec.ingredients) {
-                        AddDecomposition(ingredient.goods, ingredient.amount * amount);
-                    }
-                }
-                else if (elem is Goods g && (g.usages.Length <= 5 || (g is Item item && (item.factorioType != "item" || item.placeResult != null))) && (rec = FindSingleProduction(g.production)!) != null) {
-                    AddDecomposition(g.production[0], amount / rec.GetProductionPerRecipe(g));
-                }
-                else {
-                    continue;
-                }
-
-                _ = decomposeResult.Remove(elem);
-                if (steps++ > 1000) {
-                    break;
-                }
-            }
-
-            list.data = decomposeResult.Select(x => (x.Key, x.Value)).OrderByDescending(x => x.Value).ToArray();
-        }
+        list.data = decomposeResult.Select(x => (x.Key, x.Value)).OrderByDescending(x => x.Value).ToArray();
     }
 }

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -10,439 +10,438 @@ using Yafc.Model;
 using Yafc.Parser;
 using Yafc.UI;
 
-namespace Yafc {
-    public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboardFocus {
-        private readonly ILogger logger = Logging.GetLogger<WelcomeScreen>();
-        private bool loading;
-        private string? currentLoad1, currentLoad2;
-        private string path = "", dataPath = "", modsPath = "";
-        private bool expensive;
-        private bool netProduction;
-        private string createText;
-        private bool canCreate;
-        private readonly ScrollArea errorScroll;
-        private readonly ScrollArea recentProjectScroll;
-        private readonly ScrollArea languageScroll;
-        private string? errorMod;
-        private string? errorMessage;
-        private string? tip;
-        private readonly string[] tips;
+namespace Yafc;
+public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboardFocus {
+    private readonly ILogger logger = Logging.GetLogger<WelcomeScreen>();
+    private bool loading;
+    private string? currentLoad1, currentLoad2;
+    private string path = "", dataPath = "", modsPath = "";
+    private bool expensive;
+    private bool netProduction;
+    private string createText;
+    private bool canCreate;
+    private readonly ScrollArea errorScroll;
+    private readonly ScrollArea recentProjectScroll;
+    private readonly ScrollArea languageScroll;
+    private string? errorMod;
+    private string? errorMessage;
+    private string? tip;
+    private readonly string[] tips;
 
-        private static readonly Dictionary<string, string> languageMapping = new Dictionary<string, string>()
-        {
-            {"en", "English"},
-            {"ca", "Catalan"},
-            {"cs", "Czech"},
-            {"da", "Danish"},
-            {"nl", "Dutch"},
-            {"de", "German"},
-            {"fi", "Finnish"},
-            {"fr", "French"},
-            {"hu", "Hungarian"},
-            {"it", "Italian"},
-            {"no", "Norwegian"},
-            {"pl", "Polish"},
-            {"pt-PT", "Portuguese"},
-            {"pt-BR", "Portuguese (Brazilian)"},
-            {"ro", "Romanian"},
-            {"ru", "Russian"},
-            {"es-ES", "Spanish"},
-            {"sv-SE", "Swedish"},
-            {"tr", "Turkish"},
-            {"uk", "Ukrainian"},
-        };
+    private static readonly Dictionary<string, string> languageMapping = new Dictionary<string, string>()
+    {
+        {"en", "English"},
+        {"ca", "Catalan"},
+        {"cs", "Czech"},
+        {"da", "Danish"},
+        {"nl", "Dutch"},
+        {"de", "German"},
+        {"fi", "Finnish"},
+        {"fr", "French"},
+        {"hu", "Hungarian"},
+        {"it", "Italian"},
+        {"no", "Norwegian"},
+        {"pl", "Polish"},
+        {"pt-PT", "Portuguese"},
+        {"pt-BR", "Portuguese (Brazilian)"},
+        {"ro", "Romanian"},
+        {"ru", "Russian"},
+        {"es-ES", "Spanish"},
+        {"sv-SE", "Swedish"},
+        {"tr", "Turkish"},
+        {"uk", "Ukrainian"},
+    };
 
-        private static readonly Dictionary<string, string> languagesRequireFontOverride = new Dictionary<string, string>()
-        {
-            {"ja", "Japanese"},
-            {"zh-CN", "Chinese (Simplified)"},
-            {"zh-TW", "Chinese (Traditional)"},
-            {"ko", "Korean"},
-            {"tr", "Turkish"},
-        };
+    private static readonly Dictionary<string, string> languagesRequireFontOverride = new Dictionary<string, string>()
+    {
+        {"ja", "Japanese"},
+        {"zh-CN", "Chinese (Simplified)"},
+        {"zh-TW", "Chinese (Traditional)"},
+        {"ko", "Korean"},
+        {"tr", "Turkish"},
+    };
 
-        private enum EditType {
-            Workspace, Factorio, Mods
+    private enum EditType {
+        Workspace, Factorio, Mods
+    }
+
+    public WelcomeScreen(ProjectDefinition? cliProject = null) : base(ImGuiUtils.DefaultScreenPadding) {
+        tips = File.ReadAllLines("Data/Tips.txt");
+
+        IconCollection.ClearCustomIcons();
+        RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
+
+        recentProjectScroll = new ScrollArea(20f, BuildRecentProjectList, collapsible: true);
+        languageScroll = new ScrollArea(20f, LanguageSelection, collapsible: true);
+        errorScroll = new ScrollArea(20f, BuildError, collapsible: true);
+        Create("Welcome to YAFC CE v" + YafcLib.version.ToString(3), 45, null);
+
+        if (cliProject != null && !string.IsNullOrEmpty(cliProject.dataPath)) {
+            SetProject(cliProject);
+            LoadProject();
+        }
+        else {
+            ProjectDefinition? lastProject = Preferences.Instance.recentProjects.FirstOrDefault();
+            SetProject(lastProject);
+            _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
+        }
+    }
+
+    private void BuildError(ImGui gui) {
+        if (errorMod != null) {
+            gui.BuildText("Error While loading mod " + errorMod, TextBlockDisplayStyle.Centered with { Color = SchemeColor.Error });
         }
 
-        public WelcomeScreen(ProjectDefinition? cliProject = null) : base(ImGuiUtils.DefaultScreenPadding) {
-            tips = File.ReadAllLines("Data/Tips.txt");
+        gui.allocator = RectAllocator.Stretch;
+        gui.BuildText(errorMessage, TextBlockDisplayStyle.ErrorText);
+        gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
+    }
 
-            IconCollection.ClearCustomIcons();
-            RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
-
-            recentProjectScroll = new ScrollArea(20f, BuildRecentProjectList, collapsible: true);
-            languageScroll = new ScrollArea(20f, LanguageSelection, collapsible: true);
-            errorScroll = new ScrollArea(20f, BuildError, collapsible: true);
-            Create("Welcome to YAFC CE v" + YafcLib.version.ToString(3), 45, null);
-
-            if (cliProject != null && !string.IsNullOrEmpty(cliProject.dataPath)) {
-                SetProject(cliProject);
-                LoadProject();
+    protected override void BuildContents(ImGui gui) {
+        gui.spacing = 1.5f;
+        gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
+        if (loading) {
+            gui.BuildText(currentLoad1, TextBlockDisplayStyle.Centered);
+            gui.BuildText(currentLoad2, TextBlockDisplayStyle.Centered);
+            gui.AllocateSpacing(15f);
+            gui.BuildText(tip, new TextBlockDisplayStyle(WrapText: true, Alignment: RectAlignment.Middle));
+            gui.SetNextRebuild(Ui.time + 30);
+        }
+        else if (errorMessage != null) {
+            errorScroll.Build(gui);
+            using (gui.EnterRow()) {
+                gui.BuildText("This error is critical. Unable to load project.");
+                if (gui.BuildLink("More info")) {
+                    ShowDropDown(gui, gui.lastRect, ProjectErrorMoreInfo, new Padding(0.5f), 30f);
+                }
             }
-            else {
-                ProjectDefinition? lastProject = Preferences.Instance.recentProjects.FirstOrDefault();
-                SetProject(lastProject);
-                _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
+            using (gui.EnterRow()) {
+                if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
+                    _ = SDL.SDL_SetClipboardText(errorMessage);
+                }
+                if (gui.RemainingRow().BuildButton("Back")) {
+                    errorMessage = null;
+                    Rebuild();
+                }
             }
         }
+        else {
+            BuildPathSelect(gui, ref path, "Project file location", "You can leave it empty for a new project", EditType.Workspace);
+            BuildPathSelect(gui, ref dataPath, "Factorio Data location*\nIt should contain folders 'base' and 'core'",
+                "e.g. C:/Games/Steam/SteamApps/common/Factorio/data", EditType.Factorio);
+            BuildPathSelect(gui, ref modsPath, "Factorio Mods location (optional)\nIt should contain file 'mod-list.json'",
+                "If you don't use separate mod folder, leave it empty", EditType.Mods);
 
-        private void BuildError(ImGui gui) {
-            if (errorMod != null) {
-                gui.BuildText("Error While loading mod " + errorMod, TextBlockDisplayStyle.Centered with { Color = SchemeColor.Error });
+            using (gui.EnterRow()) {
+                _ = gui.BuildCheckBox("Expensive recipes", expensive, out expensive);
+                gui.allocator = RectAllocator.RightRow;
+                string lang = Preferences.Instance.language;
+                if (languageMapping.TryGetValue(Preferences.Instance.language, out string? mapped) || languagesRequireFontOverride.TryGetValue(Preferences.Instance.language, out mapped)) {
+                    lang = mapped;
+                }
+
+                if (gui.BuildLink(lang)) {
+                    gui.ShowDropDown(languageScroll.Build);
+                }
+
+                gui.BuildText("In-game objects language:");
             }
 
-            gui.allocator = RectAllocator.Stretch;
-            gui.BuildText(errorMessage, TextBlockDisplayStyle.ErrorText);
-            gui.DrawRectangle(gui.lastRect, SchemeColor.Error);
-        }
-
-        protected override void BuildContents(ImGui gui) {
-            gui.spacing = 1.5f;
-            gui.BuildText("Yet Another Factorio Calculator", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
-            if (loading) {
-                gui.BuildText(currentLoad1, TextBlockDisplayStyle.Centered);
-                gui.BuildText(currentLoad2, TextBlockDisplayStyle.Centered);
-                gui.AllocateSpacing(15f);
-                gui.BuildText(tip, new TextBlockDisplayStyle(WrapText: true, Alignment: RectAlignment.Middle));
-                gui.SetNextRebuild(Ui.time + 30);
-            }
-            else if (errorMessage != null) {
-                errorScroll.Build(gui);
-                using (gui.EnterRow()) {
-                    gui.BuildText("This error is critical. Unable to load project.");
-                    if (gui.BuildLink("More info")) {
-                        ShowDropDown(gui, gui.lastRect, ProjectErrorMoreInfo, new Padding(0.5f), 30f);
-                    }
-                }
-                using (gui.EnterRow()) {
-                    if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
-                        _ = SDL.SDL_SetClipboardText(errorMessage);
-                    }
-                    if (gui.RemainingRow().BuildButton("Back")) {
-                        errorMessage = null;
-                        Rebuild();
-                    }
-                }
-            }
-            else {
-                BuildPathSelect(gui, ref path, "Project file location", "You can leave it empty for a new project", EditType.Workspace);
-                BuildPathSelect(gui, ref dataPath, "Factorio Data location*\nIt should contain folders 'base' and 'core'",
-                    "e.g. C:/Games/Steam/SteamApps/common/Factorio/data", EditType.Factorio);
-                BuildPathSelect(gui, ref modsPath, "Factorio Mods location (optional)\nIt should contain file 'mod-list.json'",
-                    "If you don't use separate mod folder, leave it empty", EditType.Mods);
-
-                using (gui.EnterRow()) {
-                    _ = gui.BuildCheckBox("Expensive recipes", expensive, out expensive);
-                    gui.allocator = RectAllocator.RightRow;
-                    string lang = Preferences.Instance.language;
-                    if (languageMapping.TryGetValue(Preferences.Instance.language, out string? mapped) || languagesRequireFontOverride.TryGetValue(Preferences.Instance.language, out mapped)) {
-                        lang = mapped;
-                    }
-
-                    if (gui.BuildLink(lang)) {
-                        gui.ShowDropDown(languageScroll.Build);
-                    }
-
-                    gui.BuildText("In-game objects language:");
-                }
-
-                using (gui.EnterRowWithHelpIcon("""
-                        If checked, YAFC will only suggest production or consumption recipes that have a net production or consumption of that item or fluid.
-                        For example, kovarex enrichment will not be suggested when adding recipes that produce U-238 or consume U-235.
-                        """, false)) {
-                    _ = gui.BuildCheckBox("Use net production/consumption when analyzing recipes", netProduction, out netProduction);
-                }
-                using (gui.EnterRowWithHelpIcon("""
-                    If checked, the main project screen will not use hardware-accelerated rendering. 
-                    Enable this setting if YAFC crashes after loading without an error message, or if you know that your computer's graphics hardware does not support modern APIs (e.g. DirectX 12 on Windows).
+            using (gui.EnterRowWithHelpIcon("""
+                    If checked, YAFC will only suggest production or consumption recipes that have a net production or consumption of that item or fluid.
+                    For example, kovarex enrichment will not be suggested when adding recipes that produce U-238 or consume U-235.
                     """, false)) {
-                    bool forceSoftwareRenderer = Preferences.Instance.forceSoftwareRenderer;
-                    _ = gui.BuildCheckBox("Force software rendering in project screen", forceSoftwareRenderer, out forceSoftwareRenderer);
-                    if (forceSoftwareRenderer != Preferences.Instance.forceSoftwareRenderer) {
-                        Preferences.Instance.forceSoftwareRenderer = forceSoftwareRenderer;
-                        Preferences.Instance.Save();
-                    }
-                }
-
-                using (gui.EnterRow()) {
-                    if (Preferences.Instance.recentProjects.Length > 1) {
-                        if (gui.BuildButton("Recent projects", SchemeColor.Grey)) {
-                            gui.ShowDropDown(BuildRecentProjectsDropdown, 35f);
-                        }
-                    }
-                    if (gui.BuildButton(Icon.Help).WithTooltip(gui, "About YAFC")) {
-                        _ = new AboutScreen(this);
-                    }
-
-                    if (gui.BuildButton(Icon.DarkMode).WithTooltip(gui, "Toggle dark mode")) {
-                        Preferences.Instance.darkMode = !Preferences.Instance.darkMode;
-                        RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
-                        Preferences.Instance.Save();
-                    }
-                    if (gui.RemainingRow().BuildButton(createText, active: canCreate)) {
-                        LoadProject();
-                    }
-                }
+                _ = gui.BuildCheckBox("Use net production/consumption when analyzing recipes", netProduction, out netProduction);
             }
-        }
-
-        private void ProjectErrorMoreInfo(ImGui gui) {
-            gui.allocator = RectAllocator.LeftAlign;
-            gui.BuildText("Check that these mods load in Factorio", TextBlockDisplayStyle.WrappedText);
-            gui.BuildText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, you need to load those in Factorio and then close the game because Factorio writes some files only when exiting", TextBlockDisplayStyle.WrappedText);
-            gui.BuildText("Check that Factorio loads mods from the same folder as YAFC", TextBlockDisplayStyle.WrappedText);
-            gui.BuildText("If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, don't have required dependencies, or (especially) have several versions", TextBlockDisplayStyle.WrappedText);
-            if (gui.BuildLink("If that doesn't help either, create a github issue")) {
-                Ui.VisitLink(AboutScreen.Github);
-            }
-
-            gui.BuildText("For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.", TextBlockDisplayStyle.WrappedText);
-        }
-
-        private void DoLanguageList(ImGui gui, Dictionary<string, string> list, bool enabled) {
-            foreach (var (k, v) in list) {
-                if (!enabled) {
-                    gui.BuildText(v);
-                }
-                else if (gui.BuildLink(v)) {
-                    Preferences.Instance.language = k;
-                    Preferences.Instance.Save();
-                    _ = gui.CloseDropdown();
-                }
-            }
-        }
-
-        private void LanguageSelection(ImGui gui) {
-            gui.spacing = 0f;
-            gui.allocator = RectAllocator.LeftAlign;
-            gui.BuildText("Mods may not support your language, using English as a fallback.", TextBlockDisplayStyle.WrappedText);
-            gui.AllocateSpacing(0.5f);
-
-            DoLanguageList(gui, languageMapping, true);
-            if (!Program.hasOverriddenFont) {
-                gui.AllocateSpacing(0.5f);
-                gui.BuildText("To select languages with non-european glyphs you need to override used font first. Download or locate a font that has your language glyphs.", TextBlockDisplayStyle.WrappedText);
-                gui.AllocateSpacing(0.5f);
-            }
-            DoLanguageList(gui, languagesRequireFontOverride, Program.hasOverriddenFont);
-
-            gui.AllocateSpacing(0.5f);
-            if (gui.BuildButton("Select font to override")) {
-                SelectFont();
-            }
-
-            if (Preferences.Instance.overrideFont != null) {
-                gui.BuildText(Preferences.Instance.overrideFont, TextBlockDisplayStyle.WrappedText);
-                if (gui.BuildLink("Reset font to default")) {
-                    Preferences.Instance.overrideFont = null;
-                    languageScroll.RebuildContents();
+            using (gui.EnterRowWithHelpIcon("""
+                If checked, the main project screen will not use hardware-accelerated rendering.
+                Enable this setting if YAFC crashes after loading without an error message, or if you know that your computer's graphics hardware does not support modern APIs (e.g. DirectX 12 on Windows).
+                """, false)) {
+                bool forceSoftwareRenderer = Preferences.Instance.forceSoftwareRenderer;
+                _ = gui.BuildCheckBox("Force software rendering in project screen", forceSoftwareRenderer, out forceSoftwareRenderer);
+                if (forceSoftwareRenderer != Preferences.Instance.forceSoftwareRenderer) {
+                    Preferences.Instance.forceSoftwareRenderer = forceSoftwareRenderer;
                     Preferences.Instance.Save();
                 }
             }
-            gui.BuildText("Selecting font to override require YAFC restart to take effect", TextBlockDisplayStyle.WrappedText);
+
+            using (gui.EnterRow()) {
+                if (Preferences.Instance.recentProjects.Length > 1) {
+                    if (gui.BuildButton("Recent projects", SchemeColor.Grey)) {
+                        gui.ShowDropDown(BuildRecentProjectsDropdown, 35f);
+                    }
+                }
+                if (gui.BuildButton(Icon.Help).WithTooltip(gui, "About YAFC")) {
+                    _ = new AboutScreen(this);
+                }
+
+                if (gui.BuildButton(Icon.DarkMode).WithTooltip(gui, "Toggle dark mode")) {
+                    Preferences.Instance.darkMode = !Preferences.Instance.darkMode;
+                    RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
+                    Preferences.Instance.Save();
+                }
+                if (gui.RemainingRow().BuildButton(createText, active: canCreate)) {
+                    LoadProject();
+                }
+            }
+        }
+    }
+
+    private void ProjectErrorMoreInfo(ImGui gui) {
+        gui.allocator = RectAllocator.LeftAlign;
+        gui.BuildText("Check that these mods load in Factorio", TextBlockDisplayStyle.WrappedText);
+        gui.BuildText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, you need to load those in Factorio and then close the game because Factorio writes some files only when exiting", TextBlockDisplayStyle.WrappedText);
+        gui.BuildText("Check that Factorio loads mods from the same folder as YAFC", TextBlockDisplayStyle.WrappedText);
+        gui.BuildText("If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, don't have required dependencies, or (especially) have several versions", TextBlockDisplayStyle.WrappedText);
+        if (gui.BuildLink("If that doesn't help either, create a github issue")) {
+            Ui.VisitLink(AboutScreen.Github);
         }
 
-        private async void SelectFont() {
-            string? result = await new FilesystemScreen("Override font", "Override font that YAFC uses", "Ok", null, FilesystemScreen.Mode.SelectFile, null, this, null, null);
-            if (result == null) {
-                return;
-            }
+        gui.BuildText("For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.", TextBlockDisplayStyle.WrappedText);
+    }
 
-            if (SDL_ttf.TTF_OpenFont(result, 16) != IntPtr.Zero) {
-                Preferences.Instance.overrideFont = result;
+    private void DoLanguageList(ImGui gui, Dictionary<string, string> list, bool enabled) {
+        foreach (var (k, v) in list) {
+            if (!enabled) {
+                gui.BuildText(v);
+            }
+            else if (gui.BuildLink(v)) {
+                Preferences.Instance.language = k;
+                Preferences.Instance.Save();
+                _ = gui.CloseDropdown();
+            }
+        }
+    }
+
+    private void LanguageSelection(ImGui gui) {
+        gui.spacing = 0f;
+        gui.allocator = RectAllocator.LeftAlign;
+        gui.BuildText("Mods may not support your language, using English as a fallback.", TextBlockDisplayStyle.WrappedText);
+        gui.AllocateSpacing(0.5f);
+
+        DoLanguageList(gui, languageMapping, true);
+        if (!Program.hasOverriddenFont) {
+            gui.AllocateSpacing(0.5f);
+            gui.BuildText("To select languages with non-european glyphs you need to override used font first. Download or locate a font that has your language glyphs.", TextBlockDisplayStyle.WrappedText);
+            gui.AllocateSpacing(0.5f);
+        }
+        DoLanguageList(gui, languagesRequireFontOverride, Program.hasOverriddenFont);
+
+        gui.AllocateSpacing(0.5f);
+        if (gui.BuildButton("Select font to override")) {
+            SelectFont();
+        }
+
+        if (Preferences.Instance.overrideFont != null) {
+            gui.BuildText(Preferences.Instance.overrideFont, TextBlockDisplayStyle.WrappedText);
+            if (gui.BuildLink("Reset font to default")) {
+                Preferences.Instance.overrideFont = null;
                 languageScroll.RebuildContents();
                 Preferences.Instance.Save();
             }
         }
+        gui.BuildText("Selecting font to override require YAFC restart to take effect", TextBlockDisplayStyle.WrappedText);
+    }
 
-        public void Report((string, string) value) => (currentLoad1, currentLoad2) = value;
-
-        private bool FactorioValid(string factorio) => !string.IsNullOrEmpty(factorio) && Directory.Exists(Path.Combine(factorio, "core"));
-
-        private bool ModsValid(string mods) => string.IsNullOrEmpty(mods) || File.Exists(Path.Combine(mods, "mod-list.json"));
-
-        [MemberNotNull(nameof(createText))]
-        private void ValidateSelection() {
-            bool factorioValid = FactorioValid(dataPath);
-            bool modsValid = ModsValid(modsPath);
-            bool projectExists = File.Exists(path);
-
-            if (projectExists) {
-                createText = "Load '" + Path.GetFileNameWithoutExtension(path) + "'";
-            }
-            else if (path != "") {
-                string? directory = Path.GetDirectoryName(path);
-                if (!Directory.Exists(directory)) {
-                    createText = "Project directory does not exist";
-                    canCreate = false;
-                    return;
-                }
-                createText = "Create '" + Path.GetFileNameWithoutExtension(path) + "'";
-            }
-            else {
-                createText = "Create new project";
-            }
-
-            canCreate = factorioValid && modsValid;
+    private async void SelectFont() {
+        string? result = await new FilesystemScreen("Override font", "Override font that YAFC uses", "Ok", null, FilesystemScreen.Mode.SelectFile, null, this, null, null);
+        if (result == null) {
+            return;
         }
 
-        private void BuildPathSelect(ImGui gui, ref string path, string description, string placeholder, EditType editType) {
-            gui.BuildText(description, TextBlockDisplayStyle.WrappedText);
-            gui.spacing = 0.5f;
-            using (gui.EnterGroup(default, RectAllocator.RightRow)) {
-                if (gui.BuildButton("...")) {
-                    ShowFileSelect(description, path, editType);
-                }
+        if (SDL_ttf.TTF_OpenFont(result, 16) != IntPtr.Zero) {
+            Preferences.Instance.overrideFont = result;
+            languageScroll.RebuildContents();
+            Preferences.Instance.Save();
+        }
+    }
 
-                if (gui.RemainingRow(0f).BuildTextInput(path, out path, placeholder)) {
-                    ValidateSelection();
-                }
+    public void Report((string, string) value) => (currentLoad1, currentLoad2) = value;
+
+    private bool FactorioValid(string factorio) => !string.IsNullOrEmpty(factorio) && Directory.Exists(Path.Combine(factorio, "core"));
+
+    private bool ModsValid(string mods) => string.IsNullOrEmpty(mods) || File.Exists(Path.Combine(mods, "mod-list.json"));
+
+    [MemberNotNull(nameof(createText))]
+    private void ValidateSelection() {
+        bool factorioValid = FactorioValid(dataPath);
+        bool modsValid = ModsValid(modsPath);
+        bool projectExists = File.Exists(path);
+
+        if (projectExists) {
+            createText = "Load '" + Path.GetFileNameWithoutExtension(path) + "'";
+        }
+        else if (path != "") {
+            string? directory = Path.GetDirectoryName(path);
+            if (!Directory.Exists(directory)) {
+                createText = "Project directory does not exist";
+                canCreate = false;
+                return;
             }
-            gui.spacing = 1.5f;
+            createText = "Create '" + Path.GetFileNameWithoutExtension(path) + "'";
+        }
+        else {
+            createText = "Create new project";
         }
 
-        /// <summary>
-        /// Initializes different input fields with the supplied project definition. <br/>
-        /// If the project is null, the fields are cleared. <br/>
-        /// If the user is on Windows, it also tries to infer the installation directory of Factorio.
-        /// </summary>
-        /// <param name="project">A project definition with paths and options. Can be null.</param>
-        [MemberNotNull(nameof(createText))]
-        private void SetProject(ProjectDefinition? project) {
-            if (project != null) {
-                dataPath = project.dataPath;
-                modsPath = project.modsPath;
-                path = project.path;
-                expensive = project.expensive;
-                netProduction = project.netProduction;
-            }
-            else {
-                dataPath = "";
-                modsPath = "";
-                path = "";
-                expensive = false;
-                netProduction = false;
+        canCreate = factorioValid && modsValid;
+    }
+
+    private void BuildPathSelect(ImGui gui, ref string path, string description, string placeholder, EditType editType) {
+        gui.BuildText(description, TextBlockDisplayStyle.WrappedText);
+        gui.spacing = 0.5f;
+        using (gui.EnterGroup(default, RectAllocator.RightRow)) {
+            if (gui.BuildButton("...")) {
+                ShowFileSelect(description, path, editType);
             }
 
-            if (dataPath == "" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                string possibleDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/steamApps/common/Factorio/data");
-                if (FactorioValid(possibleDataPath)) {
-                    dataPath = possibleDataPath;
-                }
-            }
-
-            ValidateSelection();
-            rootGui.Rebuild();
-        }
-
-        private async void LoadProject() {
-            try {
-                // TODO (shpaass/yafc-ce/issues/249): Why does WelcomeScreen.cs need the internals of ProjectDefinition?
-                // Why not take or copy the whole object? The parts are used only in WelcomeScreen.cs, so I see no reason
-                // to disassemble ProjectDefinition and drag it piece by piece.
-                var (dataPath, modsPath, projectPath, expensiveRecipes) = (this.dataPath, this.modsPath, path, expensive);
-                Preferences.Instance.AddProject(dataPath, modsPath, projectPath, expensiveRecipes, netProduction);
-                Preferences.Instance.Save();
-                tip = tips.Length > 0 ? tips[DataUtils.random.Next(tips.Length)] : "";
-
-                loading = true;
-                rootGui.Rebuild();
-
-                await Ui.ExitMainThread();
-
-                ErrorCollector collector = new ErrorCollector();
-                var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, netProduction, this, collector, Preferences.Instance.language);
-
-                await Ui.EnterMainThread();
-                logger.Information("Opening main screen");
-                _ = new MainScreen(displayIndex, project);
-
-                if (collector.severity > ErrorSeverity.None) {
-                    ErrorListPanel.Show(collector);
-                }
-
-                Close();
-                GC.Collect();
-                logger.Information("GC: {TotalMemory}", GC.GetTotalMemory(false));
-            }
-            catch (Exception ex) {
-                await Ui.EnterMainThread();
-                while (ex.InnerException != null) {
-                    ex = ex.InnerException;
-                }
-
-                errorMod = FactorioDataSource.currentLoadingMod;
-                if (ex is LuaException lua) {
-                    errorMessage = lua.Message;
-                }
-                else {
-                    errorMessage = ex.Message + "\n" + ex.StackTrace;
-                }
-            }
-            finally {
-                loading = false;
-                rootGui.Rebuild();
-            }
-        }
-
-        private Func<string, bool>? GetFolderFilter(EditType type) => type switch {
-            EditType.Mods => ModsValid,
-            EditType.Factorio => FactorioValid,
-            _ => null,
-        };
-
-        private async void ShowFileSelect(string description, string path, EditType type) {
-            string? result = await new FilesystemScreen("Select folder", description, type == EditType.Workspace ? "Select" : "Select folder", type == EditType.Workspace ? Path.GetDirectoryName(path) : path,
-                type == EditType.Workspace ? FilesystemScreen.Mode.SelectOrCreateFile : FilesystemScreen.Mode.SelectFolder, "", this, GetFolderFilter(type),
-                type == EditType.Workspace ? "yafc" : null);
-            if (result != null) {
-                if (type == EditType.Factorio) {
-                    dataPath = result;
-                }
-                else if (type == EditType.Mods) {
-                    modsPath = result;
-                }
-                else {
-                    this.path = result;
-                }
-
-                Rebuild();
+            if (gui.RemainingRow(0f).BuildTextInput(path, out path, placeholder)) {
                 ValidateSelection();
             }
         }
-
-        private void BuildRecentProjectsDropdown(ImGui gui) => recentProjectScroll.Build(gui);
-
-        private void BuildRecentProjectList(ImGui gui) {
-            gui.spacing = 0f;
-            foreach (var project in Preferences.Instance.recentProjects) {
-                if (string.IsNullOrEmpty(project.path)) {
-                    continue;
-                }
-
-                using (gui.EnterGroup(new Padding(0.5f, 0.25f), RectAllocator.LeftRow)) {
-                    gui.BuildIcon(Icon.Settings);
-                    gui.RemainingRow(0.5f).BuildText(project.path);
-                }
-
-                if (gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey)) {
-                    WelcomeScreen owner = (WelcomeScreen)gui.window!; // null-forgiving: gui.window has been set earlier in the render loop.
-                    owner.SetProject(project);
-                    _ = gui.CloseDropdown();
-                }
-            }
-        }
-
-        public bool KeyDown(SDL.SDL_Keysym key) {
-            if (canCreate && key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
-                LoadProject();
-                return true;
-            }
-            return false;
-        }
-        public bool TextInput(string input) => false;
-        public bool KeyUp(SDL.SDL_Keysym key) => false;
-        public void FocusChanged(bool focused) { }
+        gui.spacing = 1.5f;
     }
+
+    /// <summary>
+    /// Initializes different input fields with the supplied project definition. <br/>
+    /// If the project is null, the fields are cleared. <br/>
+    /// If the user is on Windows, it also tries to infer the installation directory of Factorio.
+    /// </summary>
+    /// <param name="project">A project definition with paths and options. Can be null.</param>
+    [MemberNotNull(nameof(createText))]
+    private void SetProject(ProjectDefinition? project) {
+        if (project != null) {
+            dataPath = project.dataPath;
+            modsPath = project.modsPath;
+            path = project.path;
+            expensive = project.expensive;
+            netProduction = project.netProduction;
+        }
+        else {
+            dataPath = "";
+            modsPath = "";
+            path = "";
+            expensive = false;
+            netProduction = false;
+        }
+
+        if (dataPath == "" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            string possibleDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/steamApps/common/Factorio/data");
+            if (FactorioValid(possibleDataPath)) {
+                dataPath = possibleDataPath;
+            }
+        }
+
+        ValidateSelection();
+        rootGui.Rebuild();
+    }
+
+    private async void LoadProject() {
+        try {
+            // TODO (shpaass/yafc-ce/issues/249): Why does WelcomeScreen.cs need the internals of ProjectDefinition?
+            // Why not take or copy the whole object? The parts are used only in WelcomeScreen.cs, so I see no reason
+            // to disassemble ProjectDefinition and drag it piece by piece.
+            var (dataPath, modsPath, projectPath, expensiveRecipes) = (this.dataPath, this.modsPath, path, expensive);
+            Preferences.Instance.AddProject(dataPath, modsPath, projectPath, expensiveRecipes, netProduction);
+            Preferences.Instance.Save();
+            tip = tips.Length > 0 ? tips[DataUtils.random.Next(tips.Length)] : "";
+
+            loading = true;
+            rootGui.Rebuild();
+
+            await Ui.ExitMainThread();
+
+            ErrorCollector collector = new ErrorCollector();
+            var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, netProduction, this, collector, Preferences.Instance.language);
+
+            await Ui.EnterMainThread();
+            logger.Information("Opening main screen");
+            _ = new MainScreen(displayIndex, project);
+
+            if (collector.severity > ErrorSeverity.None) {
+                ErrorListPanel.Show(collector);
+            }
+
+            Close();
+            GC.Collect();
+            logger.Information("GC: {TotalMemory}", GC.GetTotalMemory(false));
+        }
+        catch (Exception ex) {
+            await Ui.EnterMainThread();
+            while (ex.InnerException != null) {
+                ex = ex.InnerException;
+            }
+
+            errorMod = FactorioDataSource.currentLoadingMod;
+            if (ex is LuaException lua) {
+                errorMessage = lua.Message;
+            }
+            else {
+                errorMessage = ex.Message + "\n" + ex.StackTrace;
+            }
+        }
+        finally {
+            loading = false;
+            rootGui.Rebuild();
+        }
+    }
+
+    private Func<string, bool>? GetFolderFilter(EditType type) => type switch {
+        EditType.Mods => ModsValid,
+        EditType.Factorio => FactorioValid,
+        _ => null,
+    };
+
+    private async void ShowFileSelect(string description, string path, EditType type) {
+        string? result = await new FilesystemScreen("Select folder", description, type == EditType.Workspace ? "Select" : "Select folder", type == EditType.Workspace ? Path.GetDirectoryName(path) : path,
+            type == EditType.Workspace ? FilesystemScreen.Mode.SelectOrCreateFile : FilesystemScreen.Mode.SelectFolder, "", this, GetFolderFilter(type),
+            type == EditType.Workspace ? "yafc" : null);
+        if (result != null) {
+            if (type == EditType.Factorio) {
+                dataPath = result;
+            }
+            else if (type == EditType.Mods) {
+                modsPath = result;
+            }
+            else {
+                this.path = result;
+            }
+
+            Rebuild();
+            ValidateSelection();
+        }
+    }
+
+    private void BuildRecentProjectsDropdown(ImGui gui) => recentProjectScroll.Build(gui);
+
+    private void BuildRecentProjectList(ImGui gui) {
+        gui.spacing = 0f;
+        foreach (var project in Preferences.Instance.recentProjects) {
+            if (string.IsNullOrEmpty(project.path)) {
+                continue;
+            }
+
+            using (gui.EnterGroup(new Padding(0.5f, 0.25f), RectAllocator.LeftRow)) {
+                gui.BuildIcon(Icon.Settings);
+                gui.RemainingRow(0.5f).BuildText(project.path);
+            }
+
+            if (gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey)) {
+                WelcomeScreen owner = (WelcomeScreen)gui.window!; // null-forgiving: gui.window has been set earlier in the render loop.
+                owner.SetProject(project);
+                _ = gui.CloseDropdown();
+            }
+        }
+    }
+
+    public bool KeyDown(SDL.SDL_Keysym key) {
+        if (canCreate && key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
+            LoadProject();
+            return true;
+        }
+        return false;
+    }
+    public bool TextInput(string input) => false;
+    public bool KeyUp(SDL.SDL_Keysym key) => false;
+    public void FocusChanged(bool focused) { }
 }

--- a/Yafc/Windows/WizardPanel.cs
+++ b/Yafc/Windows/WizardPanel.cs
@@ -4,49 +4,48 @@ using Yafc.UI;
 
 #nullable disable warnings // Disabling nullable for legacy code.
 
-namespace Yafc {
-    public class WizardPanel : PseudoScreen {
-        public static readonly WizardPanel Instance = new WizardPanel();
+namespace Yafc;
+public class WizardPanel : PseudoScreen {
+    public static readonly WizardPanel Instance = new WizardPanel();
 
-        private readonly List<PageBuilder> pages = [];
-        private string? header;
-        private Action? finish;
-        private int page;
+    private readonly List<PageBuilder> pages = [];
+    private string? header;
+    private Action? finish;
+    private int page;
 
-        public delegate void PageBuilder(ImGui gui, ref bool valid);
-        public delegate Action WizardBuilder(List<PageBuilder> pages);
+    public delegate void PageBuilder(ImGui gui, ref bool valid);
+    public delegate Action WizardBuilder(List<PageBuilder> pages);
 
-        public static void Show(string header, WizardBuilder builder) {
-            Instance.pages.Clear();
-            Instance.finish = builder(Instance.pages);
-            Instance.header = header;
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-        }
+    public static void Show(string header, WizardBuilder builder) {
+        Instance.pages.Clear();
+        Instance.finish = builder(Instance.pages);
+        Instance.header = header;
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
 
-        public override void Open() {
-            page = 0;
-            base.Open();
-        }
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, header);
-            bool valid = true;
-            pages[page](gui, ref valid);
-            using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
-                if (gui.BuildButton(page >= pages.Count - 1 ? "Finish" : "Next", active: valid)) {
-                    if (page < pages.Count - 1) {
-                        page++;
-                    }
-                    else {
-                        Close();
-                        finish();
-                    }
+    public override void Open() {
+        page = 0;
+        base.Open();
+    }
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, header);
+        bool valid = true;
+        pages[page](gui, ref valid);
+        using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
+            if (gui.BuildButton(page >= pages.Count - 1 ? "Finish" : "Next", active: valid)) {
+                if (page < pages.Count - 1) {
+                    page++;
                 }
-                if (page > 0 && gui.BuildButton("Previous")) {
-                    page--;
+                else {
+                    Close();
+                    finish();
                 }
-
-                gui.BuildText("Step " + (page + 1) + " of " + pages.Count);
             }
+            if (page > 0 && gui.BuildButton("Previous")) {
+                page--;
+            }
+
+            gui.BuildText("Step " + (page + 1) + " of " + pages.Count);
         }
     }
 }

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -5,106 +5,105 @@ using Yafc.UI;
 
 #nullable disable warnings // Disabling nullable for legacy code.
 
-namespace Yafc {
-    public class AutoPlannerView : ProjectPageView<AutoPlanner> {
-        private AutoPlannerRecipe selectedRecipe;
+namespace Yafc;
+public class AutoPlannerView : ProjectPageView<AutoPlanner> {
+    private AutoPlannerRecipe selectedRecipe;
 
-        public override void SetModel(ProjectPage? page) {
-            base.SetModel(page);
-            selectedRecipe = null;
-        }
-
-        protected override void BuildPageTooltip(ImGui gui, AutoPlanner contents) {
-            using var grid = gui.EnterInlineGrid(3f, 1f);
-            foreach (var goal in contents.goals) {
-                grid.Next();
-                _ = gui.BuildFactorioObjectWithAmount(goal.item, new(goal.amount, goal.item.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableUnscaled);
-            }
-        }
-
-        private Action CreateAutoPlannerWizard(List<WizardPanel.PageBuilder> pages) {
-            List<AutoPlannerGoal> goal = [];
-            string pageName = "Auto planner";
-
-            void Page1(ImGui gui, ref bool valid) {
-                gui.BuildText("This is an experimental feature and may lack functionality. Unfortunately, after some prototyping it wasn't very useful to work with. More research required.", TextBlockDisplayStyle.ErrorText);
-                gui.BuildText("Enter page name:");
-                _ = gui.BuildTextInput(pageName, out pageName, null);
-                gui.AllocateSpacing(2f);
-                gui.BuildText("Select your goal:");
-                using (var grid = gui.EnterInlineGrid(3f)) {
-                    for (int i = 0; i < goal.Count; i++) {
-                        var elem = goal[i];
-                        grid.Next();
-                        DisplayAmount amount = new(elem.amount, elem.item.flowUnitOfMeasure);
-                        if (gui.BuildFactorioObjectWithEditableAmount(elem.item, amount, ButtonDisplayStyle.ProductionTableUnscaled) == GoodsWithAmountEvent.TextEditing) {
-                            if (amount.Value != 0f) {
-                                elem.amount = amount.Value;
-                            }
-                            else {
-                                goal.RemoveAt(i--);
-                            }
-                        }
-                    }
-                    grid.Next();
-                    if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-                        SelectSingleObjectPanel.Select(Database.goods.all, "New production goal", x => {
-                            goal.Add(new AutoPlannerGoal { amount = 1f, item = x });
-                            gui.Rebuild();
-                        });
-                    }
-                    grid.Next();
-                }
-                gui.AllocateSpacing(2f);
-                gui.BuildText("Review active milestones, as they will restrict recipes that are considered:", TextBlockDisplayStyle.WrappedText);
-                new MilestonesWidget().Build(gui);
-                gui.AllocateSpacing(2f);
-                valid = !string.IsNullOrEmpty(pageName) && goal.Count > 0;
-            }
-
-            pages.Add(Page1);
-            return () => {
-                var planner = MainScreen.Instance.AddProjectPage("Auto planner", goal[0].item, typeof(AutoPlanner), false, false);
-                (planner.content as AutoPlanner).goals.AddRange(goal);
-                MainScreen.Instance.SetActivePage(planner);
-            };
-        }
-
-        protected override void BuildContent(ImGui gui) {
-            if (model == null) {
-                return;
-            }
-
-            if (model.tiers == null) {
-                return;
-            }
-
-            foreach (var tier in model.tiers) {
-                using var grid = gui.EnterInlineGrid(3f);
-                foreach (var recipe in tier) {
-                    var color = SchemeColor.None;
-                    if (gui.isBuilding) {
-                        if (selectedRecipe != null && ((selectedRecipe.downstream != null && selectedRecipe.downstream.Contains(recipe.recipe)) ||
-                                                       (selectedRecipe.upstream != null && selectedRecipe.upstream.Contains(recipe.recipe)))) {
-                            color = SchemeColor.Secondary;
-                        }
-                    }
-                    grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, new(recipe.recipesPerSecond, UnitOfMeasure.PerSecond), ButtonDisplayStyle.ProductionTableScaled(color)) == Click.Left) {
-                        selectedRecipe = recipe;
-                    }
-                }
-            }
-        }
-
-        /*
-        public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
-            if (gui.BuildContextMenuButton("Auto planner (Alpha)"))
-            {
-                close = true;
-                WizardPanel.Show("New auto planner", CreateAutoPlannerWizard);
-            }
-        }
-        */
+    public override void SetModel(ProjectPage? page) {
+        base.SetModel(page);
+        selectedRecipe = null;
     }
+
+    protected override void BuildPageTooltip(ImGui gui, AutoPlanner contents) {
+        using var grid = gui.EnterInlineGrid(3f, 1f);
+        foreach (var goal in contents.goals) {
+            grid.Next();
+            _ = gui.BuildFactorioObjectWithAmount(goal.item, new(goal.amount, goal.item.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableUnscaled);
+        }
+    }
+
+    private Action CreateAutoPlannerWizard(List<WizardPanel.PageBuilder> pages) {
+        List<AutoPlannerGoal> goal = [];
+        string pageName = "Auto planner";
+
+        void Page1(ImGui gui, ref bool valid) {
+            gui.BuildText("This is an experimental feature and may lack functionality. Unfortunately, after some prototyping it wasn't very useful to work with. More research required.", TextBlockDisplayStyle.ErrorText);
+            gui.BuildText("Enter page name:");
+            _ = gui.BuildTextInput(pageName, out pageName, null);
+            gui.AllocateSpacing(2f);
+            gui.BuildText("Select your goal:");
+            using (var grid = gui.EnterInlineGrid(3f)) {
+                for (int i = 0; i < goal.Count; i++) {
+                    var elem = goal[i];
+                    grid.Next();
+                    DisplayAmount amount = new(elem.amount, elem.item.flowUnitOfMeasure);
+                    if (gui.BuildFactorioObjectWithEditableAmount(elem.item, amount, ButtonDisplayStyle.ProductionTableUnscaled) == GoodsWithAmountEvent.TextEditing) {
+                        if (amount.Value != 0f) {
+                            elem.amount = amount.Value;
+                        }
+                        else {
+                            goal.RemoveAt(i--);
+                        }
+                    }
+                }
+                grid.Next();
+                if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
+                    SelectSingleObjectPanel.Select(Database.goods.all, "New production goal", x => {
+                        goal.Add(new AutoPlannerGoal { amount = 1f, item = x });
+                        gui.Rebuild();
+                    });
+                }
+                grid.Next();
+            }
+            gui.AllocateSpacing(2f);
+            gui.BuildText("Review active milestones, as they will restrict recipes that are considered:", TextBlockDisplayStyle.WrappedText);
+            new MilestonesWidget().Build(gui);
+            gui.AllocateSpacing(2f);
+            valid = !string.IsNullOrEmpty(pageName) && goal.Count > 0;
+        }
+
+        pages.Add(Page1);
+        return () => {
+            var planner = MainScreen.Instance.AddProjectPage("Auto planner", goal[0].item, typeof(AutoPlanner), false, false);
+            (planner.content as AutoPlanner).goals.AddRange(goal);
+            MainScreen.Instance.SetActivePage(planner);
+        };
+    }
+
+    protected override void BuildContent(ImGui gui) {
+        if (model == null) {
+            return;
+        }
+
+        if (model.tiers == null) {
+            return;
+        }
+
+        foreach (var tier in model.tiers) {
+            using var grid = gui.EnterInlineGrid(3f);
+            foreach (var recipe in tier) {
+                var color = SchemeColor.None;
+                if (gui.isBuilding) {
+                    if (selectedRecipe != null && ((selectedRecipe.downstream != null && selectedRecipe.downstream.Contains(recipe.recipe)) ||
+                                                   (selectedRecipe.upstream != null && selectedRecipe.upstream.Contains(recipe.recipe)))) {
+                        color = SchemeColor.Secondary;
+                    }
+                }
+                grid.Next();
+                if (gui.BuildFactorioObjectWithAmount(recipe.recipe, new(recipe.recipesPerSecond, UnitOfMeasure.PerSecond), ButtonDisplayStyle.ProductionTableScaled(color)) == Click.Left) {
+                    selectedRecipe = recipe;
+                }
+            }
+        }
+    }
+
+    /*
+    public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
+        if (gui.BuildContextMenuButton("Auto planner (Alpha)"))
+        {
+            close = true;
+            WizardPanel.Show("New auto planner", CreateAutoPlannerWizard);
+        }
+    }
+    */
 }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -1,318 +1,316 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
-        private readonly DataGrid<ProductionSummaryEntry> grid;
-        private readonly FlatHierarchy<ProductionSummaryEntry, ProductionSummaryGroup> flatHierarchy;
-        private Goods? filteredGoods;
-        private readonly Dictionary<ProductionSummaryColumn, GoodsColumn> goodsToColumn = [];
-        private readonly PaddingColumn padding;
-        private readonly SummaryColumn firstColumn;
-        private readonly RestGoodsColumn lastColumn;
+namespace Yafc;
+public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
+    private readonly DataGrid<ProductionSummaryEntry> grid;
+    private readonly FlatHierarchy<ProductionSummaryEntry, ProductionSummaryGroup> flatHierarchy;
+    private Goods? filteredGoods;
+    private readonly Dictionary<ProductionSummaryColumn, GoodsColumn> goodsToColumn = [];
+    private readonly PaddingColumn padding;
+    private readonly SummaryColumn firstColumn;
+    private readonly RestGoodsColumn lastColumn;
 
-        public ProductionSummaryView() {
-            padding = new PaddingColumn(this);
-            firstColumn = new SummaryColumn(this);
-            lastColumn = new RestGoodsColumn(this);
-            grid = new DataGrid<ProductionSummaryEntry>(padding, firstColumn, lastColumn) { headerHeight = 4.2f };
-            flatHierarchy = new FlatHierarchy<ProductionSummaryEntry, ProductionSummaryGroup>(grid, null, buildExpandedGroupRows: true);
-        }
+    public ProductionSummaryView() {
+        padding = new PaddingColumn(this);
+        firstColumn = new SummaryColumn(this);
+        lastColumn = new RestGoodsColumn(this);
+        grid = new DataGrid<ProductionSummaryEntry>(padding, firstColumn, lastColumn) { headerHeight = 4.2f };
+        flatHierarchy = new FlatHierarchy<ProductionSummaryEntry, ProductionSummaryGroup>(grid, null, buildExpandedGroupRows: true);
+    }
 
-        private class PaddingColumn : DataColumn<ProductionSummaryEntry> {
-            private readonly ProductionSummaryView view;
+    private class PaddingColumn : DataColumn<ProductionSummaryEntry> {
+        private readonly ProductionSummaryView view;
 
-            public PaddingColumn(ProductionSummaryView view) : base(3f) => this.view = view;
+        public PaddingColumn(ProductionSummaryView view) : base(3f) => this.view = view;
 
-            public override void BuildHeader(ImGui gui) { }
+        public override void BuildHeader(ImGui gui) { }
 
-            public override void BuildElement(ImGui gui, ProductionSummaryEntry row) {
-                gui.allocator = RectAllocator.Center;
-                gui.spacing = 0f;
-                if (row.subgroup != null) {
-                    if (gui.BuildButton(row.subgroup.expanded ? Icon.ShevronDown : Icon.ShevronRight)) {
-                        row.subgroup.RecordChange().expanded = !row.subgroup.expanded;
-                        view.flatHierarchy.SetData(view.model.group);
-                    }
+        public override void BuildElement(ImGui gui, ProductionSummaryEntry row) {
+            gui.allocator = RectAllocator.Center;
+            gui.spacing = 0f;
+            if (row.subgroup != null) {
+                if (gui.BuildButton(row.subgroup.expanded ? Icon.ShevronDown : Icon.ShevronRight)) {
+                    row.subgroup.RecordChange().expanded = !row.subgroup.expanded;
+                    view.flatHierarchy.SetData(view.model.group);
                 }
             }
         }
+    }
 
-        private class SummaryColumn(ProductionSummaryView view) : DataColumn<ProductionSummaryEntry>(20f, 10f, 30f) {
-            private readonly ProductionSummaryView view = view;
-            private SearchQuery productionTableSearchQuery;
+    private class SummaryColumn(ProductionSummaryView view) : DataColumn<ProductionSummaryEntry>(20f, 10f, 30f) {
+        private readonly ProductionSummaryView view = view;
+        private SearchQuery productionTableSearchQuery;
 
-            public override void BuildHeader(ImGui gui) => BuildButtons(gui, 2f, view.model.group);
+        public override void BuildHeader(ImGui gui) => BuildButtons(gui, 2f, view.model.group);
 
-            private void BuildButtons(ImGui gui, float size, ProductionSummaryGroup group) {
-                using (gui.EnterRow()) {
-                    if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, SchemeColor.PrimaryAlt, size)) {
-                        SearchableList<ProjectPage> pagesDropdown = new(30f, new Vector2(20f, 2f), PagesDropdownDrawer(group), PagesDropdownFilter) {
-                            data = Project.current.pages.Where(x => x.content is ProductionTable).ToArray(),
-                            filter = productionTableSearchQuery = new SearchQuery()
-                        };
-                        gui.ShowDropDown(AddProductionTableDropdown(pagesDropdown));
-                    }
-
-                    if (gui.BuildButton(Icon.Folder, SchemeColor.Primary, SchemeColor.PrimaryAlt, SchemeColor.PrimaryAlt, size)) {
-                        ProductionSummaryEntry entry = new ProductionSummaryEntry(group);
-                        entry.subgroup = new ProductionSummaryGroup(entry);
-                        group.RecordUndo().elements.Add(entry);
-                    }
-                }
-            }
-
-            private GuiBuilder AddProductionTableDropdown(SearchableList<ProjectPage> pagesDropdown) => gui => {
-                using (gui.EnterGroup(new Padding(1f))) {
-                    if (gui.BuildSearchBox(productionTableSearchQuery, out productionTableSearchQuery)) {
-                        pagesDropdown.filter = productionTableSearchQuery;
-                    }
-                }
-                pagesDropdown.Build(gui);
-            };
-
-            public override void BuildElement(ImGui gui, ProductionSummaryEntry entry) {
-                gui.allocator = RectAllocator.LeftAlign;
-
-                if (entry.subgroup != null) {
-                    if (entry.subgroup.expanded) {
-                        BuildButtons(gui, 1.5f, entry.subgroup);
-                    }
-                    else {
-                        if (gui.BuildTextInput(entry.subgroup.name, out string newText, "Group name", delayed: true)) {
-                            entry.subgroup.RecordUndo().name = newText;
-                        }
-                    }
-                }
-                else if (entry.page != null) { // The constructor should have thrown if this check fails, but it helps the nullability analysis
-                    using (gui.EnterGroup(new Padding(0.3f), RectAllocator.LeftRow, SchemeColor.None, 0.2f)) {
-                        var icon = entry.icon;
-                        if (icon != Icon.None) {
-                            gui.BuildIcon(entry.icon);
-                        }
-
-                        gui.BuildText(entry.name);
-                    }
-
-                    var buttonEvent = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt);
-                    if (buttonEvent == ButtonEvent.MouseOver) {
-                        MainScreen.Instance.ShowTooltip(gui, entry.page.page, false, gui.lastRect);
-                    }
-                    else if (buttonEvent == ButtonEvent.Click) {
-                        gui.ShowDropDown(dropdownGui => {
-                            if (dropdownGui.BuildButton("Go to page") && dropdownGui.CloseDropdown()) {
-                                MainScreen.Instance.SetActivePage(entry.page.page);
-                            }
-
-                            if (dropdownGui.BuildRedButton("Remove") && dropdownGui.CloseDropdown()) {
-                                _ = entry.owner.RecordUndo().elements.Remove(entry);
-                            }
-                        });
-                    }
+        private void BuildButtons(ImGui gui, float size, ProductionSummaryGroup group) {
+            using (gui.EnterRow()) {
+                if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, SchemeColor.PrimaryAlt, size)) {
+                    SearchableList<ProjectPage> pagesDropdown = new(30f, new Vector2(20f, 2f), PagesDropdownDrawer(group), PagesDropdownFilter) {
+                        data = Project.current.pages.Where(x => x.content is ProductionTable).ToArray(),
+                        filter = productionTableSearchQuery = new SearchQuery()
+                    };
+                    gui.ShowDropDown(AddProductionTableDropdown(pagesDropdown));
                 }
 
-                using (gui.EnterFixedPositioning(3f, 2f, default)) {
-                    gui.allocator = RectAllocator.LeftRow;
-                    gui.BuildText("x");
-                    DisplayAmount amount = entry.multiplier;
-                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey, Alignment = RectAlignment.MiddleLeft }) && amount.Value >= 0) {
-                        entry.SetMultiplier(amount.Value);
-                    }
-                }
-            }
-
-            private bool PagesDropdownFilter(ProjectPage data, SearchQuery searchTokens) => searchTokens.Match(data.name);
-
-            private static VirtualScrollList<ProjectPage>.Drawer PagesDropdownDrawer(ProductionSummaryGroup group) => (gui, element, _) => {
-                using (gui.EnterGroup(new Padding(1f, 0.25f), RectAllocator.LeftRow)) {
-                    if (element.icon != null) {
-                        gui.BuildIcon(element.icon.icon);
-                    }
-
-                    gui.RemainingRow().BuildText(element.name, TextBlockDisplayStyle.Default(element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint));
-                }
-
-                if (gui.BuildButton(gui.lastRect, SchemeColor.BackgroundAlt, SchemeColor.Background)) {
-                    group.RecordUndo().elements.Add(new ProductionSummaryEntry(group) { page = new PageReference(element) });
-                }
-            };
-        }
-
-        protected override void ModelContentsChanged(bool visualOnly) {
-            base.ModelContentsChanged(visualOnly);
-            RebuildColumns();
-        }
-
-        private class GoodsColumn : DataColumn<ProductionSummaryEntry> {
-            public readonly ProductionSummaryColumn column;
-            private readonly ProductionSummaryView view;
-            public Goods goods => column.goods;
-
-            public GoodsColumn(ProductionSummaryColumn column, ProductionSummaryView view) : base(4f) {
-                this.column = column;
-                this.view = view;
-            }
-
-            public override void BuildHeader(ImGui gui) {
-                var moveHandle = gui.statePosition;
-                moveHandle.Height = 5f;
-
-                if (gui.BuildFactorioObjectWithAmount(goods, new(view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
-                    view.ApplyFilter(goods);
-                }
-
-                if (!gui.InitiateDrag(moveHandle, moveHandle, column) && gui.ConsumeDrag(moveHandle.Center, column) && gui.GetDraggingObject<ProductionSummaryColumn>() is ProductionSummaryColumn draggingColumn) {
-                    view.model.RecordUndo(true).columns.MoveListElement(draggingColumn, column);
-                    view.RebuildColumns();
-                }
-            }
-
-            public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
-                float amount = data.GetAmount(goods);
-                if (amount != 0) {
-                    if (gui.BuildFactorioObjectWithAmount(goods, new(data.GetAmount(goods), goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
-                        view.ApplyFilter(goods);
-                    }
+                if (gui.BuildButton(Icon.Folder, SchemeColor.Primary, SchemeColor.PrimaryAlt, SchemeColor.PrimaryAlt, size)) {
+                    ProductionSummaryEntry entry = new ProductionSummaryEntry(group);
+                    entry.subgroup = new ProductionSummaryGroup(entry);
+                    group.RecordUndo().elements.Add(entry);
                 }
             }
         }
 
-        private class RestGoodsColumn : TextDataColumn<ProductionSummaryEntry> {
-            private readonly ProductionSummaryView view;
-            public RestGoodsColumn(ProductionSummaryView view) : base("Other", 30f, 5f, 40f) => this.view = view;
-
-            public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
-                using var grid = gui.EnterInlineGrid(2.1f);
-                foreach (var (goods, amount) in data.flow) {
-                    if (amount == 0f) {
-                        continue;
-                    }
-
-                    if (!view.model.columnsExist.Contains(goods)) {
-                        grid.Next();
-                        var evt = gui.BuildButton(goods.icon, amount > 0f ? SchemeColor.Green : SchemeColor.None, size: 1.5f);
-                        if (evt == ButtonEvent.Click) {
-                            view.AddOrRemoveColumn(goods);
-                        }
-                        else if (evt == ButtonEvent.MouseOver) {
-                            ImmediateWidgets.ShowPrecisionValueTooltip(gui, new(amount, goods.flowUnitOfMeasure), goods);
-                        }
-                    }
+        private GuiBuilder AddProductionTableDropdown(SearchableList<ProjectPage> pagesDropdown) => gui => {
+            using (gui.EnterGroup(new Padding(1f))) {
+                if (gui.BuildSearchBox(productionTableSearchQuery, out productionTableSearchQuery)) {
+                    pagesDropdown.filter = productionTableSearchQuery;
                 }
             }
-        }
+            pagesDropdown.Build(gui);
+        };
 
-        private void ApplyFilter(Goods goods) {
-            var filter = filteredGoods == goods ? null : goods;
-            filteredGoods = filter;
-            model.group.UpdateFilter(goods, default);
-            Rebuild();
-        }
+        public override void BuildElement(ImGui gui, ProductionSummaryEntry entry) {
+            gui.allocator = RectAllocator.LeftAlign;
 
-        private bool IsColumnsSynced() {
-            if (grid.columns.Count != model.columns.Count + 3) {
-                return false;
-            }
-
-            int index = 2;
-            foreach (var column in model.columns) {
-                if (grid.columns[index++] is not GoodsColumn goodsColumn || goodsColumn.goods != column.goods) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private void RebuildColumns() {
-            if (!IsColumnsSynced()) {
-                SyncGridHeaderWithColumns();
-            }
-        }
-
-        private void SyncGridHeaderWithColumns() {
-            var columns = grid.columns;
-            var modelColumns = model.columns;
-            columns.Clear();
-            columns.Add(padding);
-            columns.Add(firstColumn);
-            foreach (var column in modelColumns) {
-                if (!goodsToColumn.TryGetValue(column, out var currentColumn)) {
-                    currentColumn = new GoodsColumn(column, this);
-                    goodsToColumn[column] = currentColumn;
-                }
-                columns.Add(currentColumn);
-            }
-            columns.Add(lastColumn);
-        }
-
-        protected override void BuildHeader(ImGui gui) {
-            if (model == null) {
-                return;
-            }
-
-            grid.BuildHeader(gui);
-            base.BuildHeader(gui);
-        }
-
-        private void AddOrRemoveColumn(Goods goods) {
-            _ = model.RecordUndo();
-            bool found = false;
-            for (int i = 0; i < model.columns.Count; i++) {
-                var column = model.columns[i];
-                if (column.goods == goods) {
-                    model.columns.RemoveAt(i);
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
-                model.columns.Add(new ProductionSummaryColumn(model, goods));
-            }
-        }
-
-        protected override void BuildContent(ImGui gui) {
-            if (model == null) {
-                return;
-            }
-
-            flatHierarchy.Build(gui);
-            gui.SetMinWidth(grid.width);
-
-            gui.AllocateSpacing(1f);
-            using (gui.EnterGroup(new Padding(1))) {
-                if (model.group.elements.Count == 0) {
-                    gui.BuildText("Add your existing sheets here to keep track of what you have in your base and to see what shortages you may have");
+            if (entry.subgroup != null) {
+                if (entry.subgroup.expanded) {
+                    BuildButtons(gui, 1.5f, entry.subgroup);
                 }
                 else {
-                    gui.BuildText("List of goods produced/consumed by added blocks. Click on any of these to add it to (or remove it from) the table.");
-                }
-
-                using var inlineGrid = gui.EnterInlineGrid(3f, 1f);
-                foreach (var (goods, amount) in model.sortedFlow) {
-                    inlineGrid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
-                        AddOrRemoveColumn(goods);
+                    if (gui.BuildTextInput(entry.subgroup.name, out string newText, "Group name", delayed: true)) {
+                        entry.subgroup.RecordUndo().name = newText;
                     }
                 }
             }
-            if (gui.isBuilding) {
-                gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
+            else if (entry.page != null) { // The constructor should have thrown if this check fails, but it helps the nullability analysis
+                using (gui.EnterGroup(new Padding(0.3f), RectAllocator.LeftRow, SchemeColor.None, 0.2f)) {
+                    var icon = entry.icon;
+                    if (icon != Icon.None) {
+                        gui.BuildIcon(entry.icon);
+                    }
+
+                    gui.BuildText(entry.name);
+                }
+
+                var buttonEvent = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt);
+                if (buttonEvent == ButtonEvent.MouseOver) {
+                    MainScreen.Instance.ShowTooltip(gui, entry.page.page, false, gui.lastRect);
+                }
+                else if (buttonEvent == ButtonEvent.Click) {
+                    gui.ShowDropDown(dropdownGui => {
+                        if (dropdownGui.BuildButton("Go to page") && dropdownGui.CloseDropdown()) {
+                            MainScreen.Instance.SetActivePage(entry.page.page);
+                        }
+
+                        if (dropdownGui.BuildRedButton("Remove") && dropdownGui.CloseDropdown()) {
+                            _ = entry.owner.RecordUndo().elements.Remove(entry);
+                        }
+                    });
+                }
+            }
+
+            using (gui.EnterFixedPositioning(3f, 2f, default)) {
+                gui.allocator = RectAllocator.LeftRow;
+                gui.BuildText("x");
+                DisplayAmount amount = entry.multiplier;
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey, Alignment = RectAlignment.MiddleLeft }) && amount.Value >= 0) {
+                    entry.SetMultiplier(amount.Value);
+                }
             }
         }
 
-        public override void Rebuild(bool visualOnly = false) {
-            flatHierarchy.SetData(model.group);
-            base.Rebuild(visualOnly);
+        private bool PagesDropdownFilter(ProjectPage data, SearchQuery searchTokens) => searchTokens.Match(data.name);
+
+        private static VirtualScrollList<ProjectPage>.Drawer PagesDropdownDrawer(ProductionSummaryGroup group) => (gui, element, _) => {
+            using (gui.EnterGroup(new Padding(1f, 0.25f), RectAllocator.LeftRow)) {
+                if (element.icon != null) {
+                    gui.BuildIcon(element.icon.icon);
+                }
+
+                gui.RemainingRow().BuildText(element.name, TextBlockDisplayStyle.Default(element.visible ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint));
+            }
+
+            if (gui.BuildButton(gui.lastRect, SchemeColor.BackgroundAlt, SchemeColor.Background)) {
+                group.RecordUndo().elements.Add(new ProductionSummaryEntry(group) { page = new PageReference(element) });
+            }
+        };
+    }
+
+    protected override void ModelContentsChanged(bool visualOnly) {
+        base.ModelContentsChanged(visualOnly);
+        RebuildColumns();
+    }
+
+    private class GoodsColumn : DataColumn<ProductionSummaryEntry> {
+        public readonly ProductionSummaryColumn column;
+        private readonly ProductionSummaryView view;
+        public Goods goods => column.goods;
+
+        public GoodsColumn(ProductionSummaryColumn column, ProductionSummaryView view) : base(4f) {
+            this.column = column;
+            this.view = view;
         }
 
-        protected override void BuildPageTooltip(ImGui gui, ProductionSummary contents) {
+        public override void BuildHeader(ImGui gui) {
+            var moveHandle = gui.statePosition;
+            moveHandle.Height = 5f;
 
+            if (gui.BuildFactorioObjectWithAmount(goods, new(view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
+                view.ApplyFilter(goods);
+            }
+
+            if (!gui.InitiateDrag(moveHandle, moveHandle, column) && gui.ConsumeDrag(moveHandle.Center, column) && gui.GetDraggingObject<ProductionSummaryColumn>() is ProductionSummaryColumn draggingColumn) {
+                view.model.RecordUndo(true).columns.MoveListElement(draggingColumn, column);
+                view.RebuildColumns();
+            }
         }
+
+        public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
+            float amount = data.GetAmount(goods);
+            if (amount != 0) {
+                if (gui.BuildFactorioObjectWithAmount(goods, new(data.GetAmount(goods), goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
+                    view.ApplyFilter(goods);
+                }
+            }
+        }
+    }
+
+    private class RestGoodsColumn : TextDataColumn<ProductionSummaryEntry> {
+        private readonly ProductionSummaryView view;
+        public RestGoodsColumn(ProductionSummaryView view) : base("Other", 30f, 5f, 40f) => this.view = view;
+
+        public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
+            using var grid = gui.EnterInlineGrid(2.1f);
+            foreach (var (goods, amount) in data.flow) {
+                if (amount == 0f) {
+                    continue;
+                }
+
+                if (!view.model.columnsExist.Contains(goods)) {
+                    grid.Next();
+                    var evt = gui.BuildButton(goods.icon, amount > 0f ? SchemeColor.Green : SchemeColor.None, size: 1.5f);
+                    if (evt == ButtonEvent.Click) {
+                        view.AddOrRemoveColumn(goods);
+                    }
+                    else if (evt == ButtonEvent.MouseOver) {
+                        ImmediateWidgets.ShowPrecisionValueTooltip(gui, new(amount, goods.flowUnitOfMeasure), goods);
+                    }
+                }
+            }
+        }
+    }
+
+    private void ApplyFilter(Goods goods) {
+        var filter = filteredGoods == goods ? null : goods;
+        filteredGoods = filter;
+        model.group.UpdateFilter(goods, default);
+        Rebuild();
+    }
+
+    private bool IsColumnsSynced() {
+        if (grid.columns.Count != model.columns.Count + 3) {
+            return false;
+        }
+
+        int index = 2;
+        foreach (var column in model.columns) {
+            if (grid.columns[index++] is not GoodsColumn goodsColumn || goodsColumn.goods != column.goods) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void RebuildColumns() {
+        if (!IsColumnsSynced()) {
+            SyncGridHeaderWithColumns();
+        }
+    }
+
+    private void SyncGridHeaderWithColumns() {
+        var columns = grid.columns;
+        var modelColumns = model.columns;
+        columns.Clear();
+        columns.Add(padding);
+        columns.Add(firstColumn);
+        foreach (var column in modelColumns) {
+            if (!goodsToColumn.TryGetValue(column, out var currentColumn)) {
+                currentColumn = new GoodsColumn(column, this);
+                goodsToColumn[column] = currentColumn;
+            }
+            columns.Add(currentColumn);
+        }
+        columns.Add(lastColumn);
+    }
+
+    protected override void BuildHeader(ImGui gui) {
+        if (model == null) {
+            return;
+        }
+
+        grid.BuildHeader(gui);
+        base.BuildHeader(gui);
+    }
+
+    private void AddOrRemoveColumn(Goods goods) {
+        _ = model.RecordUndo();
+        bool found = false;
+        for (int i = 0; i < model.columns.Count; i++) {
+            var column = model.columns[i];
+            if (column.goods == goods) {
+                model.columns.RemoveAt(i);
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            model.columns.Add(new ProductionSummaryColumn(model, goods));
+        }
+    }
+
+    protected override void BuildContent(ImGui gui) {
+        if (model == null) {
+            return;
+        }
+
+        flatHierarchy.Build(gui);
+        gui.SetMinWidth(grid.width);
+
+        gui.AllocateSpacing(1f);
+        using (gui.EnterGroup(new Padding(1))) {
+            if (model.group.elements.Count == 0) {
+                gui.BuildText("Add your existing sheets here to keep track of what you have in your base and to see what shortages you may have");
+            }
+            else {
+                gui.BuildText("List of goods produced/consumed by added blocks. Click on any of these to add it to (or remove it from) the table.");
+            }
+
+            using var inlineGrid = gui.EnterInlineGrid(3f, 1f);
+            foreach (var (goods, amount) in model.sortedFlow) {
+                inlineGrid.Next();
+                if (gui.BuildFactorioObjectWithAmount(goods, new(amount, goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None)) == Click.Left) {
+                    AddOrRemoveColumn(goods);
+                }
+            }
+        }
+        if (gui.isBuilding) {
+            gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
+        }
+    }
+
+    public override void Rebuild(bool visualOnly = false) {
+        flatHierarchy.SetData(model.group);
+        base.Rebuild(visualOnly);
+    }
+
+    protected override void BuildPageTooltip(ImGui gui, ProductionSummary contents) {
+
     }
 }

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -4,224 +4,223 @@ using System.Linq;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBuilder> {
-        private static readonly ModuleCustomizationScreen Instance = new ModuleCustomizationScreen();
+namespace Yafc;
+public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBuilder> {
+    private static readonly ModuleCustomizationScreen Instance = new ModuleCustomizationScreen();
 
-        private RecipeRow? recipe;
-        private ProjectModuleTemplate? template;
-        private ModuleTemplateBuilder? modules;
+    private RecipeRow? recipe;
+    private ProjectModuleTemplate? template;
+    private ModuleTemplateBuilder? modules;
 
-        public static void Show(RecipeRow recipe) {
-            Instance.template = null;
-            Instance.recipe = recipe;
-            Instance.modules = recipe.modules?.GetBuilder();
-            Instance.completionCallback = (hasResult, builder) => {
-                if (hasResult) {
-                    recipe.RecordUndo().modules = builder?.Build(recipe);
-                }
-            };
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-        }
+    public static void Show(RecipeRow recipe) {
+        Instance.template = null;
+        Instance.recipe = recipe;
+        Instance.modules = recipe.modules?.GetBuilder();
+        Instance.completionCallback = (hasResult, builder) => {
+            if (hasResult) {
+                recipe.RecordUndo().modules = builder?.Build(recipe);
+            }
+        };
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
 
-        public static void Show(ProjectModuleTemplate template) {
-            Instance.recipe = null;
-            Instance.template = template;
-            Instance.modules = template.template.GetBuilder();
-            Instance.completionCallback = (hasResult, builder) => {
-                if (hasResult) {
-                    template.RecordUndo().template = builder!.Build(template);
-                }
-            };
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-        }
+    public static void Show(ProjectModuleTemplate template) {
+        Instance.recipe = null;
+        Instance.template = template;
+        Instance.modules = template.template.GetBuilder();
+        Instance.completionCallback = (hasResult, builder) => {
+            if (hasResult) {
+                template.RecordUndo().template = builder!.Build(template);
+            }
+        };
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
 
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Module customization");
-            if (template != null) {
-                using (gui.EnterRow()) {
-                    if (gui.BuildFactorioObjectButton(template.icon, ButtonDisplayStyle.Default) == Click.Left) {
-                        SelectSingleObjectPanel.SelectWithNone(Database.objects.all, "Select icon", x => {
-                            template.RecordUndo().icon = x;
-                            Rebuild();
-                        });
-                    }
-
-                    if (gui.BuildTextInput(template.name, out string newName, "Enter name", delayed: true) && newName != "") {
-                        template.RecordUndo().name = newName;
-                    }
-                }
-                gui.BuildText("Filter by crafting buildings (Optional):");
-                using var grid = gui.EnterInlineGrid(2f, 1f);
-                for (int i = 0; i < template.filterEntities.Count; i++) {
-                    var entity = template.filterEntities[i];
-                    grid.Next();
-                    gui.BuildFactorioObjectIcon(entity, new(2, MilestoneDisplay.Contained, false));
-                    if (gui.BuildMouseOverIcon(Icon.Close, SchemeColor.Error)) {
-                        template.RecordUndo().filterEntities.RemoveAt(i);
-                    }
-                }
-                grid.Next();
-                if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 1.5f)) {
-                    SelectSingleObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !template.filterEntities.Contains(x)), "Add module template filter", sel => {
-                        template.RecordUndo().filterEntities.Add(sel);
-                        gui.Rebuild();
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Module customization");
+        if (template != null) {
+            using (gui.EnterRow()) {
+                if (gui.BuildFactorioObjectButton(template.icon, ButtonDisplayStyle.Default) == Click.Left) {
+                    SelectSingleObjectPanel.SelectWithNone(Database.objects.all, "Select icon", x => {
+                        template.RecordUndo().icon = x;
+                        Rebuild();
                     });
                 }
+
+                if (gui.BuildTextInput(template.name, out string newName, "Enter name", delayed: true) && newName != "") {
+                    template.RecordUndo().name = newName;
+                }
             }
-            if (modules == null) {
-                if (gui.BuildButton("Enable custom modules")) {
-                    modules = new ModuleTemplateBuilder();
+            gui.BuildText("Filter by crafting buildings (Optional):");
+            using var grid = gui.EnterInlineGrid(2f, 1f);
+            for (int i = 0; i < template.filterEntities.Count; i++) {
+                var entity = template.filterEntities[i];
+                grid.Next();
+                gui.BuildFactorioObjectIcon(entity, new(2, MilestoneDisplay.Contained, false));
+                if (gui.BuildMouseOverIcon(Icon.Close, SchemeColor.Error)) {
+                    template.RecordUndo().filterEntities.RemoveAt(i);
+                }
+            }
+            grid.Next();
+            if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 1.5f)) {
+                SelectSingleObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !template.filterEntities.Contains(x)), "Add module template filter", sel => {
+                    template.RecordUndo().filterEntities.Add(sel);
+                    gui.Rebuild();
+                });
+            }
+        }
+        if (modules == null) {
+            if (gui.BuildButton("Enable custom modules")) {
+                modules = new ModuleTemplateBuilder();
+            }
+        }
+        else {
+            ModuleEffects effects = new ModuleEffects();
+            if (recipe == null || recipe.entity?.moduleSlots > 0) {
+                gui.BuildText("Internal modules:", Font.subheader);
+                gui.BuildText("Leave zero amount to fill the remaining slots");
+                DrawRecipeModules(gui, null, ref effects);
+            }
+            else {
+                gui.BuildText("This building doesn't have module slots, but can be affected by beacons");
+            }
+            gui.BuildText("Beacon modules:", Font.subheader);
+            if (modules.beacon == null) {
+                gui.BuildText("Use default parameters");
+                if (gui.BuildButton("Override beacons as well")) {
+                    SelectBeacon(gui);
+                }
+
+                var defaultFiller = recipe?.GetModuleFiller();
+                if (defaultFiller?.GetBeaconsForCrafter(recipe?.entity) is BeaconConfiguration { beacon: not null, beaconModule: not null } beaconsToUse) {
+                    effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
                 }
             }
             else {
-                ModuleEffects effects = new ModuleEffects();
-                if (recipe == null || recipe.entity?.moduleSlots > 0) {
-                    gui.BuildText("Internal modules:", Font.subheader);
-                    gui.BuildText("Leave zero amount to fill the remaining slots");
-                    DrawRecipeModules(gui, null, ref effects);
+                if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
+                    SelectBeacon(gui);
+                }
+
+                gui.BuildText("Input the amount of modules, not the amount of beacons. Single beacon can hold " + modules.beacon.moduleSlots + " modules.", TextBlockDisplayStyle.WrappedText);
+                DrawRecipeModules(gui, modules.beacon, ref effects);
+            }
+
+            if (recipe != null) {
+                float craftingSpeed = (recipe.entity?.craftingSpeed ?? 1f) * effects.speedMod;
+                gui.BuildText("Current effects:", Font.subheader);
+                gui.BuildText("Productivity bonus: " + DataUtils.FormatAmount(effects.productivity, UnitOfMeasure.Percent));
+                gui.BuildText("Speed bonus: " + DataUtils.FormatAmount(effects.speedMod - 1, UnitOfMeasure.Percent) + " (Crafting speed: " + DataUtils.FormatAmount(craftingSpeed, UnitOfMeasure.None) + ")");
+                string energyUsageLine = "Energy usage: " + DataUtils.FormatAmount(effects.energyUsageMod, UnitOfMeasure.Percent);
+                if (recipe.entity != null) {
+                    float power = effects.energyUsageMod * recipe.entity.power / recipe.entity.energy.effectivity;
+                    if (!recipe.recipe.flags.HasFlagAny(RecipeFlags.UsesFluidTemperature | RecipeFlags.ScaleProductionWithPower) && recipe.entity != null) {
+                        energyUsageLine += " (" + DataUtils.FormatAmount(power, UnitOfMeasure.Megawatt) + " per building)";
+                    }
+
+                    gui.BuildText(energyUsageLine);
+
+                    float pps = craftingSpeed * (1f + MathF.Max(0f, effects.productivity)) / recipe.recipe.time;
+                    gui.BuildText("Overall crafting speed (including productivity): " + DataUtils.FormatAmount(pps, UnitOfMeasure.PerSecond));
+                    gui.BuildText("Energy cost per recipe output: " + DataUtils.FormatAmount(power / pps, UnitOfMeasure.Megajoule));
                 }
                 else {
-                    gui.BuildText("This building doesn't have module slots, but can be affected by beacons");
+                    gui.BuildText(energyUsageLine);
                 }
-                gui.BuildText("Beacon modules:", Font.subheader);
-                if (modules.beacon == null) {
-                    gui.BuildText("Use default parameters");
-                    if (gui.BuildButton("Override beacons as well")) {
-                        SelectBeacon(gui);
-                    }
+            }
+        }
 
-                    var defaultFiller = recipe?.GetModuleFiller();
-                    if (defaultFiller?.GetBeaconsForCrafter(recipe?.entity) is BeaconConfiguration { beacon: not null, beaconModule: not null } beaconsToUse) {
-                        effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
-                    }
-                }
-                else {
-                    if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
-                        SelectBeacon(gui);
-                    }
+        gui.AllocateSpacing(3f);
+        using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
+            if (template == null && gui.BuildButton("Cancel")) {
+                Close();
+            }
+            if (template != null && gui.BuildButton("Cancel (partial)")) {
+                Close();
+            }
+            if (gui.BuildButton("Done")) {
+                CloseWithResult(modules);
+            }
 
-                    gui.BuildText("Input the amount of modules, not the amount of beacons. Single beacon can hold " + modules.beacon.moduleSlots + " modules.", TextBlockDisplayStyle.WrappedText);
-                    DrawRecipeModules(gui, modules.beacon, ref effects);
-                }
+            gui.allocator = RectAllocator.LeftRow;
+            if (modules != null && recipe != null && gui.BuildRedButton("Remove module customization")) {
+                CloseWithResult(null);
+            }
+        }
+    }
 
-                if (recipe != null) {
-                    float craftingSpeed = (recipe.entity?.craftingSpeed ?? 1f) * effects.speedMod;
-                    gui.BuildText("Current effects:", Font.subheader);
-                    gui.BuildText("Productivity bonus: " + DataUtils.FormatAmount(effects.productivity, UnitOfMeasure.Percent));
-                    gui.BuildText("Speed bonus: " + DataUtils.FormatAmount(effects.speedMod - 1, UnitOfMeasure.Percent) + " (Crafting speed: " + DataUtils.FormatAmount(craftingSpeed, UnitOfMeasure.None) + ")");
-                    string energyUsageLine = "Energy usage: " + DataUtils.FormatAmount(effects.energyUsageMod, UnitOfMeasure.Percent);
-                    if (recipe.entity != null) {
-                        float power = effects.energyUsageMod * recipe.entity.power / recipe.entity.energy.effectivity;
-                        if (!recipe.recipe.flags.HasFlagAny(RecipeFlags.UsesFluidTemperature | RecipeFlags.ScaleProductionWithPower) && recipe.entity != null) {
-                            energyUsageLine += " (" + DataUtils.FormatAmount(power, UnitOfMeasure.Megawatt) + " per building)";
+    private void SelectBeacon(ImGui gui) {
+        if (modules!.beacon is null) { // null-forgiving: Both calls are from places where we know modules is not null
+            gui.BuildObjectSelectDropDown<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
+                modules.beacon = sel;
+                contents.Rebuild();
+            }, "Select beacon");
+        }
+        else {
+            gui.BuildObjectSelectDropDownWithNone<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
+                modules.beacon = sel;
+                contents.Rebuild();
+            }, "Select beacon");
+        }
+    }
+
+    private ICollection<Module> GetModules(EntityBeacon? beacon) {
+        var modules = (beacon == null && recipe != null) ? recipe.recipe.modules : Database.allModules;
+        var filter = ((EntityWithModules?)beacon) ?? recipe?.entity;
+        if (filter == null) {
+            return modules;
+        }
+
+        return modules.Where(x => filter.CanAcceptModule(x.moduleSpecification)).ToArray();
+    }
+
+    private void DrawRecipeModules(ImGui gui, EntityBeacon? beacon, ref ModuleEffects effects) {
+        int remainingModules = recipe?.entity?.moduleSlots ?? 0;
+        using var grid = gui.EnterInlineGrid(3f, 1f);
+        var list = beacon != null ? modules!.beaconList : modules!.list;// null-forgiving: Both calls are from places where we know modules is not null
+        for (int i = 0; i < list.Count; i++) {
+            grid.Next();
+            (Module module, int fixedCount) = list[i];
+            DisplayAmount amount = fixedCount;
+            switch (gui.BuildFactorioObjectWithEditableAmount(module, amount, ButtonDisplayStyle.ProductionTableUnscaled)) {
+                case GoodsWithAmountEvent.LeftButtonClick:
+                    int idx = i; // Capture the current value of i.
+                    SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
+                        if (sel == null) {
+                            list.RemoveAt(idx);
+                        }
+                        else {
+                            list[idx] = (sel, list[idx].fixedCount);
                         }
 
-                        gui.BuildText(energyUsageLine);
+                        gui.Rebuild();
+                    }, DataUtils.FavoriteModule);
+                    break;
 
-                        float pps = craftingSpeed * (1f + MathF.Max(0f, effects.productivity)) / recipe.recipe.time;
-                        gui.BuildText("Overall crafting speed (including productivity): " + DataUtils.FormatAmount(pps, UnitOfMeasure.PerSecond));
-                        gui.BuildText("Energy cost per recipe output: " + DataUtils.FormatAmount(power / pps, UnitOfMeasure.Megajoule));
-                    }
-                    else {
-                        gui.BuildText(energyUsageLine);
-                    }
-                }
+                case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
+                    list[i] = (module, (int)amount.Value);
+                    break;
             }
 
-            gui.AllocateSpacing(3f);
-            using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
-                if (template == null && gui.BuildButton("Cancel")) {
-                    Close();
+            if (beacon == null) {
+                int count = Math.Min(remainingModules, fixedCount > 0 ? fixedCount : int.MaxValue);
+                if (count > 0) {
+                    effects.AddModules(module.moduleSpecification, count);
+                    remainingModules -= count;
                 }
-                if (template != null && gui.BuildButton("Cancel (partial)")) {
-                    Close();
-                }
-                if (gui.BuildButton("Done")) {
-                    CloseWithResult(modules);
-                }
-
-                gui.allocator = RectAllocator.LeftRow;
-                if (modules != null && recipe != null && gui.BuildRedButton("Remove module customization")) {
-                    CloseWithResult(null);
-                }
-            }
-        }
-
-        private void SelectBeacon(ImGui gui) {
-            if (modules!.beacon is null) { // null-forgiving: Both calls are from places where we know modules is not null
-                gui.BuildObjectSelectDropDown<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
-                    modules.beacon = sel;
-                    contents.Rebuild();
-                }, "Select beacon");
             }
             else {
-                gui.BuildObjectSelectDropDownWithNone<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
-                    modules.beacon = sel;
-                    contents.Rebuild();
-                }, "Select beacon");
+                effects.AddModules(module.moduleSpecification, fixedCount * beacon.beaconEfficiency);
             }
         }
 
-        private ICollection<Module> GetModules(EntityBeacon? beacon) {
-            var modules = (beacon == null && recipe != null) ? recipe.recipe.modules : Database.allModules;
-            var filter = ((EntityWithModules?)beacon) ?? recipe?.entity;
-            if (filter == null) {
-                return modules;
-            }
-
-            return modules.Where(x => filter.CanAcceptModule(x.moduleSpecification)).ToArray();
+        grid.Next();
+        if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
+            gui.BuildObjectSelectDropDown(GetModules(beacon), DataUtils.FavoriteModule, sel => {
+                list.Add((sel, 0));
+                gui.Rebuild();
+            }, "Select module");
         }
-
-        private void DrawRecipeModules(ImGui gui, EntityBeacon? beacon, ref ModuleEffects effects) {
-            int remainingModules = recipe?.entity?.moduleSlots ?? 0;
-            using var grid = gui.EnterInlineGrid(3f, 1f);
-            var list = beacon != null ? modules!.beaconList : modules!.list;// null-forgiving: Both calls are from places where we know modules is not null
-            for (int i = 0; i < list.Count; i++) {
-                grid.Next();
-                (Module module, int fixedCount) = list[i];
-                DisplayAmount amount = fixedCount;
-                switch (gui.BuildFactorioObjectWithEditableAmount(module, amount, ButtonDisplayStyle.ProductionTableUnscaled)) {
-                    case GoodsWithAmountEvent.LeftButtonClick:
-                        int idx = i; // Capture the current value of i.
-                        SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
-                            if (sel == null) {
-                                list.RemoveAt(idx);
-                            }
-                            else {
-                                list[idx] = (sel, list[idx].fixedCount);
-                            }
-
-                            gui.Rebuild();
-                        }, DataUtils.FavoriteModule);
-                        break;
-
-                    case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
-                        list[i] = (module, (int)amount.Value);
-                        break;
-                }
-
-                if (beacon == null) {
-                    int count = Math.Min(remainingModules, fixedCount > 0 ? fixedCount : int.MaxValue);
-                    if (count > 0) {
-                        effects.AddModules(module.moduleSpecification, count);
-                        remainingModules -= count;
-                    }
-                }
-                else {
-                    effects.AddModules(module.moduleSpecification, fixedCount * beacon.beaconEfficiency);
-                }
-            }
-
-            grid.Next();
-            if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-                gui.BuildObjectSelectDropDown(GetModules(beacon), DataUtils.FavoriteModule, sel => {
-                    list.Add((sel, 0));
-                    gui.Rebuild();
-                }, "Select module");
-            }
-        }
-
-        protected override void ReturnPressed() => CloseWithResult(modules);
     }
+
+    protected override void ReturnPressed() => CloseWithResult(modules);
 }

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -5,189 +5,188 @@ using System.Numerics;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ModuleFillerParametersScreen : PseudoScreen {
-        private static readonly float ModulesMinPayback = MathF.Log(600f);
-        private static readonly float ModulesMaxPayback = MathF.Log(3600f * 120f);
-        private readonly ModuleFillerParameters modules;
-        private readonly VirtualScrollList<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>> overrideList;
+namespace Yafc;
+public class ModuleFillerParametersScreen : PseudoScreen {
+    private static readonly float ModulesMinPayback = MathF.Log(600f);
+    private static readonly float ModulesMaxPayback = MathF.Log(3600f * 120f);
+    private readonly ModuleFillerParameters modules;
+    private readonly VirtualScrollList<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>> overrideList;
 
-        public static void Show(ModuleFillerParameters parameters) => _ = MainScreen.Instance.ShowPseudoScreen(new ModuleFillerParametersScreen(parameters));
+    public static void Show(ModuleFillerParameters parameters) => _ = MainScreen.Instance.ShowPseudoScreen(new ModuleFillerParametersScreen(parameters));
 
-        private ModuleFillerParametersScreen(ModuleFillerParameters modules) {
-            this.modules = modules;
-            overrideList = new(11, new(3.25f, 4.5f), ListDrawer, collapsible: true) { data = [.. modules.overrideCrafterBeacons] };
-        }
-
-        /// <summary>
-        /// Draw one item in the per-crafter beacon override display.
-        /// </summary>
-        private void ListDrawer(ImGui gui, KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> element, int index) {
-            (EntityCrafter crafter, BeaconOverrideConfiguration config) = element;
-            DisplayAmount amount = config.beaconCount;
-            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount, ButtonDisplayStyle.ProductionTableUnscaled, allowScroll: false);
-            gui.DrawIcon(new(gui.lastRect.X, gui.lastRect.Y, 1.25f, 1.25f), config.beacon.icon, SchemeColor.Source);
-            gui.DrawIcon(new(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), config.beaconModule.icon, SchemeColor.Source);
-            switch (click) {
-                case GoodsWithAmountEvent.LeftButtonClick:
-                    SelectSingleObjectPanel.SelectWithNone(Database.usableBeacons, "Select beacon", selectedBeacon => {
-                        if (selectedBeacon is null) {
-                            modules.overrideCrafterBeacons.Remove(crafter);
-                        }
-                        else {
-                            modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beacon = selectedBeacon };
-                            if (!selectedBeacon.CanAcceptModule(modules.overrideCrafterBeacons[crafter].beaconModule.moduleSpecification)) {
-                                _ = Database.GetDefaultModuleFor(selectedBeacon, out Module? module);
-                                modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconModule = module! }; // null-forgiving: Anything from usableBeacons accepts at least one module.
-                            }
-                        }
-                        overrideList.data = [.. modules.overrideCrafterBeacons];
-                    }, noneTooltip: "Click here to remove the current override.");
-                    break;
-                case GoodsWithAmountEvent.RightButtonClick:
-                    SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(m => modules.overrideCrafterBeacons[crafter].beacon.CanAcceptModule(m.moduleSpecification)), "Select beacon module", selectedModule => {
-                        if (selectedModule is null) {
-                            modules.overrideCrafterBeacons.Remove(crafter);
-                        }
-                        else {
-                            modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconModule = selectedModule };
-                        }
-                        overrideList.data = [.. modules.overrideCrafterBeacons];
-                    }, noneTooltip: "Click here to remove the current override.");
-                    break;
-                case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
-                    modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconCount = (int)amount.Value };
-                    overrideList.data = [.. modules.overrideCrafterBeacons];
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Draw the slider that controls the price of the modules that are automatically selected.
-        /// </summary>
-        public static void BuildSimple(ImGui gui, ModuleFillerParameters modules) {
-            float payback = modules.autoFillPayback;
-            float modulesLog = MathUtils.LogarithmicToLinear(payback, ModulesMinPayback, ModulesMaxPayback);
-            if (gui.BuildSlider(modulesLog, out float newValue)) {
-                payback = MathUtils.LinearToLogarithmic(newValue, ModulesMinPayback, ModulesMaxPayback, 0f, float.MaxValue); // JSON can't handle infinities
-                modules.autoFillPayback = payback;
-            }
-
-            if (payback <= 0f) {
-                gui.BuildText("Use no modules");
-            }
-            else if (payback >= float.MaxValue) {
-                gui.BuildText("Use best modules");
-            }
-            else {
-                gui.BuildText("Modules payback estimate: " + DataUtils.FormatTime(payback), TextBlockDisplayStyle.WrappedText);
-            }
-        }
-
-        /// <summary>
-        /// Draw the full configuration panel, with all the options except the slider.
-        /// </summary>
-        public override void Build(ImGui gui) {
-            EntityBeacon? defaultBeacon = Database.usableBeacons.FirstOrDefault();
-            _ = Database.GetDefaultModuleFor(defaultBeacon, out Module? defaultBeaconModule);
-
-            BuildHeader(gui, "Module autofill parameters");
-            BuildSimple(gui, modules);
-            if (gui.BuildCheckBox("Fill modules in miners", modules.fillMiners, out bool newFill)) {
-                modules.fillMiners = newFill;
-            }
-
-            gui.AllocateSpacing();
-            gui.BuildText("Filler module:", Font.subheader);
-            gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", TextBlockDisplayStyle.WrappedText);
-            if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule) == Click.Left) {
-                SelectSingleObjectPanel.SelectWithNone(Database.allModules, "Select filler module", select => { modules.fillerModule = select; });
-            }
-
-            gui.AllocateSpacing();
-            gui.BuildText("Beacons & beacon modules:", Font.subheader);
-            if (defaultBeacon is null || defaultBeaconModule is null) {
-                gui.BuildText("Your mods contain no beacons, or no modules that can be put into beacons.");
-            }
-            else {
-                if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
-                    SelectSingleObjectPanel.SelectWithNone(Database.allBeacons, "Select beacon", select => {
-                        modules.beacon = select;
-                        if (modules.beaconModule != null && (modules.beacon == null || !modules.beacon.CanAcceptModule(modules.beaconModule.moduleSpecification))) {
-                            modules.beaconModule = null;
-                        }
-
-                        gui.Rebuild();
-                    });
-                }
-
-                if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule) == Click.Left) {
-                    SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.moduleSpecification) ?? false), "Select module for beacon", select => { modules.beaconModule = select; });
-                }
-
-                using (gui.EnterRow()) {
-                    gui.BuildText("Beacons per building: ");
-                    DisplayAmount amount = modules.beaconsPerBuilding;
-                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && (int)amount.Value > 0) {
-                        modules.beaconsPerBuilding = (int)amount.Value;
-                    }
-                }
-                gui.BuildText("Please note that beacons themselves are not part of the calculation", TextBlockDisplayStyle.WrappedText);
-
-                gui.AllocateSpacing();
-                gui.BuildText("Override beacons:", Font.subheader);
-                if (modules.overrideCrafterBeacons.Count > 0) {
-                    using (gui.EnterGroup(new Padding(1, 0, 0, 0))) {
-                        gui.BuildText("Click to change beacon, right-click to change module", topOffset: -0.5f);
-                        gui.BuildText("Select the 'none' item in either prompt to remove the override.", topOffset: -0.5f);
-                    }
-                }
-                gui.AllocateSpacing(.5f);
-                overrideList.Build(gui);
-
-                using (gui.EnterRow(allocator: RectAllocator.Center)) {
-                    if (gui.BuildButton("Add an override for a building type")) {
-                        SelectMultiObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !modules.overrideCrafterBeacons.ContainsKey(x)), "Add exception(s) for:",
-                            crafter => {
-                                modules.overrideCrafterBeacons[crafter] = new BeaconOverrideConfiguration(modules.beacon ?? defaultBeacon, modules.beaconsPerBuilding, modules.beaconModule ?? defaultBeaconModule);
-                                overrideList.data = [.. modules.overrideCrafterBeacons];
-                            });
-                    }
-                }
-            }
-
-            gui.AllocateSpacing();
-            using (gui.EnterRow()) {
-                gui.BuildText("Mining productivity bonus (project-wide setting): ");
-                DisplayAmount amount = new(Project.current.settings.miningProductivity, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
-                    Project.current.settings.RecordUndo().miningProductivity = amount.Value;
-                }
-            }
-            using (gui.EnterRow()) {
-                gui.BuildText("Research speed bonus (project-wide setting): ");
-                DisplayAmount amount = new(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
-                    Project.current.settings.RecordUndo().researchSpeedBonus = amount.Value;
-                }
-            }
-            using (gui.EnterRow()) {
-                gui.BuildText("Research productivity bonus (project-wide setting): ");
-                DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
-                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
-                    Project.current.settings.RecordUndo().researchProductivity = amount.Value;
-                }
-            }
-
-            if (gui.BuildButton("Done")) {
-                Close();
-            }
-
-            if (Project.current.settings.justChanged) {
-                Project.current.RecalculateDisplayPages();
-            }
-        }
-
-        protected override void ReturnPressed() => Close();
+    private ModuleFillerParametersScreen(ModuleFillerParameters modules) {
+        this.modules = modules;
+        overrideList = new(11, new(3.25f, 4.5f), ListDrawer, collapsible: true) { data = [.. modules.overrideCrafterBeacons] };
     }
+
+    /// <summary>
+    /// Draw one item in the per-crafter beacon override display.
+    /// </summary>
+    private void ListDrawer(ImGui gui, KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> element, int index) {
+        (EntityCrafter crafter, BeaconOverrideConfiguration config) = element;
+        DisplayAmount amount = config.beaconCount;
+        GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, amount, ButtonDisplayStyle.ProductionTableUnscaled, allowScroll: false);
+        gui.DrawIcon(new(gui.lastRect.X, gui.lastRect.Y, 1.25f, 1.25f), config.beacon.icon, SchemeColor.Source);
+        gui.DrawIcon(new(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), config.beaconModule.icon, SchemeColor.Source);
+        switch (click) {
+            case GoodsWithAmountEvent.LeftButtonClick:
+                SelectSingleObjectPanel.SelectWithNone(Database.usableBeacons, "Select beacon", selectedBeacon => {
+                    if (selectedBeacon is null) {
+                        modules.overrideCrafterBeacons.Remove(crafter);
+                    }
+                    else {
+                        modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beacon = selectedBeacon };
+                        if (!selectedBeacon.CanAcceptModule(modules.overrideCrafterBeacons[crafter].beaconModule.moduleSpecification)) {
+                            _ = Database.GetDefaultModuleFor(selectedBeacon, out Module? module);
+                            modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconModule = module! }; // null-forgiving: Anything from usableBeacons accepts at least one module.
+                        }
+                    }
+                    overrideList.data = [.. modules.overrideCrafterBeacons];
+                }, noneTooltip: "Click here to remove the current override.");
+                break;
+            case GoodsWithAmountEvent.RightButtonClick:
+                SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(m => modules.overrideCrafterBeacons[crafter].beacon.CanAcceptModule(m.moduleSpecification)), "Select beacon module", selectedModule => {
+                    if (selectedModule is null) {
+                        modules.overrideCrafterBeacons.Remove(crafter);
+                    }
+                    else {
+                        modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconModule = selectedModule };
+                    }
+                    overrideList.data = [.. modules.overrideCrafterBeacons];
+                }, noneTooltip: "Click here to remove the current override.");
+                break;
+            case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
+                modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconCount = (int)amount.Value };
+                overrideList.data = [.. modules.overrideCrafterBeacons];
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Draw the slider that controls the price of the modules that are automatically selected.
+    /// </summary>
+    public static void BuildSimple(ImGui gui, ModuleFillerParameters modules) {
+        float payback = modules.autoFillPayback;
+        float modulesLog = MathUtils.LogarithmicToLinear(payback, ModulesMinPayback, ModulesMaxPayback);
+        if (gui.BuildSlider(modulesLog, out float newValue)) {
+            payback = MathUtils.LinearToLogarithmic(newValue, ModulesMinPayback, ModulesMaxPayback, 0f, float.MaxValue); // JSON can't handle infinities
+            modules.autoFillPayback = payback;
+        }
+
+        if (payback <= 0f) {
+            gui.BuildText("Use no modules");
+        }
+        else if (payback >= float.MaxValue) {
+            gui.BuildText("Use best modules");
+        }
+        else {
+            gui.BuildText("Modules payback estimate: " + DataUtils.FormatTime(payback), TextBlockDisplayStyle.WrappedText);
+        }
+    }
+
+    /// <summary>
+    /// Draw the full configuration panel, with all the options except the slider.
+    /// </summary>
+    public override void Build(ImGui gui) {
+        EntityBeacon? defaultBeacon = Database.usableBeacons.FirstOrDefault();
+        _ = Database.GetDefaultModuleFor(defaultBeacon, out Module? defaultBeaconModule);
+
+        BuildHeader(gui, "Module autofill parameters");
+        BuildSimple(gui, modules);
+        if (gui.BuildCheckBox("Fill modules in miners", modules.fillMiners, out bool newFill)) {
+            modules.fillMiners = newFill;
+        }
+
+        gui.AllocateSpacing();
+        gui.BuildText("Filler module:", Font.subheader);
+        gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", TextBlockDisplayStyle.WrappedText);
+        if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule) == Click.Left) {
+            SelectSingleObjectPanel.SelectWithNone(Database.allModules, "Select filler module", select => { modules.fillerModule = select; });
+        }
+
+        gui.AllocateSpacing();
+        gui.BuildText("Beacons & beacon modules:", Font.subheader);
+        if (defaultBeacon is null || defaultBeaconModule is null) {
+            gui.BuildText("Your mods contain no beacons, or no modules that can be put into beacons.");
+        }
+        else {
+            if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
+                SelectSingleObjectPanel.SelectWithNone(Database.allBeacons, "Select beacon", select => {
+                    modules.beacon = select;
+                    if (modules.beaconModule != null && (modules.beacon == null || !modules.beacon.CanAcceptModule(modules.beaconModule.moduleSpecification))) {
+                        modules.beaconModule = null;
+                    }
+
+                    gui.Rebuild();
+                });
+            }
+
+            if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule) == Click.Left) {
+                SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.moduleSpecification) ?? false), "Select module for beacon", select => { modules.beaconModule = select; });
+            }
+
+            using (gui.EnterRow()) {
+                gui.BuildText("Beacons per building: ");
+                DisplayAmount amount = modules.beaconsPerBuilding;
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && (int)amount.Value > 0) {
+                    modules.beaconsPerBuilding = (int)amount.Value;
+                }
+            }
+            gui.BuildText("Please note that beacons themselves are not part of the calculation", TextBlockDisplayStyle.WrappedText);
+
+            gui.AllocateSpacing();
+            gui.BuildText("Override beacons:", Font.subheader);
+            if (modules.overrideCrafterBeacons.Count > 0) {
+                using (gui.EnterGroup(new Padding(1, 0, 0, 0))) {
+                    gui.BuildText("Click to change beacon, right-click to change module", topOffset: -0.5f);
+                    gui.BuildText("Select the 'none' item in either prompt to remove the override.", topOffset: -0.5f);
+                }
+            }
+            gui.AllocateSpacing(.5f);
+            overrideList.Build(gui);
+
+            using (gui.EnterRow(allocator: RectAllocator.Center)) {
+                if (gui.BuildButton("Add an override for a building type")) {
+                    SelectMultiObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !modules.overrideCrafterBeacons.ContainsKey(x)), "Add exception(s) for:",
+                        crafter => {
+                            modules.overrideCrafterBeacons[crafter] = new BeaconOverrideConfiguration(modules.beacon ?? defaultBeacon, modules.beaconsPerBuilding, modules.beaconModule ?? defaultBeaconModule);
+                            overrideList.data = [.. modules.overrideCrafterBeacons];
+                        });
+                }
+            }
+        }
+
+        gui.AllocateSpacing();
+        using (gui.EnterRow()) {
+            gui.BuildText("Mining productivity bonus (project-wide setting): ");
+            DisplayAmount amount = new(Project.current.settings.miningProductivity, UnitOfMeasure.Percent);
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
+                Project.current.settings.RecordUndo().miningProductivity = amount.Value;
+            }
+        }
+        using (gui.EnterRow()) {
+            gui.BuildText("Research speed bonus (project-wide setting): ");
+            DisplayAmount amount = new(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent);
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
+                Project.current.settings.RecordUndo().researchSpeedBonus = amount.Value;
+            }
+        }
+        using (gui.EnterRow()) {
+            gui.BuildText("Research productivity bonus (project-wide setting): ");
+            DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
+                Project.current.settings.RecordUndo().researchProductivity = amount.Value;
+            }
+        }
+
+        if (gui.BuildButton("Done")) {
+            Close();
+        }
+
+        if (Project.current.settings.justChanged) {
+            Project.current.RecalculateDisplayPages();
+        }
+    }
+
+    protected override void ReturnPressed() => Close();
 }

--- a/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
@@ -2,76 +2,75 @@
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ModuleTemplateConfiguration : PseudoScreen {
-        private static readonly ModuleTemplateConfiguration Instance = new ModuleTemplateConfiguration();
-        private readonly VirtualScrollList<ProjectModuleTemplate> templateList;
-        private ProjectModuleTemplate? pageToDelete;
-        private string newPageName = "";
+namespace Yafc;
+public class ModuleTemplateConfiguration : PseudoScreen {
+    private static readonly ModuleTemplateConfiguration Instance = new ModuleTemplateConfiguration();
+    private readonly VirtualScrollList<ProjectModuleTemplate> templateList;
+    private ProjectModuleTemplate? pageToDelete;
+    private string newPageName = "";
 
-        public ModuleTemplateConfiguration() => templateList = new VirtualScrollList<ProjectModuleTemplate>(30, new Vector2(20, 2.5f), Drawer,
-                reorder: (from, to) => Project.current.RecordUndo().sharedModuleTemplates.MoveListElementIndex(from, to));
+    public ModuleTemplateConfiguration() => templateList = new VirtualScrollList<ProjectModuleTemplate>(30, new Vector2(20, 2.5f), Drawer,
+            reorder: (from, to) => Project.current.RecordUndo().sharedModuleTemplates.MoveListElementIndex(from, to));
 
-        public static void Show() {
-            Instance.RefreshList();
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-        }
+    public static void Show() {
+        Instance.RefreshList();
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
 
-        private void RefreshList() {
-            templateList.data = Project.current.sharedModuleTemplates;
+    private void RefreshList() {
+        templateList.data = Project.current.sharedModuleTemplates;
+        Rebuild();
+    }
+
+    private void Drawer(ImGui gui, ProjectModuleTemplate element, int index) {
+        gui.allocator = RectAllocator.RightRow;
+        if (gui.BuildButton(Icon.Delete)) {
+            pageToDelete = element;
             Rebuild();
         }
 
-        private void Drawer(ImGui gui, ProjectModuleTemplate element, int index) {
-            gui.allocator = RectAllocator.RightRow;
-            if (gui.BuildButton(Icon.Delete)) {
-                pageToDelete = element;
-                Rebuild();
+        if (gui.BuildButton(Icon.Copy)) {
+            var copy = JsonUtils.Copy(element, element.owner, null);
+            if (copy != null) {
+                element.owner.RecordUndo().sharedModuleTemplates.Add(copy);
+                ModuleCustomizationScreen.Show(copy);
             }
-
-            if (gui.BuildButton(Icon.Copy)) {
-                var copy = JsonUtils.Copy(element, element.owner, null);
-                if (copy != null) {
-                    element.owner.RecordUndo().sharedModuleTemplates.Add(copy);
-                    ModuleCustomizationScreen.Show(copy);
-                }
-            }
-            if (gui.BuildButton(Icon.Edit)) {
-                ModuleCustomizationScreen.Show(element);
-            }
-
-            gui.allocator = RectAllocator.LeftRow;
-            if (element.icon != null) {
-                gui.BuildFactorioObjectIcon(element.icon);
-            }
-
-            gui.BuildText(element.name);
+        }
+        if (gui.BuildButton(Icon.Edit)) {
+            ModuleCustomizationScreen.Show(element);
         }
 
-        public override void Activated() {
-            base.Activated();
-            templateList.RebuildContents();
+        gui.allocator = RectAllocator.LeftRow;
+        if (element.icon != null) {
+            gui.BuildFactorioObjectIcon(element.icon);
         }
 
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Module templates");
-            templateList.Build(gui);
-            if (pageToDelete != null) {
-                _ = Project.current.RecordUndo().sharedModuleTemplates.Remove(pageToDelete);
+        gui.BuildText(element.name);
+    }
+
+    public override void Activated() {
+        base.Activated();
+        templateList.RebuildContents();
+    }
+
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Module templates");
+        templateList.Build(gui);
+        if (pageToDelete != null) {
+            _ = Project.current.RecordUndo().sharedModuleTemplates.Remove(pageToDelete);
+            RefreshList();
+            pageToDelete = null;
+        }
+        using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
+            if (gui.BuildButton("Create", active: newPageName != "")) {
+                ProjectModuleTemplate template = new(Project.current, newPageName);
+                Project.current.RecordUndo().sharedModuleTemplates.Add(template);
+                newPageName = "";
+                ModuleCustomizationScreen.Show(template);
                 RefreshList();
-                pageToDelete = null;
             }
-            using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
-                if (gui.BuildButton("Create", active: newPageName != "")) {
-                    ProjectModuleTemplate template = new(Project.current, newPageName);
-                    Project.current.RecordUndo().sharedModuleTemplates.Add(template);
-                    newPageName = "";
-                    ModuleCustomizationScreen.Show(template);
-                    RefreshList();
-                }
 
-                _ = gui.RemainingRow().BuildTextInput(newPageName, out newPageName, "Create new template", setInitialFocus: true);
-            }
+            _ = gui.RemainingRow().BuildTextInput(newPageName, out newPageName, "Create new template", setInitialFocus: true);
         }
     }
 }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -3,87 +3,86 @@ using System.Collections.Generic;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow row, float flow)> {
-        private readonly ProductionLink link;
-        private readonly List<(RecipeRow row, float flow)> input = [];
-        private readonly List<(RecipeRow row, float flow)> output = [];
-        private float totalInput, totalOutput;
-        private readonly ScrollArea scrollArea;
+namespace Yafc;
+public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow row, float flow)> {
+    private readonly ProductionLink link;
+    private readonly List<(RecipeRow row, float flow)> input = [];
+    private readonly List<(RecipeRow row, float flow)> output = [];
+    private float totalInput, totalOutput;
+    private readonly ScrollArea scrollArea;
 
-        private ProductionLinkSummaryScreen(ProductionLink link) {
-            scrollArea = new ScrollArea(30, BuildScrollArea);
-            this.link = link;
-            CalculateFlow(link);
-        }
-
-        private void BuildScrollArea(ImGui gui) {
-            gui.BuildText("Production: " + DataUtils.FormatAmount(totalInput, link.goods.flowUnitOfMeasure), Font.subheader);
-            BuildFlow(gui, input, totalInput);
-            gui.spacing = 0.5f;
-            gui.BuildText("Consumption: " + DataUtils.FormatAmount(totalOutput, link.goods.flowUnitOfMeasure), Font.subheader);
-            BuildFlow(gui, output, totalOutput);
-            if (link.amount != 0) {
-                gui.spacing = 0.5f;
-                gui.BuildText((link.amount > 0 ? "Requested production: " : "Requested consumption: ") + DataUtils.FormatAmount(MathF.Abs(link.amount), link.goods.flowUnitOfMeasure), new TextBlockDisplayStyle(Font.subheader, Color: SchemeColor.GreenAlt));
-            }
-            if (link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) && totalInput != totalOutput + link.amount) {
-                float amount = totalInput - totalOutput - link.amount;
-                gui.spacing = 0.5f;
-                gui.BuildText((amount > 0 ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(amount), link.goods.flowUnitOfMeasure), new TextBlockDisplayStyle(Font.subheader, Color: SchemeColor.Error));
-            }
-        }
-
-        public override void Build(ImGui gui) {
-            BuildHeader(gui, "Link summary");
-            scrollArea.Build(gui);
-            if (gui.BuildButton("Done")) {
-                Close();
-            }
-        }
-
-        protected override void ReturnPressed() => Close();
-
-        private void BuildFlow(ImGui gui, List<(RecipeRow row, float flow)> list, float total) {
-            gui.spacing = 0f;
-            foreach (var (row, flow) in list) {
-                _ = gui.BuildFactorioObjectButtonWithText(row.recipe, DataUtils.FormatAmount(flow, link.goods.flowUnitOfMeasure));
-                if (gui.isBuilding) {
-                    var lastRect = gui.lastRect;
-                    lastRect.Width *= (flow / total);
-                    gui.DrawRectangle(lastRect, SchemeColor.Primary);
-                }
-            }
-
-        }
-
-        private void CalculateFlow(ProductionLink link) {
-            totalInput = 0;
-            totalOutput = 0;
-            foreach (var recipe in link.capturedRecipes) {
-                float production = recipe.GetProductionForRow(link.goods);
-                float consumption = recipe.GetConsumptionForRow(link.goods);
-                float fuelUsage = recipe.fuel == link.goods ? recipe.FuelInformation.Amount : 0;
-                float localFlow = production - consumption - fuelUsage;
-                if (localFlow > 0) {
-                    input.Add((recipe, localFlow));
-                    totalInput += localFlow;
-                }
-                else if (localFlow < 0) {
-                    output.Add((recipe, -localFlow));
-                    totalOutput -= localFlow;
-                }
-            }
-            input.Sort(this);
-            output.Sort(this);
-            Rebuild();
-            scrollArea.RebuildContents();
-        }
-
-        public static void Show(ProductionLink link) {
-            _ = MainScreen.Instance.ShowPseudoScreen(new ProductionLinkSummaryScreen(link));
-        }
-
-        public int Compare((RecipeRow row, float flow) x, (RecipeRow row, float flow) y) => y.flow.CompareTo(x.flow);
+    private ProductionLinkSummaryScreen(ProductionLink link) {
+        scrollArea = new ScrollArea(30, BuildScrollArea);
+        this.link = link;
+        CalculateFlow(link);
     }
+
+    private void BuildScrollArea(ImGui gui) {
+        gui.BuildText("Production: " + DataUtils.FormatAmount(totalInput, link.goods.flowUnitOfMeasure), Font.subheader);
+        BuildFlow(gui, input, totalInput);
+        gui.spacing = 0.5f;
+        gui.BuildText("Consumption: " + DataUtils.FormatAmount(totalOutput, link.goods.flowUnitOfMeasure), Font.subheader);
+        BuildFlow(gui, output, totalOutput);
+        if (link.amount != 0) {
+            gui.spacing = 0.5f;
+            gui.BuildText((link.amount > 0 ? "Requested production: " : "Requested consumption: ") + DataUtils.FormatAmount(MathF.Abs(link.amount), link.goods.flowUnitOfMeasure), new TextBlockDisplayStyle(Font.subheader, Color: SchemeColor.GreenAlt));
+        }
+        if (link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) && totalInput != totalOutput + link.amount) {
+            float amount = totalInput - totalOutput - link.amount;
+            gui.spacing = 0.5f;
+            gui.BuildText((amount > 0 ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(amount), link.goods.flowUnitOfMeasure), new TextBlockDisplayStyle(Font.subheader, Color: SchemeColor.Error));
+        }
+    }
+
+    public override void Build(ImGui gui) {
+        BuildHeader(gui, "Link summary");
+        scrollArea.Build(gui);
+        if (gui.BuildButton("Done")) {
+            Close();
+        }
+    }
+
+    protected override void ReturnPressed() => Close();
+
+    private void BuildFlow(ImGui gui, List<(RecipeRow row, float flow)> list, float total) {
+        gui.spacing = 0f;
+        foreach (var (row, flow) in list) {
+            _ = gui.BuildFactorioObjectButtonWithText(row.recipe, DataUtils.FormatAmount(flow, link.goods.flowUnitOfMeasure));
+            if (gui.isBuilding) {
+                var lastRect = gui.lastRect;
+                lastRect.Width *= (flow / total);
+                gui.DrawRectangle(lastRect, SchemeColor.Primary);
+            }
+        }
+
+    }
+
+    private void CalculateFlow(ProductionLink link) {
+        totalInput = 0;
+        totalOutput = 0;
+        foreach (var recipe in link.capturedRecipes) {
+            float production = recipe.GetProductionForRow(link.goods);
+            float consumption = recipe.GetConsumptionForRow(link.goods);
+            float fuelUsage = recipe.fuel == link.goods ? recipe.FuelInformation.Amount : 0;
+            float localFlow = production - consumption - fuelUsage;
+            if (localFlow > 0) {
+                input.Add((recipe, localFlow));
+                totalInput += localFlow;
+            }
+            else if (localFlow < 0) {
+                output.Add((recipe, -localFlow));
+                totalOutput -= localFlow;
+            }
+        }
+        input.Sort(this);
+        output.Sort(this);
+        Rebuild();
+        scrollArea.RebuildContents();
+    }
+
+    public static void Show(ProductionLink link) {
+        _ = MainScreen.Instance.ShowPseudoScreen(new ProductionLinkSummaryScreen(link));
+    }
+
+    public int Compare((RecipeRow row, float flow) x, (RecipeRow row, float flow) y) => y.flow.CompareTo(x.flow);
 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -3,304 +3,303 @@ using System.Collections.Generic;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    /// <summary>
-    /// <para>
-    /// This is a flat hierarchy that can be used to display a table with nested groups in a single list.
-    /// The method <see cref="BuildFlatHierarchy"/> flattens the tree.
-    /// </para>
-    /// <para>
-    /// This class interacts tightly with <see cref="ProductionTableView"/>. The computation of the rendering
-    /// state occurs at multiple stages, resulting in some interleaving. This is due to YAFC utilizing an
-    /// intermediate GUI architecture with loop-based rendering via SDL instead of employing an event-based
-    /// GUI system.
-    /// </para>
-    /// </summary>
-    public class FlatHierarchy<TRow, TGroup> where TRow : ModelObject<TGroup>, IGroupedElement<TGroup> where TGroup : ModelObject<ModelObject>, IElementGroup<TRow> {
-        private readonly DataGrid<TRow> grid;
-        // These two arrays contain:
-        // - (recipe, null) for rows with no subgroup or with a collapsed subgroup
-        // - (recipe, subgroup) for rows with an expanded subgroup
-        // - (null, subgroup) to mark the end of the expanded subgroup
-        private readonly List<TRow?> flatRecipes = [];
-        private readonly List<TGroup?> flatGroups = [];
-        private readonly List<RowHighlighting> rowHighlighting = [];
-        private TRow? draggingRecipe;
-        private TGroup root = null!; // null-forgiving: root is set by SetData whenever the selected page is set or the chevrons are clicked.
-        private bool rebuildRequired;
-        private readonly Action<ImGui, TGroup>? drawTableHeader;
-        private readonly string emptyGroupMessage;
-        private readonly bool buildExpandedGroupRows;
+namespace Yafc;
+/// <summary>
+/// <para>
+/// This is a flat hierarchy that can be used to display a table with nested groups in a single list.
+/// The method <see cref="BuildFlatHierarchy"/> flattens the tree.
+/// </para>
+/// <para>
+/// This class interacts tightly with <see cref="ProductionTableView"/>. The computation of the rendering
+/// state occurs at multiple stages, resulting in some interleaving. This is due to YAFC utilizing an
+/// intermediate GUI architecture with loop-based rendering via SDL instead of employing an event-based
+/// GUI system.
+/// </para>
+/// </summary>
+public class FlatHierarchy<TRow, TGroup> where TRow : ModelObject<TGroup>, IGroupedElement<TGroup> where TGroup : ModelObject<ModelObject>, IElementGroup<TRow> {
+    private readonly DataGrid<TRow> grid;
+    // These two arrays contain:
+    // - (recipe, null) for rows with no subgroup or with a collapsed subgroup
+    // - (recipe, subgroup) for rows with an expanded subgroup
+    // - (null, subgroup) to mark the end of the expanded subgroup
+    private readonly List<TRow?> flatRecipes = [];
+    private readonly List<TGroup?> flatGroups = [];
+    private readonly List<RowHighlighting> rowHighlighting = [];
+    private TRow? draggingRecipe;
+    private TGroup root = null!; // null-forgiving: root is set by SetData whenever the selected page is set or the chevrons are clicked.
+    private bool rebuildRequired;
+    private readonly Action<ImGui, TGroup>? drawTableHeader;
+    private readonly string emptyGroupMessage;
+    private readonly bool buildExpandedGroupRows;
 
-        public FlatHierarchy(DataGrid<TRow> grid, Action<ImGui, TGroup>? drawTableHeader, string emptyGroupMessage = "This is an empty group", bool buildExpandedGroupRows = true) {
-            this.grid = grid;
-            this.drawTableHeader = drawTableHeader;
-            this.emptyGroupMessage = emptyGroupMessage;
-            this.buildExpandedGroupRows = buildExpandedGroupRows;
+    public FlatHierarchy(DataGrid<TRow> grid, Action<ImGui, TGroup>? drawTableHeader, string emptyGroupMessage = "This is an empty group", bool buildExpandedGroupRows = true) {
+        this.grid = grid;
+        this.drawTableHeader = drawTableHeader;
+        this.emptyGroupMessage = emptyGroupMessage;
+        this.buildExpandedGroupRows = buildExpandedGroupRows;
+    }
+
+    public float width => grid.width;
+    public void SetData(TGroup table) {
+        root = table;
+        rebuildRequired = true;
+    }
+
+    private (TGroup?, int) FindDraggingRecipeParentAndIndex() {
+        int index = flatRecipes.IndexOf(draggingRecipe);
+        if (index == -1) {
+            return default;
         }
 
-        public float width => grid.width;
-        public void SetData(TGroup table) {
-            root = table;
-            rebuildRequired = true;
-        }
-
-        private (TGroup?, int) FindDraggingRecipeParentAndIndex() {
-            int index = flatRecipes.IndexOf(draggingRecipe);
-            if (index == -1) {
-                return default;
-            }
-
-            int currentIndex = 0;
-            for (int i = index - 1; i >= 0; i--) {
-                if (flatRecipes[i] is TRow recipe) {
-                    var group = recipe.subgroup;
-                    if (group != null && group.expanded) {
-                        return (group, currentIndex);
-                    }
+        int currentIndex = 0;
+        for (int i = index - 1; i >= 0; i--) {
+            if (flatRecipes[i] is TRow recipe) {
+                var group = recipe.subgroup;
+                if (group != null && group.expanded) {
+                    return (group, currentIndex);
                 }
-                else {
-                    i = flatRecipes.LastIndexOf(flatGroups[i]!.owner as TRow, i); // null-forgiving: The construction of flatRows and flatGroups guarantees they aren't both null at the same index.
-                }
-
-                currentIndex++;
-            }
-            return (root, currentIndex);
-        }
-
-        private void ActuallyMoveDraggingRecipe() {
-            var (parent, index) = FindDraggingRecipeParentAndIndex();
-            if (parent == null) {
-                return;
-            }
-
-            if (draggingRecipe!.owner == parent && parent.elements[index] == draggingRecipe) { // null-forgiving: Only called after checking that draggingRecipe is not null.
-                return;
-            }
-
-            _ = draggingRecipe.owner.RecordUndo().elements.Remove(draggingRecipe);
-            draggingRecipe.SetOwner(parent);
-            parent.RecordUndo().elements.Insert(index, draggingRecipe);
-        }
-
-        private void MoveFlatHierarchy(TRow from, TRow to) {
-            draggingRecipe = from;
-            int indexFrom = flatRecipes.IndexOf(from);
-            int indexTo = flatRecipes.IndexOf(to);
-            flatRecipes.MoveListElementIndex(indexFrom, indexTo);
-            flatGroups.MoveListElementIndex(indexFrom, indexTo);
-        }
-
-        private void MoveFlatHierarchy(TRow from, TGroup to) {
-            draggingRecipe = from;
-            int indexFrom = flatRecipes.IndexOf(from);
-            int indexTo = flatGroups.IndexOf(to);
-            flatRecipes.MoveListElementIndex(indexFrom, indexTo);
-            flatGroups.MoveListElementIndex(indexFrom, indexTo);
-        }
-
-        private readonly Stack<float> depthStart = new Stack<float>();
-
-        /// <summary>
-        /// This method alternates between the two row background colors, which in turn increase readability.
-        /// If a row is highlighted, the background color is set to the highlighting color without alternation.
-        /// </summary>
-        /// <param name="color">Current background color</param>
-        private void SwapBgColor(ref SchemeColor color) {
-            if (nextRowIsHighlighted) {
-                color = nextRowBackgroundColor;
             }
             else {
-                color = (color == SchemeColor.Background) ? SchemeColor.PureBackground : SchemeColor.Background;
+                i = flatRecipes.LastIndexOf(flatGroups[i]!.owner as TRow, i); // null-forgiving: The construction of flatRows and flatGroups guarantees they aren't both null at the same index.
             }
+
+            currentIndex++;
         }
-
-        /// <summary>
-        /// This property is utilized by the rendering code to determine whether a row that will be drawn
-        /// requires highlighting.
-        /// </summary>
-        public bool nextRowIsHighlighted { get; private set; }
-
-        public SchemeColor nextRowBackgroundColor { get; private set; }
-        public SchemeColor nextRowTextColor { get; private set; }
-
-        public void Build(ImGui gui) {
-            if (draggingRecipe != null && !gui.isDragging) {
-                ActuallyMoveDraggingRecipe();
-                draggingRecipe = null;
-                rebuildRequired = true;
-            }
-            if (rebuildRequired) {
-                Rebuild();
-            }
-
-            grid.BeginBuildingContent(gui);
-            var bgColor = SchemeColor.PureBackground;
-            int depth = 0;
-            float depWidth = 0f;
-            for (int i = 0; i < flatRecipes.Count; i++) {
-                var recipe = flatRecipes[i];
-                var item = flatGroups[i];
-
-                nextRowIsHighlighted = (typeof(TRow) == typeof(RecipeRow)) && (rowHighlighting[i] != RowHighlighting.None);
-
-                // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
-                //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550369353
-                if (nextRowIsHighlighted) {
-                    nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i], recipe is RecipeRow { enabled: true });
-                    nextRowTextColor = GetHighlightingTextColor(rowHighlighting[i]);
-                }
-                else {
-                    nextRowBackgroundColor = bgColor;
-                    nextRowTextColor = SchemeColor.BackgroundText;
-                }
-
-                bool isError = recipe is RecipeRow r && r.warningFlags >= WarningFlags.EntityNotSpecified;
-                if (isError) {
-                    nextRowBackgroundColor = SchemeColor.Error;
-                    nextRowTextColor = SchemeColor.PureForeground;
-                }
-
-                if (recipe != null) {
-                    if (!recipe.visible) {
-                        if (item != null) {
-                            i = flatGroups.LastIndexOf(item);
-                        }
-
-                        continue;
-                    }
-
-                    if (item != null) {
-                        depth++;
-                        SwapBgColor(ref bgColor);
-                        depWidth = depth * 0.5f;
-                        if (gui.isBuilding) {
-                            depthStart.Push(gui.statePosition.Bottom);
-                        }
-                    }
-
-                    if (buildExpandedGroupRows || item == null) {
-                        var rect = grid.BuildRow(gui, recipe, depWidth);
-                        if (item == null && gui.InitiateDrag(rect, rect, recipe, bgColor)) {
-                            draggingRecipe = recipe;
-                        }
-                        else if (gui.ConsumeDrag(rect.Center, recipe)) {
-                            MoveFlatHierarchy(gui.GetDraggingObject<TRow>()!, recipe); // null-forgiving: currentDraggingObject is set to recipe (a non-null TRow, despite several checks for RecipeRow) by InitiateDrag
-                        }
-
-                        if (nextRowIsHighlighted || isError) {
-                            rect.X += depWidth;
-                            rect.Width -= depWidth;
-                            gui.DrawRectangle(rect, nextRowBackgroundColor);
-                        }
-                    }
-                    if (item != null) {
-                        if (item.elements.Count == 0) {
-                            using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
-                                gui.BuildText(emptyGroupMessage, TextBlockDisplayStyle.WrappedText); // set color if the nested row is empty
-                            }
-                        }
-
-                        if (drawTableHeader != null) {
-                            using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
-                                drawTableHeader(gui, item);
-                            }
-                        }
-                    }
-                }
-                else {
-                    if (gui.isBuilding) {
-                        float top = depthStart.Pop();
-                        // set color bgColor if the row is a nested table and is not collapsed
-                        gui.DrawRectangle(new Rect(depWidth, top, grid.width - depWidth, gui.statePosition.Bottom - top), bgColor, RectangleBorder.Thin);
-                    }
-                    SwapBgColor(ref bgColor);
-                    depth--;
-                    depWidth = depth * 0.5f;
-                    _ = gui.AllocateRect(20f, 0.5f);
-                }
-            }
-            var fullRect = grid.EndBuildingContent(gui);
-            gui.DrawRectangle(fullRect, SchemeColor.PureBackground);
-        }
-
-        private void Rebuild() {
-            flatRecipes.Clear();
-            flatGroups.Clear();
-            rowHighlighting.Clear();
-
-            BuildFlatHierarchy(root);
-            rebuildRequired = false;
-        }
-
-        private void BuildFlatHierarchy(TGroup table, RowHighlighting parentHighlight = RowHighlighting.None) {
-            foreach (var recipe in table.elements) {
-                flatRecipes.Add(recipe);
-
-                RowHighlighting highlight = parentHighlight;
-
-                if (recipe is RecipeRow r && r.highlighting != RowHighlighting.None) {
-                    // Only respect any highlighting if the recipe is in fact a RecipeRow
-                    highlight = r.highlighting;
-                }
-
-                rowHighlighting.Add(highlight);
-
-                var sub = recipe.subgroup;
-
-                if (sub is { expanded: true }) {
-                    flatGroups.Add(sub);
-
-                    BuildFlatHierarchy(sub, highlight); // Pass the current highlight color to the child rows
-
-                    // The flattened hierarchy contains empty rows for the nested table. But since this
-                    // is a rendering issue, it is not necessary to add them to the actual data structure.
-                    // TODO: Investigate why this is needed and how to clean it up.
-                    flatRecipes.Add(null);
-                    flatGroups.Add(sub);
-                    rowHighlighting.Add(RowHighlighting.None);
-                }
-                else {
-                    flatGroups.Add(null);
-                }
-            }
-        }
-
-        public void BuildHeader(ImGui gui) => grid.BuildHeader(gui);
-
-        /// <summary>
-        /// This method is used to determine the background color for a highlighted row. To avoid
-        /// excessive coupling, the tag state and the row color are kept separate.
-        /// </summary>
-        /// <param name="highlighting">
-        /// Represents the highlighting state for which the corresponding color needs to be determined.
-        /// </param>
-        /// <param name="isEnabled">
-        /// If the row is not enabled, a fainter color is used.
-        /// </param>
-        /// <returns></returns>
-        private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting, bool isEnabled) => highlighting switch {
-            RowHighlighting.Green => isEnabled ? SchemeColor.TagColorGreen : SchemeColor.TagColorGreenAlt,
-            RowHighlighting.Yellow => isEnabled ? SchemeColor.TagColorYellow : SchemeColor.TagColorYellowAlt,
-            RowHighlighting.Red => isEnabled ? SchemeColor.TagColorRed : SchemeColor.TagColorRedAlt,
-            RowHighlighting.Blue => isEnabled ? SchemeColor.TagColorBlue : SchemeColor.TagColorBlueAlt,
-            _ => SchemeColor.None
-        };
-
-        /// <summary>
-        /// This method is used to determine the text color for a highlighted row. To avoid
-        /// excessive coupling, the tag state and the row color are kept separate.
-        /// </summary>
-        /// <param name="highlighting">
-        /// Represents the highlighting state for which the corresponding color needs to be determined.
-        /// </param>
-        /// <returns></returns>
-        private static SchemeColor GetHighlightingTextColor(RowHighlighting highlighting) => highlighting switch {
-            RowHighlighting.Green => SchemeColor.TagColorGreenText,
-            RowHighlighting.Yellow => SchemeColor.TagColorYellowText,
-            RowHighlighting.Red => SchemeColor.TagColorRedText,
-            RowHighlighting.Blue => SchemeColor.TagColorBlueText,
-            _ => SchemeColor.None
-        };
+        return (root, currentIndex);
     }
+
+    private void ActuallyMoveDraggingRecipe() {
+        var (parent, index) = FindDraggingRecipeParentAndIndex();
+        if (parent == null) {
+            return;
+        }
+
+        if (draggingRecipe!.owner == parent && parent.elements[index] == draggingRecipe) { // null-forgiving: Only called after checking that draggingRecipe is not null.
+            return;
+        }
+
+        _ = draggingRecipe.owner.RecordUndo().elements.Remove(draggingRecipe);
+        draggingRecipe.SetOwner(parent);
+        parent.RecordUndo().elements.Insert(index, draggingRecipe);
+    }
+
+    private void MoveFlatHierarchy(TRow from, TRow to) {
+        draggingRecipe = from;
+        int indexFrom = flatRecipes.IndexOf(from);
+        int indexTo = flatRecipes.IndexOf(to);
+        flatRecipes.MoveListElementIndex(indexFrom, indexTo);
+        flatGroups.MoveListElementIndex(indexFrom, indexTo);
+    }
+
+    private void MoveFlatHierarchy(TRow from, TGroup to) {
+        draggingRecipe = from;
+        int indexFrom = flatRecipes.IndexOf(from);
+        int indexTo = flatGroups.IndexOf(to);
+        flatRecipes.MoveListElementIndex(indexFrom, indexTo);
+        flatGroups.MoveListElementIndex(indexFrom, indexTo);
+    }
+
+    private readonly Stack<float> depthStart = new Stack<float>();
+
+    /// <summary>
+    /// This method alternates between the two row background colors, which in turn increase readability.
+    /// If a row is highlighted, the background color is set to the highlighting color without alternation.
+    /// </summary>
+    /// <param name="color">Current background color</param>
+    private void SwapBgColor(ref SchemeColor color) {
+        if (nextRowIsHighlighted) {
+            color = nextRowBackgroundColor;
+        }
+        else {
+            color = (color == SchemeColor.Background) ? SchemeColor.PureBackground : SchemeColor.Background;
+        }
+    }
+
+    /// <summary>
+    /// This property is utilized by the rendering code to determine whether a row that will be drawn
+    /// requires highlighting.
+    /// </summary>
+    public bool nextRowIsHighlighted { get; private set; }
+
+    public SchemeColor nextRowBackgroundColor { get; private set; }
+    public SchemeColor nextRowTextColor { get; private set; }
+
+    public void Build(ImGui gui) {
+        if (draggingRecipe != null && !gui.isDragging) {
+            ActuallyMoveDraggingRecipe();
+            draggingRecipe = null;
+            rebuildRequired = true;
+        }
+        if (rebuildRequired) {
+            Rebuild();
+        }
+
+        grid.BeginBuildingContent(gui);
+        var bgColor = SchemeColor.PureBackground;
+        int depth = 0;
+        float depWidth = 0f;
+        for (int i = 0; i < flatRecipes.Count; i++) {
+            var recipe = flatRecipes[i];
+            var item = flatGroups[i];
+
+            nextRowIsHighlighted = (typeof(TRow) == typeof(RecipeRow)) && (rowHighlighting[i] != RowHighlighting.None);
+
+            // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
+            //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550369353
+            if (nextRowIsHighlighted) {
+                nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i], recipe is RecipeRow { enabled: true });
+                nextRowTextColor = GetHighlightingTextColor(rowHighlighting[i]);
+            }
+            else {
+                nextRowBackgroundColor = bgColor;
+                nextRowTextColor = SchemeColor.BackgroundText;
+            }
+
+            bool isError = recipe is RecipeRow r && r.warningFlags >= WarningFlags.EntityNotSpecified;
+            if (isError) {
+                nextRowBackgroundColor = SchemeColor.Error;
+                nextRowTextColor = SchemeColor.PureForeground;
+            }
+
+            if (recipe != null) {
+                if (!recipe.visible) {
+                    if (item != null) {
+                        i = flatGroups.LastIndexOf(item);
+                    }
+
+                    continue;
+                }
+
+                if (item != null) {
+                    depth++;
+                    SwapBgColor(ref bgColor);
+                    depWidth = depth * 0.5f;
+                    if (gui.isBuilding) {
+                        depthStart.Push(gui.statePosition.Bottom);
+                    }
+                }
+
+                if (buildExpandedGroupRows || item == null) {
+                    var rect = grid.BuildRow(gui, recipe, depWidth);
+                    if (item == null && gui.InitiateDrag(rect, rect, recipe, bgColor)) {
+                        draggingRecipe = recipe;
+                    }
+                    else if (gui.ConsumeDrag(rect.Center, recipe)) {
+                        MoveFlatHierarchy(gui.GetDraggingObject<TRow>()!, recipe); // null-forgiving: currentDraggingObject is set to recipe (a non-null TRow, despite several checks for RecipeRow) by InitiateDrag
+                    }
+
+                    if (nextRowIsHighlighted || isError) {
+                        rect.X += depWidth;
+                        rect.Width -= depWidth;
+                        gui.DrawRectangle(rect, nextRowBackgroundColor);
+                    }
+                }
+                if (item != null) {
+                    if (item.elements.Count == 0) {
+                        using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
+                            gui.BuildText(emptyGroupMessage, TextBlockDisplayStyle.WrappedText); // set color if the nested row is empty
+                        }
+                    }
+
+                    if (drawTableHeader != null) {
+                        using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
+                            drawTableHeader(gui, item);
+                        }
+                    }
+                }
+            }
+            else {
+                if (gui.isBuilding) {
+                    float top = depthStart.Pop();
+                    // set color bgColor if the row is a nested table and is not collapsed
+                    gui.DrawRectangle(new Rect(depWidth, top, grid.width - depWidth, gui.statePosition.Bottom - top), bgColor, RectangleBorder.Thin);
+                }
+                SwapBgColor(ref bgColor);
+                depth--;
+                depWidth = depth * 0.5f;
+                _ = gui.AllocateRect(20f, 0.5f);
+            }
+        }
+        var fullRect = grid.EndBuildingContent(gui);
+        gui.DrawRectangle(fullRect, SchemeColor.PureBackground);
+    }
+
+    private void Rebuild() {
+        flatRecipes.Clear();
+        flatGroups.Clear();
+        rowHighlighting.Clear();
+
+        BuildFlatHierarchy(root);
+        rebuildRequired = false;
+    }
+
+    private void BuildFlatHierarchy(TGroup table, RowHighlighting parentHighlight = RowHighlighting.None) {
+        foreach (var recipe in table.elements) {
+            flatRecipes.Add(recipe);
+
+            RowHighlighting highlight = parentHighlight;
+
+            if (recipe is RecipeRow r && r.highlighting != RowHighlighting.None) {
+                // Only respect any highlighting if the recipe is in fact a RecipeRow
+                highlight = r.highlighting;
+            }
+
+            rowHighlighting.Add(highlight);
+
+            var sub = recipe.subgroup;
+
+            if (sub is { expanded: true }) {
+                flatGroups.Add(sub);
+
+                BuildFlatHierarchy(sub, highlight); // Pass the current highlight color to the child rows
+
+                // The flattened hierarchy contains empty rows for the nested table. But since this
+                // is a rendering issue, it is not necessary to add them to the actual data structure.
+                // TODO: Investigate why this is needed and how to clean it up.
+                flatRecipes.Add(null);
+                flatGroups.Add(sub);
+                rowHighlighting.Add(RowHighlighting.None);
+            }
+            else {
+                flatGroups.Add(null);
+            }
+        }
+    }
+
+    public void BuildHeader(ImGui gui) => grid.BuildHeader(gui);
+
+    /// <summary>
+    /// This method is used to determine the background color for a highlighted row. To avoid
+    /// excessive coupling, the tag state and the row color are kept separate.
+    /// </summary>
+    /// <param name="highlighting">
+    /// Represents the highlighting state for which the corresponding color needs to be determined.
+    /// </param>
+    /// <param name="isEnabled">
+    /// If the row is not enabled, a fainter color is used.
+    /// </param>
+    /// <returns></returns>
+    private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting, bool isEnabled) => highlighting switch {
+        RowHighlighting.Green => isEnabled ? SchemeColor.TagColorGreen : SchemeColor.TagColorGreenAlt,
+        RowHighlighting.Yellow => isEnabled ? SchemeColor.TagColorYellow : SchemeColor.TagColorYellowAlt,
+        RowHighlighting.Red => isEnabled ? SchemeColor.TagColorRed : SchemeColor.TagColorRedAlt,
+        RowHighlighting.Blue => isEnabled ? SchemeColor.TagColorBlue : SchemeColor.TagColorBlueAlt,
+        _ => SchemeColor.None
+    };
+
+    /// <summary>
+    /// This method is used to determine the text color for a highlighted row. To avoid
+    /// excessive coupling, the tag state and the row color are kept separate.
+    /// </summary>
+    /// <param name="highlighting">
+    /// Represents the highlighting state for which the corresponding color needs to be determined.
+    /// </param>
+    /// <returns></returns>
+    private static SchemeColor GetHighlightingTextColor(RowHighlighting highlighting) => highlighting switch {
+        RowHighlighting.Green => SchemeColor.TagColorGreenText,
+        RowHighlighting.Yellow => SchemeColor.TagColorYellowText,
+        RowHighlighting.Red => SchemeColor.TagColorRedText,
+        RowHighlighting.Blue => SchemeColor.TagColorBlueText,
+        _ => SchemeColor.None
+    };
 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1031,6 +1031,7 @@ goodsHaveNoProduction:;
                     // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
                     iconColor = SchemeColor.Error;
                 }
+                // TODO (shpaass/yafc-ce/issues/269): refactor enum check into explicit instead of ordinal instructions
                 else if (dropdownType >= ProductDropdownType.Product && CheckPossibleOverproducing(link)) {
                     // Actual overproduction occurred in the recipe
                     iconColor = SchemeColor.Magenta;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -8,370 +8,382 @@ using Yafc.Model;
 using Yafc.Parser;
 using Yafc.UI;
 
-namespace Yafc {
-    public class ProductionTableView : ProjectPageView<ProductionTable> {
-        private readonly FlatHierarchy<RecipeRow, ProductionTable> flatHierarchyBuilder;
+namespace Yafc;
+public class ProductionTableView : ProjectPageView<ProductionTable> {
+    private readonly FlatHierarchy<RecipeRow, ProductionTable> flatHierarchyBuilder;
 
-        public ProductionTableView() {
-            DataGrid<RecipeRow> grid = new DataGrid<RecipeRow>(new RecipePadColumn(this), new RecipeColumn(this), new EntityColumn(this), new IngredientsColumn(this), new ProductsColumn(this), new ModulesColumn(this));
-            flatHierarchyBuilder = new FlatHierarchy<RecipeRow, ProductionTable>(grid, BuildSummary, "This is a nested group. You can drag&drop recipes here. Nested groups can have their own linked materials.");
-        }
+    public ProductionTableView() {
+        DataGrid<RecipeRow> grid = new DataGrid<RecipeRow>(new RecipePadColumn(this), new RecipeColumn(this), new EntityColumn(this), new IngredientsColumn(this), new ProductsColumn(this), new ModulesColumn(this));
+        flatHierarchyBuilder = new FlatHierarchy<RecipeRow, ProductionTable>(grid, BuildSummary, "This is a nested group. You can drag&drop recipes here. Nested groups can have their own linked materials.");
+    }
 
-        /// <param name="widthStorage">If not <see langword="null"/>, names an instance property in <see cref="Preferences"/> that will be used to store the width of this column.
-        /// If the current value of the property is out of range, the initial width will be <paramref name="initialWidth"/>.</param>
-        private abstract class ProductionTableDataColumn(ProductionTableView view, string header, float initialWidth, float minWidth = 0, float maxWidth = 0, bool hasMenu = true, string? widthStorage = null)
-            : TextDataColumn<RecipeRow>(header, initialWidth, minWidth, maxWidth, hasMenu, widthStorage) {
-            protected readonly ProductionTableView view = view;
-        }
+    /// <param name="widthStorage">If not <see langword="null"/>, names an instance property in <see cref="Preferences"/> that will be used to store the width of this column.
+    /// If the current value of the property is out of range, the initial width will be <paramref name="initialWidth"/>.</param>
+    private abstract class ProductionTableDataColumn(ProductionTableView view, string header, float initialWidth, float minWidth = 0, float maxWidth = 0, bool hasMenu = true, string? widthStorage = null)
+        : TextDataColumn<RecipeRow>(header, initialWidth, minWidth, maxWidth, hasMenu, widthStorage) {
+        protected readonly ProductionTableView view = view;
+    }
 
-        private class RecipePadColumn(ProductionTableView view) : ProductionTableDataColumn(view, "", 3f, hasMenu: false) {
-            public override void BuildElement(ImGui gui, RecipeRow row) {
-                gui.allocator = RectAllocator.Center;
-                gui.spacing = 0f;
-                if (row.subgroup != null) {
-                    if (gui.BuildButton(row.subgroup.expanded ? Icon.ShevronDown : Icon.ShevronRight)) {
-                        if (InputSystem.Instance.control) {
-                            toggleAll(!row.subgroup.expanded, view.model);
-                        }
-                        else {
-                            row.subgroup.RecordChange().expanded = !row.subgroup.expanded;
-                        }
-
-                        view.flatHierarchyBuilder.SetData(view.model);
-                    }
-                }
-
-
-                if (row.warningFlags != 0) {
-                    bool isError = row.warningFlags >= WarningFlags.EntityNotSpecified;
-                    bool hover;
-                    if (isError) {
-                        hover = gui.BuildRedButton(Icon.Error, invertedColors: true) == ButtonEvent.MouseOver;
-                    }
-                    else {
-                        using (gui.EnterGroup(ImGuiUtils.DefaultIconPadding)) {
-                            gui.BuildIcon(Icon.Help);
-                        }
-
-                        hover = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver;
-                    }
-                    if (hover) {
-                        gui.ShowTooltip(g => {
-                            if (isError) {
-                                g.boxColor = SchemeColor.Error;
-                                g.textColor = SchemeColor.ErrorText;
-                            }
-                            foreach (var (flag, text) in WarningsMeaning) {
-                                if ((row.warningFlags & flag) != 0) {
-                                    g.BuildText(text, TextBlockDisplayStyle.WrappedText);
-                                }
-                            }
-                        });
-                    }
-                }
-                else {
-                    if (row.tag != 0) {
-                        BuildRowMarker(gui, row);
-                    }
-                }
-
-                static void toggleAll(bool state, ProductionTable table) {
-                    foreach (var subgroup in table.recipes.Select(r => r.subgroup).WhereNotNull()) {
-                        subgroup.RecordChange().expanded = state;
-                        toggleAll(state, subgroup);
-                    }
-                }
-            }
-
-            private void BuildRowMarker(ImGui gui, RecipeRow row) {
-                int markerId = row.tag;
-                if (markerId < 0 || markerId >= tagIcons.Length) {
-                    markerId = 0;
-                }
-
-                var (icon, color) = tagIcons[markerId];
-                gui.BuildIcon(icon, color: color);
-                if (gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt)) {
-                    gui.ShowDropDown(imGui => view.DrawRecipeTagSelect(imGui, row));
-                }
-            }
-        }
-
-        private class RecipeColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Recipe", 13f, 13f, 30f, widthStorage: nameof(Preferences.recipeColumnWidth)) {
-            public override void BuildElement(ImGui gui, RecipeRow recipe) {
-                gui.spacing = 0.5f;
-                switch (gui.BuildFactorioObjectButton(recipe.recipe, ButtonDisplayStyle.ProductionTableUnscaled)) {
-                    case Click.Left:
-                        gui.ShowDropDown(delegate (ImGui imgui) {
-                            view.DrawRecipeTagSelect(imgui, recipe);
-
-                            if (recipe.subgroup == null && imgui.BuildButton("Create nested table") && imgui.CloseDropdown()) {
-                                recipe.RecordUndo().subgroup = new ProductionTable(recipe);
-                            }
-
-                            if (recipe.subgroup != null && imgui.BuildButton("Add nested desired product") && imgui.CloseDropdown()) {
-                                view.AddDesiredProductAtLevel(recipe.subgroup);
-                            }
-
-                            if (recipe.subgroup != null) {
-                                BuildRecipeButton(imgui, recipe.subgroup);
-                            }
-
-                            if (recipe.subgroup != null && imgui.BuildButton("Unpack nested table").WithTooltip(imgui, recipe.subgroup.expanded ? "Shortcut: right-click" : "Shortcut: Expand, then right-click") && imgui.CloseDropdown()) {
-                                unpackNestedTable();
-                            }
-
-                            if (recipe.subgroup != null && imgui.BuildButton("ShoppingList") && imgui.CloseDropdown()) {
-                                view.BuildShoppingList(recipe);
-                            }
-
-                            if (imgui.BuildCheckBox("Enabled", recipe.enabled, out bool newEnabled)) {
-                                recipe.RecordUndo().enabled = newEnabled;
-                            }
-
-                            BuildFavorites(imgui, recipe.recipe, "Add recipe to favorites");
-
-                            if (recipe.subgroup != null && imgui.BuildRedButton("Delete nested table").WithTooltip(imgui, recipe.subgroup.expanded ? "Shortcut: Collapse, then right-click" : "Shortcut: right-click") && imgui.CloseDropdown()) {
-                                _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
-                            }
-
-                            if (recipe.subgroup == null && imgui.BuildRedButton("Delete recipe").WithTooltip(imgui, "Shortcut: right-click") && imgui.CloseDropdown()) {
-                                _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
-                            }
-                        });
-                        break;
-                    case Click.Right when recipe.subgroup?.expanded ?? false: // With expanded subgroup
-                        unpackNestedTable();
-                        break;
-                    case Click.Right: // With collapsed or no subgroup
-                        _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
-                        break;
-                }
-
-                if (!recipe.enabled) {
-                    gui.textColor = SchemeColor.BackgroundTextFaint;
-                }
-                else if (view.flatHierarchyBuilder.nextRowIsHighlighted) {
-                    gui.textColor = view.flatHierarchyBuilder.nextRowTextColor;
-                }
-                else {
-                    gui.textColor = recipe.hierarchyEnabled ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint;
-                }
-
-                gui.BuildText(recipe.recipe.locName, TextBlockDisplayStyle.WrappedText);
-
-                void unpackNestedTable() {
-                    var evacuate = recipe.subgroup.recipes;
-                    _ = recipe.subgroup.RecordUndo();
-                    recipe.RecordUndo().subgroup = null;
-                    int index = recipe.owner.recipes.IndexOf(recipe);
-                    foreach (var evacRecipe in evacuate) {
-                        evacRecipe.SetOwner(recipe.owner);
-                    }
-
-                    recipe.owner.RecordUndo().recipes.InsertRange(index + 1, evacuate);
-                }
-            }
-
-            private void RemoveZeroRecipes(ProductionTable productionTable) {
-                _ = productionTable.RecordUndo().recipes.RemoveAll(x => x.subgroup == null && x.recipesPerSecond == 0);
-                foreach (var recipe in productionTable.recipes) {
-                    if (recipe.subgroup != null) {
-                        RemoveZeroRecipes(recipe.subgroup);
-                    }
-                }
-            }
-
-            public override void BuildMenu(ImGui gui) {
-                BuildRecipeButton(gui, view.model);
-
-                gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", TextBlockDisplayStyle.WrappedText);
-                using (gui.EnterRow()) {
-                    gui.BuildText("Amount per:");
-                    if (gui.BuildLink("second") && gui.CloseDropdown()) {
-                        ExportIo(1f);
-                    }
-
-                    if (gui.BuildLink("minute") && gui.CloseDropdown()) {
-                        ExportIo(60f);
-                    }
-
-                    if (gui.BuildLink("hour") && gui.CloseDropdown()) {
-                        ExportIo(3600f);
-                    }
-                }
-
-                if (gui.BuildButton("Remove all zero-building recipes") && gui.CloseDropdown()) {
-                    RemoveZeroRecipes(view.model);
-                }
-
-                if (gui.BuildRedButton("Clear recipes") && gui.CloseDropdown()) {
-                    view.model.RecordUndo().recipes.Clear();
-                }
-
-                if (InputSystem.Instance.control && gui.BuildButton("Add ALL recipes") && gui.CloseDropdown()) {
-                    foreach (var recipe in Database.recipes.all) {
-                        if (!recipe.IsAccessible()) {
-                            continue;
-                        }
-
-                        foreach (var ingredient in recipe.ingredients) {
-                            if (ingredient.goods.production.Length == 0) {
-                                // 'goto' is a readable way to break out of a nested loop.
-                                // See https://stackoverflow.com/questions/324831/breaking-out-of-a-nested-loop
-                                goto goodsHaveNoProduction;
-                            }
-                        }
-                        foreach (var product in recipe.products) {
-                            view.CreateLink(view.model, product.goods);
-                        }
-
-                        view.model.AddRecipe(recipe, DefaultVariantOrdering);
-goodsHaveNoProduction:;
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Build the "Add raw recipe" button and handle its clicks.
-            /// </summary>
-            /// <param name="table">The table that will receive the new recipes or technologies, if any are selected</param>
-            private static void BuildRecipeButton(ImGui gui, ProductionTable table) {
-                if (gui.BuildButton("Add raw recipe").WithTooltip(gui, "Ctrl-click to add a technology instead") && gui.CloseDropdown()) {
+    private class RecipePadColumn(ProductionTableView view) : ProductionTableDataColumn(view, "", 3f, hasMenu: false) {
+        public override void BuildElement(ImGui gui, RecipeRow row) {
+            gui.allocator = RectAllocator.Center;
+            gui.spacing = 0f;
+            if (row.subgroup != null) {
+                if (gui.BuildButton(row.subgroup.expanded ? Icon.ShevronDown : Icon.ShevronRight)) {
                     if (InputSystem.Instance.control) {
-                        SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology", r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
+                        toggleAll(!row.subgroup.expanded, view.model);
                     }
                     else {
-                        SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
+                        row.subgroup.RecordChange().expanded = !row.subgroup.expanded;
                     }
+
+                    view.flatHierarchyBuilder.SetData(view.model);
                 }
             }
 
-            private void ExportIo(float multiplier) {
-                List<(Goods, int)> goods = [];
-                foreach (var link in view.model.links) {
-                    int rounded = MathUtils.Round(link.amount * multiplier);
-                    if (rounded == 0) {
-                        continue;
+
+            if (row.warningFlags != 0) {
+                bool isError = row.warningFlags >= WarningFlags.EntityNotSpecified;
+                bool hover;
+                if (isError) {
+                    hover = gui.BuildRedButton(Icon.Error, invertedColors: true) == ButtonEvent.MouseOver;
+                }
+                else {
+                    using (gui.EnterGroup(ImGuiUtils.DefaultIconPadding)) {
+                        gui.BuildIcon(Icon.Help);
                     }
 
-                    goods.Add((link.goods, rounded));
+                    hover = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver;
                 }
-
-                foreach (var flow in view.model.flow) {
-                    int rounded = MathUtils.Round(flow.amount * multiplier);
-                    if (rounded == 0) {
-                        continue;
-                    }
-
-                    goods.Add((flow.goods, rounded));
+                if (hover) {
+                    gui.ShowTooltip(g => {
+                        if (isError) {
+                            g.boxColor = SchemeColor.Error;
+                            g.textColor = SchemeColor.ErrorText;
+                        }
+                        foreach (var (flag, text) in WarningsMeaning) {
+                            if ((row.warningFlags & flag) != 0) {
+                                g.BuildText(text, TextBlockDisplayStyle.WrappedText);
+                            }
+                        }
+                    });
                 }
+            }
+            else {
+                if (row.tag != 0) {
+                    BuildRowMarker(gui, row);
+                }
+            }
 
-                _ = BlueprintUtilities.ExportConstantCombinators(view.projectPage!.name, goods); // null-forgiving: An active view always has an active page.
+            static void toggleAll(bool state, ProductionTable table) {
+                foreach (var subgroup in table.recipes.Select(r => r.subgroup).WhereNotNull()) {
+                    subgroup.RecordChange().expanded = state;
+                    toggleAll(state, subgroup);
+                }
             }
         }
 
-        private class EntityColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Entity", 8f) {
-            public override void BuildElement(ImGui gui, RecipeRow recipe) {
-                if (recipe.isOverviewMode) {
+        private void BuildRowMarker(ImGui gui, RecipeRow row) {
+            int markerId = row.tag;
+            if (markerId < 0 || markerId >= tagIcons.Length) {
+                markerId = 0;
+            }
+
+            var (icon, color) = tagIcons[markerId];
+            gui.BuildIcon(icon, color: color);
+            if (gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt)) {
+                gui.ShowDropDown(imGui => view.DrawRecipeTagSelect(imGui, row));
+            }
+        }
+    }
+
+    private class RecipeColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Recipe", 13f, 13f, 30f, widthStorage: nameof(Preferences.recipeColumnWidth)) {
+        public override void BuildElement(ImGui gui, RecipeRow recipe) {
+            gui.spacing = 0.5f;
+            switch (gui.BuildFactorioObjectButton(recipe.recipe, ButtonDisplayStyle.ProductionTableUnscaled)) {
+                case Click.Left:
+                    gui.ShowDropDown(delegate (ImGui imgui) {
+                        view.DrawRecipeTagSelect(imgui, recipe);
+
+                        if (recipe.subgroup == null && imgui.BuildButton("Create nested table") && imgui.CloseDropdown()) {
+                            recipe.RecordUndo().subgroup = new ProductionTable(recipe);
+                        }
+
+                        if (recipe.subgroup != null && imgui.BuildButton("Add nested desired product") && imgui.CloseDropdown()) {
+                            view.AddDesiredProductAtLevel(recipe.subgroup);
+                        }
+
+                        if (recipe.subgroup != null) {
+                            BuildRecipeButton(imgui, recipe.subgroup);
+                        }
+
+                        if (recipe.subgroup != null && imgui.BuildButton("Unpack nested table").WithTooltip(imgui, recipe.subgroup.expanded ? "Shortcut: right-click" : "Shortcut: Expand, then right-click") && imgui.CloseDropdown()) {
+                            unpackNestedTable();
+                        }
+
+                        if (recipe.subgroup != null && imgui.BuildButton("ShoppingList") && imgui.CloseDropdown()) {
+                            view.BuildShoppingList(recipe);
+                        }
+
+                        if (imgui.BuildCheckBox("Enabled", recipe.enabled, out bool newEnabled)) {
+                            recipe.RecordUndo().enabled = newEnabled;
+                        }
+
+                        BuildFavorites(imgui, recipe.recipe, "Add recipe to favorites");
+
+                        if (recipe.subgroup != null && imgui.BuildRedButton("Delete nested table").WithTooltip(imgui, recipe.subgroup.expanded ? "Shortcut: Collapse, then right-click" : "Shortcut: right-click") && imgui.CloseDropdown()) {
+                            _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
+                        }
+
+                        if (recipe.subgroup == null && imgui.BuildRedButton("Delete recipe").WithTooltip(imgui, "Shortcut: right-click") && imgui.CloseDropdown()) {
+                            _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
+                        }
+                    });
+                    break;
+                case Click.Right when recipe.subgroup?.expanded ?? false: // With expanded subgroup
+                    unpackNestedTable();
+                    break;
+                case Click.Right: // With collapsed or no subgroup
+                    _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
+                    break;
+            }
+
+            if (!recipe.enabled) {
+                gui.textColor = SchemeColor.BackgroundTextFaint;
+            }
+            else if (view.flatHierarchyBuilder.nextRowIsHighlighted) {
+                gui.textColor = view.flatHierarchyBuilder.nextRowTextColor;
+            }
+            else {
+                gui.textColor = recipe.hierarchyEnabled ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint;
+            }
+
+            gui.BuildText(recipe.recipe.locName, TextBlockDisplayStyle.WrappedText);
+
+            void unpackNestedTable() {
+                var evacuate = recipe.subgroup.recipes;
+                _ = recipe.subgroup.RecordUndo();
+                recipe.RecordUndo().subgroup = null;
+                int index = recipe.owner.recipes.IndexOf(recipe);
+                foreach (var evacRecipe in evacuate) {
+                    evacRecipe.SetOwner(recipe.owner);
+                }
+
+                recipe.owner.RecordUndo().recipes.InsertRange(index + 1, evacuate);
+            }
+        }
+
+        private void RemoveZeroRecipes(ProductionTable productionTable) {
+            _ = productionTable.RecordUndo().recipes.RemoveAll(x => x.subgroup == null && x.recipesPerSecond == 0);
+            foreach (var recipe in productionTable.recipes) {
+                if (recipe.subgroup != null) {
+                    RemoveZeroRecipes(recipe.subgroup);
+                }
+            }
+        }
+
+        public override void BuildMenu(ImGui gui) {
+            BuildRecipeButton(gui, view.model);
+
+            gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", TextBlockDisplayStyle.WrappedText);
+            using (gui.EnterRow()) {
+                gui.BuildText("Amount per:");
+                if (gui.BuildLink("second") && gui.CloseDropdown()) {
+                    ExportIo(1f);
+                }
+
+                if (gui.BuildLink("minute") && gui.CloseDropdown()) {
+                    ExportIo(60f);
+                }
+
+                if (gui.BuildLink("hour") && gui.CloseDropdown()) {
+                    ExportIo(3600f);
+                }
+            }
+
+            if (gui.BuildButton("Remove all zero-building recipes") && gui.CloseDropdown()) {
+                RemoveZeroRecipes(view.model);
+            }
+
+            if (gui.BuildRedButton("Clear recipes") && gui.CloseDropdown()) {
+                view.model.RecordUndo().recipes.Clear();
+            }
+
+            if (InputSystem.Instance.control && gui.BuildButton("Add ALL recipes") && gui.CloseDropdown()) {
+                foreach (var recipe in Database.recipes.all) {
+                    if (!recipe.IsAccessible()) {
+                        continue;
+                    }
+
+                    foreach (var ingredient in recipe.ingredients) {
+                        if (ingredient.goods.production.Length == 0) {
+                            // 'goto' is a readable way to break out of a nested loop.
+                            // See https://stackoverflow.com/questions/324831/breaking-out-of-a-nested-loop
+                            goto goodsHaveNoProduction;
+                        }
+                    }
+                    foreach (var product in recipe.products) {
+                        view.CreateLink(view.model, product.goods);
+                    }
+
+                    view.model.AddRecipe(recipe, DefaultVariantOrdering);
+goodsHaveNoProduction:;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Build the "Add raw recipe" button and handle its clicks.
+        /// </summary>
+        /// <param name="table">The table that will receive the new recipes or technologies, if any are selected</param>
+        private static void BuildRecipeButton(ImGui gui, ProductionTable table) {
+            if (gui.BuildButton("Add raw recipe").WithTooltip(gui, "Ctrl-click to add a technology instead") && gui.CloseDropdown()) {
+                if (InputSystem.Instance.control) {
+                    SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology", r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
+                }
+                else {
+                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
+                }
+            }
+        }
+
+        private void ExportIo(float multiplier) {
+            List<(Goods, int)> goods = [];
+            foreach (var link in view.model.links) {
+                int rounded = MathUtils.Round(link.amount * multiplier);
+                if (rounded == 0) {
+                    continue;
+                }
+
+                goods.Add((link.goods, rounded));
+            }
+
+            foreach (var flow in view.model.flow) {
+                int rounded = MathUtils.Round(flow.amount * multiplier);
+                if (rounded == 0) {
+                    continue;
+                }
+
+                goods.Add((flow.goods, rounded));
+            }
+
+            _ = BlueprintUtilities.ExportConstantCombinators(view.projectPage!.name, goods); // null-forgiving: An active view always has an active page.
+        }
+    }
+
+    private class EntityColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Entity", 8f) {
+        public override void BuildElement(ImGui gui, RecipeRow recipe) {
+            if (recipe.isOverviewMode) {
+                return;
+            }
+
+            Click click;
+            using (var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f)) {
+                group.SetWidth(3f);
+                if (recipe.fixedBuildings > 0 && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
+                    DisplayAmount amount = recipe.fixedBuildings;
+                    GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled);
+                    if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
+                        recipe.RecordUndo().fixedBuildings = amount.Value;
+                    }
+
+                    click = (Click)evt;
+                }
+                else {
+                    click = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, ButtonDisplayStyle.ProductionTableUnscaled);
+                }
+
+                if (recipe.builtBuildings != null) {
+                    DisplayAmount amount = recipe.builtBuildings.Value;
+                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }) && amount.Value >= 0) {
+                        recipe.RecordUndo().builtBuildings = (int)amount.Value;
+                    }
+                }
+            }
+
+            if (recipe.recipe.crafters.Length == 0) {
+                // ignore all clicks
+            }
+            else if (click == Click.Left) {
+                ShowEntityDropdown(gui, recipe);
+            }
+            else if (click == Click.Right) {
+                EntityCrafter favoriteCrafter = recipe.recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter)!; // null-forgiving: We know recipe.recipe.crafters is not empty, so AutoSelect can't return null.
+                if (favoriteCrafter != null && recipe.entity != favoriteCrafter) {
+                    _ = recipe.RecordUndo();
+                    recipe.entity = favoriteCrafter;
+                    if (!recipe.entity.energy.fuels.Contains(recipe.fuel)) {
+                        recipe.fuel = recipe.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
+                    }
+                }
+                else if (recipe.fixedBuildings > 0) {
+                    recipe.RecordUndo().fixedBuildings = 0;
+                }
+                else if (recipe.builtBuildings != null) {
+                    recipe.RecordUndo().builtBuildings = null;
+                }
+            }
+
+            gui.AllocateSpacing(0.5f);
+            if (recipe.fuel != Database.voidEnergy || recipe.entity == null || recipe.entity.energy.type != EntityEnergyType.Void) {
+                var (fuel, fuelAmount, fuelLink, _) = recipe.FuelInformation;
+                view.BuildGoodsIcon(gui, fuel, fuelLink, fuelAmount, ProductDropdownType.Fuel, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes);
+            }
+            else {
+                if (recipe.recipe == Database.electricityGeneration && recipe.entity.factorioType == "solar-panel") {
+                    BuildSolarPanelAccumulatorView(gui, recipe);
+                }
+            }
+        }
+
+        private static void BuildSolarPanelAccumulatorView(ImGui gui, RecipeRow recipe) {
+            var accumulator = recipe.GetVariant(Database.allAccumulators);
+            float requiredMj = recipe.entity?.craftingSpeed * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
+            float requiredAccumulators = requiredMj / accumulator.accumulatorCapacity;
+            if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators, ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
+                ShowAccumulatorDropdown(gui, recipe, accumulator);
+            }
+        }
+
+        private static void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity currentAccumulator) => gui.ShowDropDown(imGui => {
+            imGui.BuildInlineObjectListAndButton<EntityAccumulator>(Database.allAccumulators, DataUtils.DefaultOrdering,
+                newAccumulator => recipe.RecordUndo().ChangeVariant(currentAccumulator, newAccumulator), "Select accumulator",
+                extra: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule));
+        });
+
+        private static void ShowEntityDropdown(ImGui imgui, RecipeRow recipe) => imgui.ShowDropDown(gui => {
+            EntityCrafter? favoriteCrafter = recipe.recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
+            if (favoriteCrafter == recipe.entity) { favoriteCrafter = null; }
+            bool willResetFixed = favoriteCrafter == null, willResetBuilt = willResetFixed && recipe.fixedBuildings == 0;
+
+            gui.BuildInlineObjectListAndButton(recipe.recipe.crafters, DataUtils.FavoriteCrafter, sel => {
+                if (recipe.entity == sel) {
                     return;
                 }
 
-                Click click;
-                using (var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f)) {
-                    group.SetWidth(3f);
-                    if (recipe.fixedBuildings > 0 && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
-                        DisplayAmount amount = recipe.fixedBuildings;
-                        GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled);
-                        if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
-                            recipe.RecordUndo().fixedBuildings = amount.Value;
-                        }
+                _ = recipe.RecordUndo();
+                recipe.entity = sel;
+                if (!sel.energy.fuels.Contains(recipe.fuel)) {
+                    recipe.fuel = recipe.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
+                }
+            }, "Select crafting entity", extra: x => DataUtils.FormatAmount(x.craftingSpeed, UnitOfMeasure.Percent));
 
-                        click = (Click)evt;
-                    }
-                    else {
-                        click = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, ButtonDisplayStyle.ProductionTableUnscaled);
-                    }
+            gui.AllocateSpacing(0.5f);
 
-                    if (recipe.builtBuildings != null) {
-                        DisplayAmount amount = recipe.builtBuildings.Value;
-                        if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }) && amount.Value >= 0) {
-                            recipe.RecordUndo().builtBuildings = (int)amount.Value;
-                        }
-                    }
+            if (recipe.fixedBuildings > 0f && (recipe.fixedFuel || recipe.fixedIngredient != null || recipe.fixedProduct != null)) {
+                ButtonEvent evt = gui.BuildButton("Clear fixed recipe multiplier");
+                if (willResetFixed) {
+                    _ = evt.WithTooltip(gui, "Shortcut: right-click");
                 }
-
-                if (recipe.recipe.crafters.Length == 0) {
-                    // ignore all clicks
-                }
-                else if (click == Click.Left) {
-                    ShowEntityDropdown(gui, recipe);
-                }
-                else if (click == Click.Right) {
-                    EntityCrafter favoriteCrafter = recipe.recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter)!; // null-forgiving: We know recipe.recipe.crafters is not empty, so AutoSelect can't return null.
-                    if (favoriteCrafter != null && recipe.entity != favoriteCrafter) {
-                        _ = recipe.RecordUndo();
-                        recipe.entity = favoriteCrafter;
-                        if (!recipe.entity.energy.fuels.Contains(recipe.fuel)) {
-                            recipe.fuel = recipe.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
-                        }
-                    }
-                    else if (recipe.fixedBuildings > 0) {
-                        recipe.RecordUndo().fixedBuildings = 0;
-                    }
-                    else if (recipe.builtBuildings != null) {
-                        recipe.RecordUndo().builtBuildings = null;
-                    }
-                }
-
-                gui.AllocateSpacing(0.5f);
-                if (recipe.fuel != Database.voidEnergy || recipe.entity == null || recipe.entity.energy.type != EntityEnergyType.Void) {
-                    var (fuel, fuelAmount, fuelLink, _) = recipe.FuelInformation;
-                    view.BuildGoodsIcon(gui, fuel, fuelLink, fuelAmount, ProductDropdownType.Fuel, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes);
-                }
-                else {
-                    if (recipe.recipe == Database.electricityGeneration && recipe.entity.factorioType == "solar-panel") {
-                        BuildSolarPanelAccumulatorView(gui, recipe);
-                    }
+                if (evt && gui.CloseDropdown()) {
+                    recipe.RecordUndo().fixedBuildings = 0f;
                 }
             }
 
-            private static void BuildSolarPanelAccumulatorView(ImGui gui, RecipeRow recipe) {
-                var accumulator = recipe.GetVariant(Database.allAccumulators);
-                float requiredMj = recipe.entity?.craftingSpeed * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
-                float requiredAccumulators = requiredMj / accumulator.accumulatorCapacity;
-                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators, ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
-                    ShowAccumulatorDropdown(gui, recipe, accumulator);
-                }
-            }
-
-            private static void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity currentAccumulator) => gui.ShowDropDown(imGui => {
-                imGui.BuildInlineObjectListAndButton<EntityAccumulator>(Database.allAccumulators, DataUtils.DefaultOrdering,
-                    newAccumulator => recipe.RecordUndo().ChangeVariant(currentAccumulator, newAccumulator), "Select accumulator",
-                    extra: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule));
-            });
-
-            private static void ShowEntityDropdown(ImGui imgui, RecipeRow recipe) => imgui.ShowDropDown(gui => {
-                EntityCrafter? favoriteCrafter = recipe.recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
-                if (favoriteCrafter == recipe.entity) { favoriteCrafter = null; }
-                bool willResetFixed = favoriteCrafter == null, willResetBuilt = willResetFixed && recipe.fixedBuildings == 0;
-
-                gui.BuildInlineObjectListAndButton(recipe.recipe.crafters, DataUtils.FavoriteCrafter, sel => {
-                    if (recipe.entity == sel) {
-                        return;
-                    }
-
-                    _ = recipe.RecordUndo();
-                    recipe.entity = sel;
-                    if (!sel.energy.fuels.Contains(recipe.fuel)) {
-                        recipe.fuel = recipe.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
-                    }
-                }, "Select crafting entity", extra: x => DataUtils.FormatAmount(x.craftingSpeed, UnitOfMeasure.Percent));
-
-                gui.AllocateSpacing(0.5f);
-
-                if (recipe.fixedBuildings > 0f && (recipe.fixedFuel || recipe.fixedIngredient != null || recipe.fixedProduct != null)) {
-                    ButtonEvent evt = gui.BuildButton("Clear fixed recipe multiplier");
+            using (gui.EnterRowWithHelpIcon("Tell YAFC how many buildings it must use when solving this page.\nUse this to ask questions like 'What does it take to handle the output of ten miners?'")) {
+                gui.allocator = RectAllocator.RemainingRow;
+                if (recipe.fixedBuildings > 0f && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
+                    ButtonEvent evt = gui.BuildButton("Clear fixed building count");
                     if (willResetFixed) {
                         _ = evt.WithTooltip(gui, "Shortcut: right-click");
                     }
@@ -379,1022 +391,1009 @@ goodsHaveNoProduction:;
                         recipe.RecordUndo().fixedBuildings = 0f;
                     }
                 }
+                else if (gui.BuildButton("Set fixed building count") && gui.CloseDropdown()) {
+                    recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0f ? 1f : recipe.buildingCount;
+                    recipe.fixedFuel = false;
+                    recipe.fixedIngredient = null;
+                    recipe.fixedProduct = null;
+                }
+            }
 
-                using (gui.EnterRowWithHelpIcon("Tell YAFC how many buildings it must use when solving this page.\nUse this to ask questions like 'What does it take to handle the output of ten miners?'")) {
+            using (gui.EnterRowWithHelpIcon("Tell YAFC how many of these buildings you have in your factory.\nYAFC will warn you if you need to build more buildings.")) {
+                gui.allocator = RectAllocator.RemainingRow;
+                if (recipe.builtBuildings != null) {
+                    ButtonEvent evt = gui.BuildButton("Clear built building count");
+                    if (willResetBuilt) {
+                        _ = evt.WithTooltip(gui, "Shortcut: right-click");
+                    }
+                    if (evt && gui.CloseDropdown()) {
+                        recipe.RecordUndo().builtBuildings = null;
+                    }
+                }
+                else if (gui.BuildButton("Set built building count") && gui.CloseDropdown()) {
+                    recipe.RecordUndo().builtBuildings = Math.Max(0, Convert.ToInt32(Math.Ceiling(recipe.buildingCount)));
+                }
+            }
+
+            if (recipe.entity != null) {
+                using (gui.EnterRowWithHelpIcon("Generate a blueprint for one of these buildings, with the recipe and internal modules set.")) {
                     gui.allocator = RectAllocator.RemainingRow;
-                    if (recipe.fixedBuildings > 0f && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
-                        ButtonEvent evt = gui.BuildButton("Clear fixed building count");
-                        if (willResetFixed) {
-                            _ = evt.WithTooltip(gui, "Shortcut: right-click");
+                    if (gui.BuildButton("Create single building blueprint") && gui.CloseDropdown()) {
+                        BlueprintEntity entity = new BlueprintEntity { index = 1, name = recipe.entity.name };
+                        if (recipe.recipe is not Mechanics) {
+                            entity.recipe = recipe.recipe.name;
                         }
-                        if (evt && gui.CloseDropdown()) {
-                            recipe.RecordUndo().fixedBuildings = 0f;
-                        }
-                    }
-                    else if (gui.BuildButton("Set fixed building count") && gui.CloseDropdown()) {
-                        recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0f ? 1f : recipe.buildingCount;
-                        recipe.fixedFuel = false;
-                        recipe.fixedIngredient = null;
-                        recipe.fixedProduct = null;
-                    }
-                }
 
-                using (gui.EnterRowWithHelpIcon("Tell YAFC how many of these buildings you have in your factory.\nYAFC will warn you if you need to build more buildings.")) {
-                    gui.allocator = RectAllocator.RemainingRow;
-                    if (recipe.builtBuildings != null) {
-                        ButtonEvent evt = gui.BuildButton("Clear built building count");
-                        if (willResetBuilt) {
-                            _ = evt.WithTooltip(gui, "Shortcut: right-click");
-                        }
-                        if (evt && gui.CloseDropdown()) {
-                            recipe.RecordUndo().builtBuildings = null;
-                        }
-                    }
-                    else if (gui.BuildButton("Set built building count") && gui.CloseDropdown()) {
-                        recipe.RecordUndo().builtBuildings = Math.Max(0, Convert.ToInt32(Math.Ceiling(recipe.buildingCount)));
-                    }
-                }
-
-                if (recipe.entity != null) {
-                    using (gui.EnterRowWithHelpIcon("Generate a blueprint for one of these buildings, with the recipe and internal modules set.")) {
-                        gui.allocator = RectAllocator.RemainingRow;
-                        if (gui.BuildButton("Create single building blueprint") && gui.CloseDropdown()) {
-                            BlueprintEntity entity = new BlueprintEntity { index = 1, name = recipe.entity.name };
-                            if (recipe.recipe is not Mechanics) {
-                                entity.recipe = recipe.recipe.name;
-                            }
-
-                            var modules = recipe.usedModules.modules;
-                            if (modules != null) {
-                                entity.items = [];
-                                foreach (var (module, count, beacon) in modules) {
-                                    if (!beacon) {
-                                        entity.items[module.name] = count;
-                                    }
-                                }
-                            }
-                            BlueprintString bp = new BlueprintString(recipe.recipe.locName) { blueprint = { entities = { entity } } };
-                            _ = SDL.SDL_SetClipboardText(bp.ToBpString());
-                        }
-                    }
-
-                    if (recipe.recipe.crafters.Length > 1) {
-                        BuildFavorites(gui, recipe.entity, "Add building to favorites");
-                    }
-                }
-            });
-
-            public override void BuildMenu(ImGui gui) {
-                if (gui.BuildButton("Mass set assembler") && gui.CloseDropdown()) {
-                    SelectSingleObjectPanel.Select(Database.allCrafters, "Set assembler for all recipes", set => {
-                        DataUtils.FavoriteCrafter.AddToFavorite(set, 10);
-                        foreach (var recipe in view.GetRecipesRecursive()) {
-                            if (recipe.recipe.crafters.Contains(set)) {
-                                _ = recipe.RecordUndo();
-                                recipe.entity = set;
-                                if (!set.energy.fuels.Contains(recipe.fuel)) {
-                                    recipe.fuel = recipe.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
+                        var modules = recipe.usedModules.modules;
+                        if (modules != null) {
+                            entity.items = [];
+                            foreach (var (module, count, beacon) in modules) {
+                                if (!beacon) {
+                                    entity.items[module.name] = count;
                                 }
                             }
                         }
-                    }, DataUtils.FavoriteCrafter);
+                        BlueprintString bp = new BlueprintString(recipe.recipe.locName) { blueprint = { entities = { entity } } };
+                        _ = SDL.SDL_SetClipboardText(bp.ToBpString());
+                    }
                 }
 
-                if (gui.BuildButton("Mass set fuel") && gui.CloseDropdown()) {
-                    SelectSingleObjectPanel.Select(Database.goods.all.Where(x => x.fuelValue > 0), "Set fuel for all recipes", set => {
-                        DataUtils.FavoriteFuel.AddToFavorite(set, 10);
-                        foreach (var recipe in view.GetRecipesRecursive()) {
-                            if (recipe.entity != null && recipe.entity.energy.fuels.Contains(set)) {
-                                recipe.RecordUndo().fuel = set;
+                if (recipe.recipe.crafters.Length > 1) {
+                    BuildFavorites(gui, recipe.entity, "Add building to favorites");
+                }
+            }
+        });
+
+        public override void BuildMenu(ImGui gui) {
+            if (gui.BuildButton("Mass set assembler") && gui.CloseDropdown()) {
+                SelectSingleObjectPanel.Select(Database.allCrafters, "Set assembler for all recipes", set => {
+                    DataUtils.FavoriteCrafter.AddToFavorite(set, 10);
+                    foreach (var recipe in view.GetRecipesRecursive()) {
+                        if (recipe.recipe.crafters.Contains(set)) {
+                            _ = recipe.RecordUndo();
+                            recipe.entity = set;
+                            if (!set.energy.fuels.Contains(recipe.fuel)) {
+                                recipe.fuel = recipe.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
                             }
                         }
-                    }, DataUtils.FavoriteFuel);
-                }
-
-                if (gui.BuildButton("Shopping list") && gui.CloseDropdown()) {
-                    view.BuildShoppingList(null);
-                }
-            }
-        }
-
-        private class IngredientsColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Ingredients", 32f, 16f, 100f, hasMenu: false, nameof(Preferences.ingredientsColumWidth)) {
-            public override void BuildElement(ImGui gui, RecipeRow recipe) {
-                var grid = gui.EnterInlineGrid(3f, 1f);
-                if (recipe.isOverviewMode) {
-                    view.BuildTableIngredients(gui, recipe.subgroup, recipe.owner, ref grid);
-                }
-                else {
-                    foreach (var (goods, amount, link, variants) in recipe.Ingredients) {
-                        grid.Next();
-                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
                     }
-                }
-                grid.Dispose();
-            }
-        }
-
-        private class ProductsColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Products", 12f, 10f, 70f, hasMenu: false, nameof(Preferences.productsColumWidth)) {
-            public override void BuildElement(ImGui gui, RecipeRow recipe) {
-                var grid = gui.EnterInlineGrid(3f, 1f);
-                if (recipe.isOverviewMode) {
-                    view.BuildTableProducts(gui, recipe.subgroup, recipe.owner, ref grid, false);
-                }
-                else {
-                    foreach (var (goods, amount, link) in recipe.Products) {
-                        grid.Next();
-                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
-                    }
-                }
-                grid.Dispose();
-            }
-        }
-
-        private class ModulesColumn : ProductionTableDataColumn {
-            private readonly VirtualScrollList<ProjectModuleTemplate> moduleTemplateList;
-            private RecipeRow editingRecipeModules = null!; // null-forgiving: This is set as soon as we open a module dropdown.
-
-            public ModulesColumn(ProductionTableView view) : base(view, "Modules", 10f, 7f, 16f, widthStorage: nameof(Preferences.modulesColumnWidth))
-                => moduleTemplateList = new VirtualScrollList<ProjectModuleTemplate>(15f, new Vector2(20f, 2.5f), ModuleTemplateDrawer, collapsible: true);
-
-            private void ModuleTemplateDrawer(ImGui gui, ProjectModuleTemplate element, int index) {
-                var evt = gui.BuildContextMenuButton(element.name, icon: element.icon?.icon ?? default, disabled: !element.template.IsCompatibleWith(editingRecipeModules));
-                if (evt == ButtonEvent.Click && gui.CloseDropdown()) {
-                    var copied = JsonUtils.Copy(element.template, editingRecipeModules, null);
-                    editingRecipeModules.RecordUndo().modules = copied;
-                    view.Rebuild();
-                }
-                else if (evt == ButtonEvent.MouseOver) {
-                    ShowModuleTemplateTooltip(gui, element.template);
-                }
+                }, DataUtils.FavoriteCrafter);
             }
 
-            public override void BuildElement(ImGui gui, RecipeRow recipe) {
-                if (recipe.isOverviewMode) {
-                    return;
-                }
-
-                if (recipe.entity == null || recipe.entity.allowedEffects == AllowedEffects.None || recipe.recipe.modules.Length == 0) {
-                    return;
-                }
-
-                using var grid = gui.EnterInlineGrid(3f);
-                if (recipe.usedModules.modules == null || recipe.usedModules.modules.Length == 0) {
-                    drawItem(gui, null, 0);
-                }
-                else {
-                    bool wasBeacon = false;
-                    foreach (var (module, count, beacon) in recipe.usedModules.modules) {
-                        if (beacon && !wasBeacon) {
-                            wasBeacon = true;
-                            if (recipe.usedModules.beacon != null) {
-                                drawItem(gui, recipe.usedModules.beacon, recipe.usedModules.beaconCount);
-                            }
+            if (gui.BuildButton("Mass set fuel") && gui.CloseDropdown()) {
+                SelectSingleObjectPanel.Select(Database.goods.all.Where(x => x.fuelValue > 0), "Set fuel for all recipes", set => {
+                    DataUtils.FavoriteFuel.AddToFavorite(set, 10);
+                    foreach (var recipe in view.GetRecipesRecursive()) {
+                        if (recipe.entity != null && recipe.entity.energy.fuels.Contains(set)) {
+                            recipe.RecordUndo().fuel = set;
                         }
-                        drawItem(gui, module, count);
                     }
-                }
+                }, DataUtils.FavoriteFuel);
+            }
 
-                void drawItem(ImGui gui, FactorioObject? item, int count) {
+            if (gui.BuildButton("Shopping list") && gui.CloseDropdown()) {
+                view.BuildShoppingList(null);
+            }
+        }
+    }
+
+    private class IngredientsColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Ingredients", 32f, 16f, 100f, hasMenu: false, nameof(Preferences.ingredientsColumWidth)) {
+        public override void BuildElement(ImGui gui, RecipeRow recipe) {
+            var grid = gui.EnterInlineGrid(3f, 1f);
+            if (recipe.isOverviewMode) {
+                view.BuildTableIngredients(gui, recipe.subgroup, recipe.owner, ref grid);
+            }
+            else {
+                foreach (var (goods, amount, link, variants) in recipe.Ingredients) {
                     grid.Next();
-                    switch (gui.BuildFactorioObjectWithAmount(item, count, ButtonDisplayStyle.ProductionTableUnscaled)) {
-                        case Click.Left:
-                            ShowModuleDropDown(gui, recipe);
-                            break;
-                        case Click.Right when recipe.modules != null:
-                            recipe.RecordUndo().RemoveFixedModules();
-                            break;
+                    view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
+                }
+            }
+            grid.Dispose();
+        }
+    }
+
+    private class ProductsColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Products", 12f, 10f, 70f, hasMenu: false, nameof(Preferences.productsColumWidth)) {
+        public override void BuildElement(ImGui gui, RecipeRow recipe) {
+            var grid = gui.EnterInlineGrid(3f, 1f);
+            if (recipe.isOverviewMode) {
+                view.BuildTableProducts(gui, recipe.subgroup, recipe.owner, ref grid, false);
+            }
+            else {
+                foreach (var (goods, amount, link) in recipe.Products) {
+                    grid.Next();
+                    view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
+                }
+            }
+            grid.Dispose();
+        }
+    }
+
+    private class ModulesColumn : ProductionTableDataColumn {
+        private readonly VirtualScrollList<ProjectModuleTemplate> moduleTemplateList;
+        private RecipeRow editingRecipeModules = null!; // null-forgiving: This is set as soon as we open a module dropdown.
+
+        public ModulesColumn(ProductionTableView view) : base(view, "Modules", 10f, 7f, 16f, widthStorage: nameof(Preferences.modulesColumnWidth))
+            => moduleTemplateList = new VirtualScrollList<ProjectModuleTemplate>(15f, new Vector2(20f, 2.5f), ModuleTemplateDrawer, collapsible: true);
+
+        private void ModuleTemplateDrawer(ImGui gui, ProjectModuleTemplate element, int index) {
+            var evt = gui.BuildContextMenuButton(element.name, icon: element.icon?.icon ?? default, disabled: !element.template.IsCompatibleWith(editingRecipeModules));
+            if (evt == ButtonEvent.Click && gui.CloseDropdown()) {
+                var copied = JsonUtils.Copy(element.template, editingRecipeModules, null);
+                editingRecipeModules.RecordUndo().modules = copied;
+                view.Rebuild();
+            }
+            else if (evt == ButtonEvent.MouseOver) {
+                ShowModuleTemplateTooltip(gui, element.template);
+            }
+        }
+
+        public override void BuildElement(ImGui gui, RecipeRow recipe) {
+            if (recipe.isOverviewMode) {
+                return;
+            }
+
+            if (recipe.entity == null || recipe.entity.allowedEffects == AllowedEffects.None || recipe.recipe.modules.Length == 0) {
+                return;
+            }
+
+            using var grid = gui.EnterInlineGrid(3f);
+            if (recipe.usedModules.modules == null || recipe.usedModules.modules.Length == 0) {
+                drawItem(gui, null, 0);
+            }
+            else {
+                bool wasBeacon = false;
+                foreach (var (module, count, beacon) in recipe.usedModules.modules) {
+                    if (beacon && !wasBeacon) {
+                        wasBeacon = true;
+                        if (recipe.usedModules.beacon != null) {
+                            drawItem(gui, recipe.usedModules.beacon, recipe.usedModules.beaconCount);
+                        }
                     }
+                    drawItem(gui, module, count);
                 }
             }
 
-            private void ShowModuleTemplateTooltip(ImGui gui, ModuleTemplate template) => gui.ShowTooltip(imGui => {
-                if (!template.IsCompatibleWith(editingRecipeModules)) {
-                    imGui.BuildText("This module template seems incompatible with the recipe or the building", TextBlockDisplayStyle.WrappedText);
+            void drawItem(ImGui gui, FactorioObject? item, int count) {
+                grid.Next();
+                switch (gui.BuildFactorioObjectWithAmount(item, count, ButtonDisplayStyle.ProductionTableUnscaled)) {
+                    case Click.Left:
+                        ShowModuleDropDown(gui, recipe);
+                        break;
+                    case Click.Right when recipe.modules != null:
+                        recipe.RecordUndo().RemoveFixedModules();
+                        break;
                 }
+            }
+        }
 
-                using var grid = imGui.EnterInlineGrid(3f, 1f);
-                foreach (var module in template.list) {
+        private void ShowModuleTemplateTooltip(ImGui gui, ModuleTemplate template) => gui.ShowTooltip(imGui => {
+            if (!template.IsCompatibleWith(editingRecipeModules)) {
+                imGui.BuildText("This module template seems incompatible with the recipe or the building", TextBlockDisplayStyle.WrappedText);
+            }
+
+            using var grid = imGui.EnterInlineGrid(3f, 1f);
+            foreach (var module in template.list) {
+                grid.Next();
+                _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, ButtonDisplayStyle.ProductionTableUnscaled);
+            }
+
+            if (template.beacon != null) {
+                grid.Next();
+                _ = imGui.BuildFactorioObjectWithAmount(template.beacon, template.CalcBeaconCount(), ButtonDisplayStyle.ProductionTableUnscaled);
+                foreach (var module in template.beaconList) {
                     grid.Next();
                     _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, ButtonDisplayStyle.ProductionTableUnscaled);
                 }
+            }
+        });
 
-                if (template.beacon != null) {
-                    grid.Next();
-                    _ = imGui.BuildFactorioObjectWithAmount(template.beacon, template.CalcBeaconCount(), ButtonDisplayStyle.ProductionTableUnscaled);
-                    foreach (var module in template.beaconList) {
-                        grid.Next();
-                        _ = imGui.BuildFactorioObjectWithAmount(module.module, module.fixedCount, ButtonDisplayStyle.ProductionTableUnscaled);
-                    }
+        private void ShowModuleDropDown(ImGui gui, RecipeRow recipe) {
+            var modules = recipe.recipe.modules.Where(x => recipe.entity?.CanAcceptModule(x.moduleSpecification) ?? false).ToArray();
+            editingRecipeModules = recipe;
+            moduleTemplateList.data = [.. Project.current.sharedModuleTemplates
+                .Where(x => x.filterEntities.Count == 0 || x.filterEntities.Contains(recipe.entity!)) // null-forgiving: non-nullable collections are happy to report they don't contain null values.
+                .OrderByDescending(x => x.template.IsCompatibleWith(recipe))];
+
+            gui.ShowDropDown(dropGui => {
+                if (recipe.modules != null && dropGui.BuildButton("Use default modules").WithTooltip(dropGui, "Shortcut: right-click") && dropGui.CloseDropdown()) {
+                    recipe.RemoveFixedModules();
+                }
+
+                if (recipe.entity?.moduleSlots > 0) {
+                    dropGui.BuildInlineObjectListAndButton(modules, DataUtils.FavoriteModule, recipe.SetFixedModule, "Select fixed module");
+                }
+
+                if (moduleTemplateList.data.Count > 0) {
+                    dropGui.BuildText("Use module template:", Font.subheader);
+                    moduleTemplateList.Build(dropGui);
+                }
+                if (dropGui.BuildButton("Configure module templates") && dropGui.CloseDropdown()) {
+                    ModuleTemplateConfiguration.Show();
+                }
+
+                if (dropGui.BuildButton("Customize modules") && dropGui.CloseDropdown()) {
+                    ModuleCustomizationScreen.Show(recipe);
                 }
             });
+        }
 
-            private void ShowModuleDropDown(ImGui gui, RecipeRow recipe) {
-                var modules = recipe.recipe.modules.Where(x => recipe.entity?.CanAcceptModule(x.moduleSpecification) ?? false).ToArray();
-                editingRecipeModules = recipe;
-                moduleTemplateList.data = [.. Project.current.sharedModuleTemplates
-                    .Where(x => x.filterEntities.Count == 0 || x.filterEntities.Contains(recipe.entity!)) // null-forgiving: non-nullable collections are happy to report they don't contain null values.
-                    .OrderByDescending(x => x.template.IsCompatibleWith(recipe))];
+        public override void BuildMenu(ImGui gui) {
+            var model = view.model;
 
-                gui.ShowDropDown(dropGui => {
-                    if (recipe.modules != null && dropGui.BuildButton("Use default modules").WithTooltip(dropGui, "Shortcut: right-click") && dropGui.CloseDropdown()) {
-                        recipe.RemoveFixedModules();
-                    }
-
-                    if (recipe.entity?.moduleSlots > 0) {
-                        dropGui.BuildInlineObjectListAndButton(modules, DataUtils.FavoriteModule, recipe.SetFixedModule, "Select fixed module");
-                    }
-
-                    if (moduleTemplateList.data.Count > 0) {
-                        dropGui.BuildText("Use module template:", Font.subheader);
-                        moduleTemplateList.Build(dropGui);
-                    }
-                    if (dropGui.BuildButton("Configure module templates") && dropGui.CloseDropdown()) {
-                        ModuleTemplateConfiguration.Show();
-                    }
-
-                    if (dropGui.BuildButton("Customize modules") && dropGui.CloseDropdown()) {
-                        ModuleCustomizationScreen.Show(recipe);
-                    }
-                });
+            gui.BuildText("Auto modules", Font.subheader);
+            ModuleFillerParametersScreen.BuildSimple(gui, model.modules!); // null-forgiving: owner is a ProjectPage, so modules is not null.
+            if (gui.BuildButton("Module settings") && gui.CloseDropdown()) {
+                ModuleFillerParametersScreen.Show(model.modules!);
             }
+        }
+    }
 
-            public override void BuildMenu(ImGui gui) {
-                var model = view.model;
+    public static void BuildFavorites(ImGui imgui, FactorioObject? obj, string prompt) {
+        if (obj == null) {
+            return;
+        }
 
-                gui.BuildText("Auto modules", Font.subheader);
-                ModuleFillerParametersScreen.BuildSimple(gui, model.modules!); // null-forgiving: owner is a ProjectPage, so modules is not null.
-                if (gui.BuildButton("Module settings") && gui.CloseDropdown()) {
-                    ModuleFillerParametersScreen.Show(model.modules!);
+        bool isFavorite = Project.current.preferences.favorites.Contains(obj);
+        using (imgui.EnterRow(0.5f, RectAllocator.LeftRow)) {
+            imgui.BuildIcon(isFavorite ? Icon.StarFull : Icon.StarEmpty);
+            imgui.RemainingRow().BuildText(isFavorite ? "Favorite" : prompt);
+        }
+        if (imgui.OnClick(imgui.lastRect)) {
+            Project.current.preferences.ToggleFavorite(obj);
+        }
+    }
+
+    public override float CalculateWidth() => flatHierarchyBuilder.width;
+
+    public static void CreateProductionSheet() => ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true));
+
+    private static readonly IComparer<Goods> DefaultVariantOrdering = new DataUtils.FactorioObjectComparer<Goods>((x, y) => (y.ApproximateFlow() / MathF.Abs(y.Cost())).CompareTo(x.ApproximateFlow() / MathF.Abs(x.Cost())));
+
+    private enum ProductDropdownType {
+        DesiredProduct,
+        Fuel,
+        Ingredient,
+        Product,
+        DesiredIngredient,
+    }
+
+    private void CreateLink(ProductionTable table, Goods goods) {
+        if (table.linkMap.ContainsKey(goods)) {
+            return;
+        }
+
+        ProductionLink link = new ProductionLink(table, goods);
+        Rebuild();
+        table.RecordUndo().links.Add(link);
+    }
+
+    private void DestroyLink(ProductionLink link) {
+        if (link.owner.links.Contains(link)) {
+            _ = link.owner.RecordUndo().links.Remove(link);
+            Rebuild();
+        }
+    }
+
+    private void CreateNewProductionTable(Goods goods, float amount) {
+        var page = MainScreen.Instance.AddProjectPage(goods.locName, goods, typeof(ProductionTable), true, false);
+        ProductionTable content = (ProductionTable)page.content;
+        ProductionLink link = new ProductionLink(content, goods) { amount = amount > 0 ? amount : 1 };
+        content.links.Add(link);
+        content.RebuildLinkMap();
+    }
+
+    private void OpenProductDropdown(ImGui targetGui, Rect rect, Goods goods, float amount, ProductionLink? link, ProductDropdownType type, RecipeRow? recipe, ProductionTable context, Goods[]? variants = null) {
+        if (InputSystem.Instance.shift) {
+            Project.current.preferences.SetSourceResource(goods, !goods.IsSourceResource());
+            targetGui.Rebuild();
+            return;
+        }
+
+        var comparer = DataUtils.GetRecipeComparerFor(goods);
+        HashSet<RecipeOrTechnology> allRecipes = new HashSet<RecipeOrTechnology>(context.recipes.Select(x => x.recipe));
+        bool recipeExists(RecipeOrTechnology rec) {
+            return allRecipes.Contains(rec);
+        }
+
+        Goods? selectedFuel = null;
+        Goods? spentFuel = null;
+        async void addRecipe(RecipeOrTechnology rec) {
+            if (variants == null) {
+                CreateLink(context, goods);
+            }
+            else {
+                foreach (var variant in variants) {
+                    if (rec.GetProductionPerRecipe(variant) > 0f) {
+                        CreateLink(context, variant);
+                        if (variant != goods) {
+                            recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
+                        }
+
+                        break;
+                    }
                 }
             }
+            if (!allRecipes.Contains(rec) || (await MessageBox.Show("Recipe already exists", $"Add a second copy of {rec.locName}?", "Add a copy", "Cancel")).choice) {
+                context.AddRecipe(rec, DefaultVariantOrdering, selectedFuel, spentFuel);
+            }
         }
 
-        public static void BuildFavorites(ImGui imgui, FactorioObject? obj, string prompt) {
-            if (obj == null) {
+        if (InputSystem.Instance.control) {
+            bool isInput = type <= ProductDropdownType.Ingredient;
+            var recipeList = isInput ? goods.production : goods.usages;
+            if (recipeList.SelectSingle(out _) is Recipe selected) {
+                addRecipe(selected);
                 return;
             }
-
-            bool isFavorite = Project.current.preferences.favorites.Contains(obj);
-            using (imgui.EnterRow(0.5f, RectAllocator.LeftRow)) {
-                imgui.BuildIcon(isFavorite ? Icon.StarFull : Icon.StarEmpty);
-                imgui.RemainingRow().BuildText(isFavorite ? "Favorite" : prompt);
-            }
-            if (imgui.OnClick(imgui.lastRect)) {
-                Project.current.preferences.ToggleFavorite(obj);
-            }
         }
 
-        public override float CalculateWidth() => flatHierarchyBuilder.width;
+        Recipe[] allProduction = variants == null ? goods.production : variants.SelectMany(x => x.production).Distinct().ToArray();
+        Recipe[] fuelUseList = goods.fuelFor.OfType<EntityCrafter>()
+            .SelectMany(e => e.recipes).OfType<Recipe>()
+            .Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
+        Recipe[] spentFuelRecipes = goods.miscSources.OfType<Item>()
+            .SelectMany(e => e.fuelFor.OfType<EntityCrafter>())
+            .SelectMany(e => e.recipes).OfType<Recipe>()
+            .Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
 
-        public static void CreateProductionSheet() => ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true));
+        targetGui.ShowDropDown(rect, dropDownContent, new Padding(1f), 25f);
 
-        private static readonly IComparer<Goods> DefaultVariantOrdering = new DataUtils.FactorioObjectComparer<Goods>((x, y) => (y.ApproximateFlow() / MathF.Abs(y.Cost())).CompareTo(x.ApproximateFlow() / MathF.Abs(x.Cost())));
+        void dropDownContent(ImGui gui) {
+            if (type == ProductDropdownType.Fuel && recipe?.entity != null) {
+                EntityEnergy? energy = recipe.entity.energy;
 
-        private enum ProductDropdownType {
-            DesiredProduct,
-            Fuel,
-            Ingredient,
-            Product,
-            DesiredIngredient,
-        }
+                if (energy == null || energy.fuels.Length == 0) {
+                    gui.BuildText("This entity has no known fuels");
+                }
+                else if (energy.fuels.Length > 1 || energy.fuels[0] != recipe.fuel) {
+                    Func<Goods, string> fuelDisplayFunc = energy.type == EntityEnergyType.FluidHeat
+                         ? g => DataUtils.FormatAmount(g.fluid?.heatValue ?? 0, UnitOfMeasure.Megajoule)
+                         : g => DataUtils.FormatAmount(g.fuelValue, UnitOfMeasure.Megajoule);
 
-        private void CreateLink(ProductionTable table, Goods goods) {
-            if (table.linkMap.ContainsKey(goods)) {
-                return;
+                    BuildFavorites(gui, recipe.fuel, "Add fuel to favorites");
+                    gui.BuildInlineObjectListAndButton(energy.fuels, DataUtils.FavoriteFuel,
+                        fuel => recipe.RecordUndo().fuel = fuel, "Select fuel", extra: fuelDisplayFunc);
+                }
             }
 
-            ProductionLink link = new ProductionLink(table, goods);
-            Rebuild();
-            table.RecordUndo().links.Add(link);
-        }
+            if (variants != null) {
+                gui.BuildText("Accepted fluid variants:");
+                using (var grid = gui.EnterInlineGrid(3f)) {
+                    foreach (var variant in variants) {
+                        grid.Next();
+                        if (gui.BuildFactorioObjectButton(variant, ButtonDisplayStyle.ProductionTableScaled(variant == goods ? SchemeColor.Primary : SchemeColor.None), tooltipOptions: HintLocations.OnProducingRecipes) == Click.Left &&
+                            variant != goods) {
+                            recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
+                            if (recipe!.fixedIngredient == goods) {
+                                recipe.fixedIngredient = variant;
+                            }
+                            _ = gui.CloseDropdown();
+                        }
+                    }
+                }
 
-        private void DestroyLink(ProductionLink link) {
-            if (link.owner.links.Contains(link)) {
-                _ = link.owner.RecordUndo().links.Remove(link);
-                Rebuild();
-            }
-        }
-
-        private void CreateNewProductionTable(Goods goods, float amount) {
-            var page = MainScreen.Instance.AddProjectPage(goods.locName, goods, typeof(ProductionTable), true, false);
-            ProductionTable content = (ProductionTable)page.content;
-            ProductionLink link = new ProductionLink(content, goods) { amount = amount > 0 ? amount : 1 };
-            content.links.Add(link);
-            content.RebuildLinkMap();
-        }
-
-        private void OpenProductDropdown(ImGui targetGui, Rect rect, Goods goods, float amount, ProductionLink? link, ProductDropdownType type, RecipeRow? recipe, ProductionTable context, Goods[]? variants = null) {
-            if (InputSystem.Instance.shift) {
-                Project.current.preferences.SetSourceResource(goods, !goods.IsSourceResource());
-                targetGui.Rebuild();
-                return;
+                gui.allocator = RectAllocator.Stretch;
             }
 
-            var comparer = DataUtils.GetRecipeComparerFor(goods);
-            HashSet<RecipeOrTechnology> allRecipes = new HashSet<RecipeOrTechnology>(context.recipes.Select(x => x.recipe));
-            bool recipeExists(RecipeOrTechnology rec) {
-                return allRecipes.Contains(rec);
+            if (link != null) {
+                foreach (string warning in link.LinkWarnings) {
+                    gui.BuildText(warning, TextBlockDisplayStyle.ErrorText);
+                }
             }
 
-            Goods? selectedFuel = null;
-            Goods? spentFuel = null;
-            async void addRecipe(RecipeOrTechnology rec) {
-                if (variants == null) {
-                    CreateLink(context, goods);
+            #region Recipe selection
+            int numberOfShownRecipes = 0;
+            if (goods.name == SpecialNames.ResearchUnit) {
+                if (gui.BuildButton("Add technology") && gui.CloseDropdown()) {
+                    SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology", r => context.AddRecipe(r, DefaultVariantOrdering), checkMark: r => context.recipes.Any(rr => rr.recipe == r));
+                }
+            }
+            else if (type <= ProductDropdownType.Ingredient && allProduction.Length > 0) {
+                gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 6, true, recipeExists);
+                numberOfShownRecipes += allProduction.Length;
+                if (link == null) {
+                    Rect iconRect = new Rect(gui.lastRect.Right - 2f, gui.lastRect.Top, 2f, 2f);
+                    gui.DrawIcon(iconRect.Expand(-0.2f), Icon.OpenNew, gui.textColor);
+                    var evt = gui.BuildButton(iconRect, SchemeColor.None, SchemeColor.Grey);
+                    if (evt == ButtonEvent.Click && gui.CloseDropdown()) {
+                        CreateNewProductionTable(goods, amount);
+                    }
+                    else if (evt == ButtonEvent.MouseOver) {
+                        gui.ShowTooltip(iconRect, "Create new production table for " + goods.locName);
+                    }
+                }
+            }
+
+            if (type <= ProductDropdownType.Ingredient && spentFuelRecipes.Length > 0) {
+                gui.BuildInlineObjectListAndButton(
+                    spentFuelRecipes,
+                    DataUtils.AlreadySortedRecipe,
+                    (x) => { spentFuel = goods; addRecipe(x); },
+                    "Produce it as a spent fuel",
+                    3,
+                    true,
+                    recipeExists);
+                numberOfShownRecipes += spentFuelRecipes.Length;
+            }
+
+            if (type >= ProductDropdownType.Product && goods.usages.Length > 0) {
+                gui.BuildInlineObjectListAndButton(
+                    goods.usages,
+                    DataUtils.DefaultRecipeOrdering,
+                    addRecipe,
+                    "Add consumption recipe",
+                    6,
+                    true,
+                    recipeExists);
+                numberOfShownRecipes += goods.usages.Length;
+            }
+
+            if (type >= ProductDropdownType.Product && fuelUseList.Length > 0) {
+                gui.BuildInlineObjectListAndButton(
+                    fuelUseList,
+                    DataUtils.AlreadySortedRecipe,
+                    (x) => { selectedFuel = goods; addRecipe(x); },
+                    "Add fuel usage",
+                    6,
+                    true,
+                    recipeExists);
+                numberOfShownRecipes += fuelUseList.Length;
+            }
+
+            if (type >= ProductDropdownType.Product && Database.allSciencePacks.Contains(goods)
+                && gui.BuildButton("Add consumption technology") && gui.CloseDropdown()) {
+                // Select from the technologies that consume this science pack.
+                SelectMultiObjectPanel.Select(Database.technologies.all.Where(t => t.ingredients.Select(i => i.goods).Contains(goods)), "Add technology", addRecipe, checkMark: recipeExists);
+            }
+
+            if (type >= ProductDropdownType.Product && allProduction.Length > 0) {
+                gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 1, true, recipeExists);
+                numberOfShownRecipes += allProduction.Length;
+            }
+
+            if (numberOfShownRecipes > 1) {
+                gui.BuildText("Hint: ctrl+click to add multiple", TextBlockDisplayStyle.HintText);
+            }
+            #endregion
+
+            #region Link management
+            if (link != null && gui.BuildCheckBox("Allow overproduction", link.algorithm == LinkAlgorithm.AllowOverProduction, out bool newValue)) {
+                link.RecordUndo().algorithm = newValue ? LinkAlgorithm.AllowOverProduction : LinkAlgorithm.Match;
+            }
+
+            if (link != null && gui.BuildButton("View link summary") && gui.CloseDropdown()) {
+                ProductionLinkSummaryScreen.Show(link);
+            }
+
+            if (link != null && link.owner == context) {
+                if (link.amount != 0) {
+                    gui.BuildText(goods.locName + " is a desired product and cannot be unlinked.", TextBlockDisplayStyle.WrappedText);
                 }
                 else {
-                    foreach (var variant in variants) {
-                        if (rec.GetProductionPerRecipe(variant) > 0f) {
-                            CreateLink(context, variant);
-                            if (variant != goods) {
-                                recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
-                            }
-
-                            break;
-                        }
-                    }
-                }
-                if (!allRecipes.Contains(rec) || (await MessageBox.Show("Recipe already exists", $"Add a second copy of {rec.locName}?", "Add a copy", "Cancel")).choice) {
-                    context.AddRecipe(rec, DefaultVariantOrdering, selectedFuel, spentFuel);
-                }
-            }
-
-            if (InputSystem.Instance.control) {
-                bool isInput = type <= ProductDropdownType.Ingredient;
-                var recipeList = isInput ? goods.production : goods.usages;
-                if (recipeList.SelectSingle(out _) is Recipe selected) {
-                    addRecipe(selected);
-                    return;
-                }
-            }
-
-            Recipe[] allProduction = variants == null ? goods.production : variants.SelectMany(x => x.production).Distinct().ToArray();
-            Recipe[] fuelUseList = goods.fuelFor.OfType<EntityCrafter>()
-                .SelectMany(e => e.recipes).OfType<Recipe>()
-                .Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
-            Recipe[] spentFuelRecipes = goods.miscSources.OfType<Item>()
-                .SelectMany(e => e.fuelFor.OfType<EntityCrafter>())
-                .SelectMany(e => e.recipes).OfType<Recipe>()
-                .Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray();
-
-            targetGui.ShowDropDown(rect, dropDownContent, new Padding(1f), 25f);
-
-            void dropDownContent(ImGui gui) {
-                if (type == ProductDropdownType.Fuel && recipe?.entity != null) {
-                    EntityEnergy? energy = recipe.entity.energy;
-
-                    if (energy == null || energy.fuels.Length == 0) {
-                        gui.BuildText("This entity has no known fuels");
-                    }
-                    else if (energy.fuels.Length > 1 || energy.fuels[0] != recipe.fuel) {
-                        Func<Goods, string> fuelDisplayFunc = energy.type == EntityEnergyType.FluidHeat
-                             ? g => DataUtils.FormatAmount(g.fluid?.heatValue ?? 0, UnitOfMeasure.Megajoule)
-                             : g => DataUtils.FormatAmount(g.fuelValue, UnitOfMeasure.Megajoule);
-
-                        BuildFavorites(gui, recipe.fuel, "Add fuel to favorites");
-                        gui.BuildInlineObjectListAndButton(energy.fuels, DataUtils.FavoriteFuel,
-                            fuel => recipe.RecordUndo().fuel = fuel, "Select fuel", extra: fuelDisplayFunc);
-                    }
+                    gui.BuildText(goods.locName + " production is currently linked. This means that YAFC will try to match production with consumption.", TextBlockDisplayStyle.WrappedText);
                 }
 
-                if (variants != null) {
-                    gui.BuildText("Accepted fluid variants:");
-                    using (var grid = gui.EnterInlineGrid(3f)) {
-                        foreach (var variant in variants) {
-                            grid.Next();
-                            if (gui.BuildFactorioObjectButton(variant, ButtonDisplayStyle.ProductionTableScaled(variant == goods ? SchemeColor.Primary : SchemeColor.None), tooltipOptions: HintLocations.OnProducingRecipes) == Click.Left &&
-                                variant != goods) {
-                                recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
-                                if (recipe!.fixedIngredient == goods) {
-                                    recipe.fixedIngredient = variant;
-                                }
-                                _ = gui.CloseDropdown();
-                            }
-                        }
+                if (type is ProductDropdownType.DesiredIngredient or ProductDropdownType.DesiredProduct) {
+                    if (gui.BuildButton("Remove desired product") && gui.CloseDropdown()) {
+                        link.RecordUndo().amount = 0;
                     }
 
-                    gui.allocator = RectAllocator.Stretch;
-                }
-
-                if (link != null) {
-                    foreach (string warning in link.LinkWarnings) {
-                        gui.BuildText(warning, TextBlockDisplayStyle.ErrorText);
-                    }
-                }
-
-                #region Recipe selection
-                int numberOfShownRecipes = 0;
-                if (goods.name == SpecialNames.ResearchUnit) {
-                    if (gui.BuildButton("Add technology") && gui.CloseDropdown()) {
-                        SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology", r => context.AddRecipe(r, DefaultVariantOrdering), checkMark: r => context.recipes.Any(rr => rr.recipe == r));
-                    }
-                }
-                else if (type <= ProductDropdownType.Ingredient && allProduction.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 6, true, recipeExists);
-                    numberOfShownRecipes += allProduction.Length;
-                    if (link == null) {
-                        Rect iconRect = new Rect(gui.lastRect.Right - 2f, gui.lastRect.Top, 2f, 2f);
-                        gui.DrawIcon(iconRect.Expand(-0.2f), Icon.OpenNew, gui.textColor);
-                        var evt = gui.BuildButton(iconRect, SchemeColor.None, SchemeColor.Grey);
-                        if (evt == ButtonEvent.Click && gui.CloseDropdown()) {
-                            CreateNewProductionTable(goods, amount);
-                        }
-                        else if (evt == ButtonEvent.MouseOver) {
-                            gui.ShowTooltip(iconRect, "Create new production table for " + goods.locName);
-                        }
-                    }
-                }
-
-                if (type <= ProductDropdownType.Ingredient && spentFuelRecipes.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(
-                        spentFuelRecipes,
-                        DataUtils.AlreadySortedRecipe,
-                        (x) => { spentFuel = goods; addRecipe(x); },
-                        "Produce it as a spent fuel",
-                        3,
-                        true,
-                        recipeExists);
-                    numberOfShownRecipes += spentFuelRecipes.Length;
-                }
-
-                if (type >= ProductDropdownType.Product && goods.usages.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(
-                        goods.usages,
-                        DataUtils.DefaultRecipeOrdering,
-                        addRecipe,
-                        "Add consumption recipe",
-                        6,
-                        true,
-                        recipeExists);
-                    numberOfShownRecipes += goods.usages.Length;
-                }
-
-                if (type >= ProductDropdownType.Product && fuelUseList.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(
-                        fuelUseList,
-                        DataUtils.AlreadySortedRecipe,
-                        (x) => { selectedFuel = goods; addRecipe(x); },
-                        "Add fuel usage",
-                        6,
-                        true,
-                        recipeExists);
-                    numberOfShownRecipes += fuelUseList.Length;
-                }
-
-                if (type >= ProductDropdownType.Product && Database.allSciencePacks.Contains(goods)
-                    && gui.BuildButton("Add consumption technology") && gui.CloseDropdown()) {
-                    // Select from the technologies that consume this science pack.
-                    SelectMultiObjectPanel.Select(Database.technologies.all.Where(t => t.ingredients.Select(i => i.goods).Contains(goods)), "Add technology", addRecipe, checkMark: recipeExists);
-                }
-
-                if (type >= ProductDropdownType.Product && allProduction.Length > 0) {
-                    gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 1, true, recipeExists);
-                    numberOfShownRecipes += allProduction.Length;
-                }
-
-                if (numberOfShownRecipes > 1) {
-                    gui.BuildText("Hint: ctrl+click to add multiple", TextBlockDisplayStyle.HintText);
-                }
-                #endregion
-
-                #region Link management
-                if (link != null && gui.BuildCheckBox("Allow overproduction", link.algorithm == LinkAlgorithm.AllowOverProduction, out bool newValue)) {
-                    link.RecordUndo().algorithm = newValue ? LinkAlgorithm.AllowOverProduction : LinkAlgorithm.Match;
-                }
-
-                if (link != null && gui.BuildButton("View link summary") && gui.CloseDropdown()) {
-                    ProductionLinkSummaryScreen.Show(link);
-                }
-
-                if (link != null && link.owner == context) {
-                    if (link.amount != 0) {
-                        gui.BuildText(goods.locName + " is a desired product and cannot be unlinked.", TextBlockDisplayStyle.WrappedText);
-                    }
-                    else {
-                        gui.BuildText(goods.locName + " production is currently linked. This means that YAFC will try to match production with consumption.", TextBlockDisplayStyle.WrappedText);
-                    }
-
-                    if (type is ProductDropdownType.DesiredIngredient or ProductDropdownType.DesiredProduct) {
-                        if (gui.BuildButton("Remove desired product") && gui.CloseDropdown()) {
-                            link.RecordUndo().amount = 0;
-                        }
-
-                        if (gui.BuildButton("Remove and unlink").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
-                            DestroyLink(link);
-                        }
-                    }
-                    else if (link.amount == 0 && gui.BuildButton("Unlink").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
+                    if (gui.BuildButton("Remove and unlink").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
                         DestroyLink(link);
                     }
                 }
-                else if (goods != null) {
-                    if (link != null) {
-                        gui.BuildText(goods.locName + " production is currently linked, but the link is outside this nested table. Nested tables can have its own separate set of links", TextBlockDisplayStyle.WrappedText);
-                    }
-                    else {
-                        gui.BuildText(goods.locName + " production is currently NOT linked. This means that YAFC will make no attempt to match production with consumption.", TextBlockDisplayStyle.WrappedText);
-                    }
-
-                    if (gui.BuildButton("Create link").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
-                        CreateLink(context, goods);
-                    }
+                else if (link.amount == 0 && gui.BuildButton("Unlink").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
+                    DestroyLink(link);
                 }
-                #endregion
+            }
+            else if (goods != null) {
+                if (link != null) {
+                    gui.BuildText(goods.locName + " production is currently linked, but the link is outside this nested table. Nested tables can have its own separate set of links", TextBlockDisplayStyle.WrappedText);
+                }
+                else {
+                    gui.BuildText(goods.locName + " production is currently NOT linked. This means that YAFC will make no attempt to match production with consumption.", TextBlockDisplayStyle.WrappedText);
+                }
 
-                #region Fixed production/consumption
-                if (goods != null && recipe != null) {
-                    if (recipe.fixedBuildings == 0
-                        || (type == ProductDropdownType.Fuel && !recipe.fixedFuel)
-                        || (type == ProductDropdownType.Ingredient && recipe.fixedIngredient != goods)
-                        || (type == ProductDropdownType.Product && recipe.fixedProduct != goods)) {
-                        string? prompt = type switch {
-                            ProductDropdownType.Fuel => "Set fixed fuel consumption",
-                            ProductDropdownType.Ingredient => "Set fixed ingredient consumption",
-                            ProductDropdownType.Product => "Set fixed production amount",
-                            _ => null
-                        };
-                        if (prompt != null) {
-                            ButtonEvent evt;
-                            if (recipe.fixedBuildings == 0) {
+                if (gui.BuildButton("Create link").WithTooltip(gui, "Shortcut: right-click") && gui.CloseDropdown()) {
+                    CreateLink(context, goods);
+                }
+            }
+            #endregion
+
+            #region Fixed production/consumption
+            if (goods != null && recipe != null) {
+                if (recipe.fixedBuildings == 0
+                    || (type == ProductDropdownType.Fuel && !recipe.fixedFuel)
+                    || (type == ProductDropdownType.Ingredient && recipe.fixedIngredient != goods)
+                    || (type == ProductDropdownType.Product && recipe.fixedProduct != goods)) {
+                    string? prompt = type switch {
+                        ProductDropdownType.Fuel => "Set fixed fuel consumption",
+                        ProductDropdownType.Ingredient => "Set fixed ingredient consumption",
+                        ProductDropdownType.Product => "Set fixed production amount",
+                        _ => null
+                    };
+                    if (prompt != null) {
+                        ButtonEvent evt;
+                        if (recipe.fixedBuildings == 0) {
+                            evt = gui.BuildButton(prompt);
+                        }
+                        else {
+                            using (gui.EnterRowWithHelpIcon("This will replace the other fixed amount in this row.")) {
+                                gui.allocator = RectAllocator.RemainingRow;
                                 evt = gui.BuildButton(prompt);
                             }
-                            else {
-                                using (gui.EnterRowWithHelpIcon("This will replace the other fixed amount in this row.")) {
-                                    gui.allocator = RectAllocator.RemainingRow;
-                                    evt = gui.BuildButton(prompt);
-                                }
+                        }
+                        if (evt && gui.CloseDropdown()) {
+                            recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0 ? 1 : recipe.buildingCount;
+                            switch (type) {
+                                case ProductDropdownType.Fuel:
+                                    recipe.fixedFuel = true;
+                                    recipe.fixedIngredient = null;
+                                    recipe.fixedProduct = null;
+                                    break;
+                                case ProductDropdownType.Ingredient:
+                                    recipe.fixedFuel = false;
+                                    recipe.fixedIngredient = goods;
+                                    recipe.fixedProduct = null;
+                                    break;
+                                case ProductDropdownType.Product:
+                                    recipe.fixedFuel = false;
+                                    recipe.fixedIngredient = null;
+                                    recipe.fixedProduct = goods;
+                                    break;
+                                default:
+                                    break;
                             }
-                            if (evt && gui.CloseDropdown()) {
-                                recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0 ? 1 : recipe.buildingCount;
-                                switch (type) {
-                                    case ProductDropdownType.Fuel:
-                                        recipe.fixedFuel = true;
-                                        recipe.fixedIngredient = null;
-                                        recipe.fixedProduct = null;
-                                        break;
-                                    case ProductDropdownType.Ingredient:
-                                        recipe.fixedFuel = false;
-                                        recipe.fixedIngredient = goods;
-                                        recipe.fixedProduct = null;
-                                        break;
-                                    case ProductDropdownType.Product:
-                                        recipe.fixedFuel = false;
-                                        recipe.fixedIngredient = null;
-                                        recipe.fixedProduct = goods;
-                                        break;
-                                    default:
-                                        break;
-                                }
-                                targetGui.Rebuild();
-                            }
+                            targetGui.Rebuild();
                         }
                     }
+                }
 
-                    if (recipe.fixedBuildings != 0
-                        && ((type == ProductDropdownType.Fuel && recipe.fixedFuel)
-                        || (type == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
-                        || (type == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
-                        string? prompt = type switch {
-                            ProductDropdownType.Fuel => "Clear fixed fuel consumption",
-                            ProductDropdownType.Ingredient => "Clear fixed ingredient consumption",
-                            ProductDropdownType.Product => "Clear fixed production amount",
-                            _ => null
-                        };
-                        if (prompt != null && gui.BuildButton(prompt) && gui.CloseDropdown()) {
-                            recipe.RecordUndo().fixedBuildings = 0;
-                        }
-                        targetGui.Rebuild();
+                if (recipe.fixedBuildings != 0
+                    && ((type == ProductDropdownType.Fuel && recipe.fixedFuel)
+                    || (type == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
+                    || (type == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
+                    string? prompt = type switch {
+                        ProductDropdownType.Fuel => "Clear fixed fuel consumption",
+                        ProductDropdownType.Ingredient => "Clear fixed ingredient consumption",
+                        ProductDropdownType.Product => "Clear fixed production amount",
+                        _ => null
+                    };
+                    if (prompt != null && gui.BuildButton(prompt) && gui.CloseDropdown()) {
+                        recipe.RecordUndo().fixedBuildings = 0;
                     }
-                }
-                #endregion
-
-                if (goods is Item) {
-                    BuildBeltInserterInfo(gui, amount, recipe?.buildingCount ?? 0);
+                    targetGui.Rebuild();
                 }
             }
-        }
+            #endregion
 
-        public override void SetSearchQuery(SearchQuery query) {
-            _ = model.Search(query);
-            bodyContent.Rebuild();
-        }
-
-        private void DrawDesiredProduct(ImGui gui, ProductionLink element) {
-            gui.allocator = RectAllocator.Stretch;
-            gui.spacing = 0f;
-            SchemeColor iconColor = SchemeColor.Primary;
-
-            if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
-                if (element.linkFlow > element.amount && CheckPossibleOverproducing(element)) {
-                    // Actual overproduction occurred for this product
-                    iconColor = SchemeColor.Magenta;
-                }
-                else {
-                    // There is not enough production (most likely none at all, otherwise the analyzer will have a deadlock)
-                    iconColor = SchemeColor.Error;
-                }
-            }
-
-            ObjectTooltipOptions tooltipOptions = element.amount < 0 ? HintLocations.OnConsumingRecipes : HintLocations.OnProducingRecipes;
-            if (element.LinkWarnings is IEnumerable<string> warnings) {
-                tooltipOptions.DrawBelowHeader = gui => {
-                    foreach (string warning in warnings) {
-                        gui.BuildText(warning, TextBlockDisplayStyle.ErrorText);
-                    }
-                };
-            }
-
-            DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
-            switch (gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions)) {
-                case GoodsWithAmountEvent.LeftButtonClick:
-                    OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, element.amount < 0 ? ProductDropdownType.DesiredIngredient : ProductDropdownType.DesiredProduct, null, element.owner);
-                    break;
-                case GoodsWithAmountEvent.RightButtonClick:
-                    DestroyLink(element);
-                    break;
-                case GoodsWithAmountEvent.TextEditing when amount.Value != 0:
-                    element.RecordUndo().amount = amount.Value;
-                    break;
+            if (goods is Item) {
+                BuildBeltInserterInfo(gui, amount, recipe?.buildingCount ?? 0);
             }
         }
+    }
 
-        public override void Rebuild(bool visualOnly = false) {
-            flatHierarchyBuilder.SetData(model);
-            base.Rebuild(visualOnly);
-        }
+    public override void SetSearchQuery(SearchQuery query) {
+        _ = model.Search(query);
+        bodyContent.Rebuild();
+    }
 
-        private void BuildGoodsIcon(ImGui gui, Goods? goods, ProductionLink? link, float amount, ProductDropdownType dropdownType, RecipeRow? recipe, ProductionTable context, ObjectTooltipOptions tooltipOptions, Goods[]? variants = null) {
-            SchemeColor iconColor;
-            if (link != null) {
-                // The icon is part of a production link
-                if ((link.flags & (ProductionLink.Flags.HasProductionAndConsumption | ProductionLink.Flags.LinkRecursiveNotMatched | ProductionLink.Flags.ChildNotMatched)) != ProductionLink.Flags.HasProductionAndConsumption) {
-                    // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
-                    iconColor = SchemeColor.Error;
-                }
-                // TODO (shpaass/yafc-ce/issues/269): refactor enum check into explicit instead of ordinal instructions
-                else if (dropdownType >= ProductDropdownType.Product && CheckPossibleOverproducing(link)) {
-                    // Actual overproduction occurred in the recipe
-                    iconColor = SchemeColor.Magenta;
-                }
-                else if (link.owner != context) {
-                    // It is a foreign link (e.g. not part of the sub group)
-                    iconColor = SchemeColor.Secondary;
-                }
-                else {
-                    // Regular (nothing going on) linked icon
-                    iconColor = SchemeColor.Primary;
-                }
+    private void DrawDesiredProduct(ImGui gui, ProductionLink element) {
+        gui.allocator = RectAllocator.Stretch;
+        gui.spacing = 0f;
+        SchemeColor iconColor = SchemeColor.Primary;
+
+        if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
+            if (element.linkFlow > element.amount && CheckPossibleOverproducing(element)) {
+                // Actual overproduction occurred for this product
+                iconColor = SchemeColor.Magenta;
             }
             else {
-                // The icon is not part of a production link
-                iconColor = goods.IsSourceResource() ? SchemeColor.Green : SchemeColor.None;
+                // There is not enough production (most likely none at all, otherwise the analyzer will have a deadlock)
+                iconColor = SchemeColor.Error;
             }
+        }
 
-            // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
-            //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550377021
-            SchemeColor textColor = flatHierarchyBuilder.nextRowTextColor;
-            if (!flatHierarchyBuilder.nextRowIsHighlighted) {
-                textColor = SchemeColor.None;
+        ObjectTooltipOptions tooltipOptions = element.amount < 0 ? HintLocations.OnConsumingRecipes : HintLocations.OnProducingRecipes;
+        if (element.LinkWarnings is IEnumerable<string> warnings) {
+            tooltipOptions.DrawBelowHeader = gui => {
+                foreach (string warning in warnings) {
+                    gui.BuildText(warning, TextBlockDisplayStyle.ErrorText);
+                }
+            };
+        }
+
+        DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
+        switch (gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions)) {
+            case GoodsWithAmountEvent.LeftButtonClick:
+                OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, element.amount < 0 ? ProductDropdownType.DesiredIngredient : ProductDropdownType.DesiredProduct, null, element.owner);
+                break;
+            case GoodsWithAmountEvent.RightButtonClick:
+                DestroyLink(element);
+                break;
+            case GoodsWithAmountEvent.TextEditing when amount.Value != 0:
+                element.RecordUndo().amount = amount.Value;
+                break;
+        }
+    }
+
+    public override void Rebuild(bool visualOnly = false) {
+        flatHierarchyBuilder.SetData(model);
+        base.Rebuild(visualOnly);
+    }
+
+    private void BuildGoodsIcon(ImGui gui, Goods? goods, ProductionLink? link, float amount, ProductDropdownType dropdownType, RecipeRow? recipe, ProductionTable context, ObjectTooltipOptions tooltipOptions, Goods[]? variants = null) {
+        SchemeColor iconColor;
+        if (link != null) {
+            // The icon is part of a production link
+            if ((link.flags & (ProductionLink.Flags.HasProductionAndConsumption | ProductionLink.Flags.LinkRecursiveNotMatched | ProductionLink.Flags.ChildNotMatched)) != ProductionLink.Flags.HasProductionAndConsumption) {
+                // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
+                iconColor = SchemeColor.Error;
             }
-            else if (recipe is { enabled: false }) {
-                textColor = SchemeColor.BackgroundTextFaint;
+            // TODO (shpaass/yafc-ce/issues/269): refactor enum check into explicit instead of ordinal instructions
+            else if (dropdownType >= ProductDropdownType.Product && CheckPossibleOverproducing(link)) {
+                // Actual overproduction occurred in the recipe
+                iconColor = SchemeColor.Magenta;
             }
-
-            GoodsWithAmountEvent evt;
-            DisplayAmount displayAmount = new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None);
-
-            if (link?.LinkWarnings is IEnumerable<string> warnings) {
-                tooltipOptions.DrawBelowHeader += gui => {
-                    foreach (string warning in warnings) {
-                        gui.BuildText(warning, TextBlockDisplayStyle.ErrorText);
-                    }
-                };
-            }
-
-            if (recipe != null && recipe.fixedBuildings > 0
-                && ((dropdownType == ProductDropdownType.Fuel && recipe.fixedFuel)
-                || (dropdownType == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
-                || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
-                evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions);
+            else if (link.owner != context) {
+                // It is a foreign link (e.g. not part of the sub group)
+                iconColor = SchemeColor.Secondary;
             }
             else {
-                evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions);
-            }
-
-            switch (evt) {
-                case GoodsWithAmountEvent.LeftButtonClick when goods is not null:
-                    OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
-                    break;
-                case GoodsWithAmountEvent.RightButtonClick when goods is not null && (link is null || link.owner != context):
-                    CreateLink(context, goods);
-                    break;
-                case GoodsWithAmountEvent.RightButtonClick when link?.amount == 0 && link.owner == context:
-                    DestroyLink(link);
-                    break;
-                case GoodsWithAmountEvent.TextEditing when displayAmount.Value >= 0:
-                    // The amount is always stored in fixedBuildings. Scale it to match the requested change to this item.
-                    recipe!.RecordUndo().fixedBuildings *= displayAmount.Value / amount;
-                    break;
+                // Regular (nothing going on) linked icon
+                iconColor = SchemeColor.Primary;
             }
         }
+        else {
+            // The icon is not part of a production link
+            iconColor = goods.IsSourceResource() ? SchemeColor.Green : SchemeColor.None;
+        }
 
-        /// <summary>
-        /// Checks some criteria that are necessary but not sufficient to consider something overproduced.
-        /// </summary>
-        private static bool CheckPossibleOverproducing(ProductionLink link) => link.algorithm == LinkAlgorithm.AllowOverProduction && link.flags.HasFlag(ProductionLink.Flags.LinkNotMatched);
+        // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
+        //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550377021
+        SchemeColor textColor = flatHierarchyBuilder.nextRowTextColor;
+        if (!flatHierarchyBuilder.nextRowIsHighlighted) {
+            textColor = SchemeColor.None;
+        }
+        else if (recipe is { enabled: false }) {
+            textColor = SchemeColor.BackgroundTextFaint;
+        }
 
-        /// <param name="isForSummary">If <see langword="true"/>, this call is for a summary box, at the top of a root-level or nested table.
-        /// If <see langword="false"/>, this call is for collapsed recipe row.</param>
-        /// <param name="initializeDrawArea">If not <see langword="null"/>, this will be called before drawing the first element. This method may choose not to draw
-        /// some or all of a table's extra products, and this lets the caller suppress the surrounding UI elements if no product end up being drawn.</param>
-        private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid, bool isForSummary, Action<ImGui>? initializeDrawArea = null) {
-            var flow = table.flow;
-            int firstProduct = Array.BinarySearch(flow, new ProductionTableFlow(Database.voidEnergy, 1e-9f, null), model);
-            if (firstProduct < 0) {
-                firstProduct = ~firstProduct;
-            }
+        GoodsWithAmountEvent evt;
+        DisplayAmount displayAmount = new(amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None);
 
-            for (int i = firstProduct; i < flow.Length; i++) {
-                float amt = flow[i].amount;
-                if (isForSummary) {
-                    amt -= flow[i].link?.amount ?? 0;
+        if (link?.LinkWarnings is IEnumerable<string> warnings) {
+            tooltipOptions.DrawBelowHeader += gui => {
+                foreach (string warning in warnings) {
+                    gui.BuildText(warning, TextBlockDisplayStyle.ErrorText);
                 }
-                if (amt <= 0f) {
-                    continue;
-                }
+            };
+        }
 
-                initializeDrawArea?.Invoke(gui);
-                initializeDrawArea = null;
+        if (recipe != null && recipe.fixedBuildings > 0
+            && ((dropdownType == ProductDropdownType.Fuel && recipe.fixedFuel)
+            || (dropdownType == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
+            || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
+            evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions);
+        }
+        else {
+            evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions);
+        }
 
-                grid.Next();
-                BuildGoodsIcon(gui, flow[i].goods, flow[i].link, amt, ProductDropdownType.Product, null, context, HintLocations.OnConsumingRecipes);
+        switch (evt) {
+            case GoodsWithAmountEvent.LeftButtonClick when goods is not null:
+                OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
+                break;
+            case GoodsWithAmountEvent.RightButtonClick when goods is not null && (link is null || link.owner != context):
+                CreateLink(context, goods);
+                break;
+            case GoodsWithAmountEvent.RightButtonClick when link?.amount == 0 && link.owner == context:
+                DestroyLink(link);
+                break;
+            case GoodsWithAmountEvent.TextEditing when displayAmount.Value >= 0:
+                // The amount is always stored in fixedBuildings. Scale it to match the requested change to this item.
+                recipe!.RecordUndo().fixedBuildings *= displayAmount.Value / amount;
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Checks some criteria that are necessary but not sufficient to consider something overproduced.
+    /// </summary>
+    private static bool CheckPossibleOverproducing(ProductionLink link) => link.algorithm == LinkAlgorithm.AllowOverProduction && link.flags.HasFlag(ProductionLink.Flags.LinkNotMatched);
+
+    /// <param name="isForSummary">If <see langword="true"/>, this call is for a summary box, at the top of a root-level or nested table.
+    /// If <see langword="false"/>, this call is for collapsed recipe row.</param>
+    /// <param name="initializeDrawArea">If not <see langword="null"/>, this will be called before drawing the first element. This method may choose not to draw
+    /// some or all of a table's extra products, and this lets the caller suppress the surrounding UI elements if no product end up being drawn.</param>
+    private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid, bool isForSummary, Action<ImGui>? initializeDrawArea = null) {
+        var flow = table.flow;
+        int firstProduct = Array.BinarySearch(flow, new ProductionTableFlow(Database.voidEnergy, 1e-9f, null), model);
+        if (firstProduct < 0) {
+            firstProduct = ~firstProduct;
+        }
+
+        for (int i = firstProduct; i < flow.Length; i++) {
+            float amt = flow[i].amount;
+            if (isForSummary) {
+                amt -= flow[i].link?.amount ?? 0;
+            }
+            if (amt <= 0f) {
+                continue;
+            }
+
+            initializeDrawArea?.Invoke(gui);
+            initializeDrawArea = null;
+
+            grid.Next();
+            BuildGoodsIcon(gui, flow[i].goods, flow[i].link, amt, ProductDropdownType.Product, null, context, HintLocations.OnConsumingRecipes);
+        }
+    }
+
+    private void FillRecipeList(ProductionTable table, List<RecipeRow> list) {
+        foreach (var recipe in table.recipes) {
+            list.Add(recipe);
+            if (recipe.subgroup != null) {
+                FillRecipeList(recipe.subgroup, list);
+            }
+        }
+    }
+
+    private void FillLinkList(ProductionTable table, List<ProductionLink> list) {
+        list.AddRange(table.links);
+        foreach (var recipe in table.recipes) {
+            if (recipe.subgroup != null) {
+                FillLinkList(recipe.subgroup, list);
+            }
+        }
+    }
+
+    private List<RecipeRow> GetRecipesRecursive() {
+        List<RecipeRow> list = [];
+        FillRecipeList(model, list);
+        return list;
+    }
+
+    private List<RecipeRow> GetRecipesRecursive(RecipeRow recipeRoot) {
+        List<RecipeRow> list = [recipeRoot];
+        if (recipeRoot.subgroup != null) {
+            FillRecipeList(recipeRoot.subgroup, list);
+        }
+
+        return list;
+    }
+
+    private void BuildShoppingList(RecipeRow? recipeRoot) => ShoppingListScreen.Show(recipeRoot == null ? GetRecipesRecursive() : GetRecipesRecursive(recipeRoot));
+
+    private void BuildBeltInserterInfo(ImGui gui, float amount, float buildingCount) {
+        var prefs = Project.current.preferences;
+        var belt = prefs.defaultBelt;
+        var inserter = prefs.defaultInserter;
+        if (belt == null || inserter == null) {
+            return;
+        }
+
+        float beltCount = amount / belt.beltItemsPerSecond;
+        float buildingsPerHalfBelt = belt.beltItemsPerSecond * buildingCount / (amount * 2f);
+        bool click = false;
+
+        using (gui.EnterRow()) {
+            click |= gui.BuildFactorioObjectButton(belt, ButtonDisplayStyle.Default) == Click.Left;
+            gui.BuildText(DataUtils.FormatAmount(beltCount, UnitOfMeasure.None));
+            if (buildingsPerHalfBelt > 0f) {
+                gui.BuildText("(Buildings per half belt: " + DataUtils.FormatAmount(buildingsPerHalfBelt, UnitOfMeasure.None) + ")");
             }
         }
 
-        private void FillRecipeList(ProductionTable table, List<RecipeRow> list) {
-            foreach (var recipe in table.recipes) {
-                list.Add(recipe);
-                if (recipe.subgroup != null) {
-                    FillRecipeList(recipe.subgroup, list);
-                }
-            }
-        }
-
-        private void FillLinkList(ProductionTable table, List<ProductionLink> list) {
-            list.AddRange(table.links);
-            foreach (var recipe in table.recipes) {
-                if (recipe.subgroup != null) {
-                    FillLinkList(recipe.subgroup, list);
-                }
-            }
-        }
-
-        private List<RecipeRow> GetRecipesRecursive() {
-            List<RecipeRow> list = [];
-            FillRecipeList(model, list);
-            return list;
-        }
-
-        private List<RecipeRow> GetRecipesRecursive(RecipeRow recipeRoot) {
-            List<RecipeRow> list = [recipeRoot];
-            if (recipeRoot.subgroup != null) {
-                FillRecipeList(recipeRoot.subgroup, list);
+        using (gui.EnterRow()) {
+            int capacity = prefs.inserterCapacity;
+            float inserterBase = inserter.inserterSwingTime * amount / capacity;
+            click |= gui.BuildFactorioObjectButton(inserter, ButtonDisplayStyle.Default) == Click.Left;
+            string text = DataUtils.FormatAmount(inserterBase, UnitOfMeasure.None);
+            if (buildingCount > 1) {
+                text += " (" + DataUtils.FormatAmount(inserterBase / buildingCount, UnitOfMeasure.None) + "/building)";
             }
 
-            return list;
-        }
-
-        private void BuildShoppingList(RecipeRow? recipeRoot) => ShoppingListScreen.Show(recipeRoot == null ? GetRecipesRecursive() : GetRecipesRecursive(recipeRoot));
-
-        private void BuildBeltInserterInfo(ImGui gui, float amount, float buildingCount) {
-            var prefs = Project.current.preferences;
-            var belt = prefs.defaultBelt;
-            var inserter = prefs.defaultInserter;
-            if (belt == null || inserter == null) {
-                return;
-            }
-
-            float beltCount = amount / belt.beltItemsPerSecond;
-            float buildingsPerHalfBelt = belt.beltItemsPerSecond * buildingCount / (amount * 2f);
-            bool click = false;
-
-            using (gui.EnterRow()) {
+            gui.BuildText(text);
+            if (capacity > 1) {
+                float withBeltSwingTime = inserter.inserterSwingTime + (2f * (capacity - 1.5f) / belt.beltItemsPerSecond);
+                float inserterToBelt = amount * withBeltSwingTime / capacity;
                 click |= gui.BuildFactorioObjectButton(belt, ButtonDisplayStyle.Default) == Click.Left;
-                gui.BuildText(DataUtils.FormatAmount(beltCount, UnitOfMeasure.None));
-                if (buildingsPerHalfBelt > 0f) {
-                    gui.BuildText("(Buildings per half belt: " + DataUtils.FormatAmount(buildingsPerHalfBelt, UnitOfMeasure.None) + ")");
-                }
-            }
-
-            using (gui.EnterRow()) {
-                int capacity = prefs.inserterCapacity;
-                float inserterBase = inserter.inserterSwingTime * amount / capacity;
+                gui.AllocateSpacing(-1.5f);
                 click |= gui.BuildFactorioObjectButton(inserter, ButtonDisplayStyle.Default) == Click.Left;
-                string text = DataUtils.FormatAmount(inserterBase, UnitOfMeasure.None);
+                text = DataUtils.FormatAmount(inserterToBelt, UnitOfMeasure.None, "~");
                 if (buildingCount > 1) {
-                    text += " (" + DataUtils.FormatAmount(inserterBase / buildingCount, UnitOfMeasure.None) + "/building)";
+                    text += " (" + DataUtils.FormatAmount(inserterToBelt / buildingCount, UnitOfMeasure.None) + "/b)";
                 }
 
                 gui.BuildText(text);
-                if (capacity > 1) {
-                    float withBeltSwingTime = inserter.inserterSwingTime + (2f * (capacity - 1.5f) / belt.beltItemsPerSecond);
-                    float inserterToBelt = amount * withBeltSwingTime / capacity;
-                    click |= gui.BuildFactorioObjectButton(belt, ButtonDisplayStyle.Default) == Click.Left;
-                    gui.AllocateSpacing(-1.5f);
-                    click |= gui.BuildFactorioObjectButton(inserter, ButtonDisplayStyle.Default) == Click.Left;
-                    text = DataUtils.FormatAmount(inserterToBelt, UnitOfMeasure.None, "~");
-                    if (buildingCount > 1) {
-                        text += " (" + DataUtils.FormatAmount(inserterToBelt / buildingCount, UnitOfMeasure.None) + "/b)";
-                    }
-
-                    gui.BuildText(text);
-                }
-            }
-
-            if (click && gui.CloseDropdown()) {
-                PreferencesScreen.Show();
             }
         }
 
-        private void BuildTableIngredients(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid) {
-            foreach (var flow in table.flow) {
-                if (flow.amount >= 0f) {
-                    break;
-                }
-
-                grid.Next();
-                BuildGoodsIcon(gui, flow.goods, flow.link, -flow.amount, ProductDropdownType.Ingredient, null, context, HintLocations.OnProducingRecipes);
-            }
+        if (click && gui.CloseDropdown()) {
+            PreferencesScreen.Show();
         }
+    }
 
-        private void DrawRecipeTagSelect(ImGui gui, RecipeRow recipe) {
-            using (gui.EnterRow()) {
-                for (int i = 0; i < tagIcons.Length; i++) {
-                    var (icon, color) = tagIcons[i];
-                    bool selected = i == recipe.tag;
-                    gui.BuildIcon(icon, color: selected ? SchemeColor.Background : color);
-                    if (selected) {
-                        gui.DrawRectangle(gui.lastRect, color);
-                    }
-                    else {
-                        var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt, SchemeColor.BackgroundAlt);
-                        if (evt) {
-                            recipe.RecordUndo(true).tag = i;
-                        }
-                    }
-                }
-            }
-        }
-
-        protected override void BuildHeader(ImGui gui) {
-            base.BuildHeader(gui);
-            flatHierarchyBuilder.BuildHeader(gui);
-        }
-
-        protected override void BuildPageTooltip(ImGui gui, ProductionTable contents) {
-            foreach (var link in contents.links) {
-                if (link.amount != 0f) {
-                    using (gui.EnterRow()) {
-                        gui.BuildFactorioObjectIcon(link.goods);
-                        using (gui.EnterGroup(default, RectAllocator.LeftAlign, spacing: 0)) {
-                            gui.BuildText(link.goods.locName);
-                            gui.BuildText(DataUtils.FormatAmount(link.amount, link.goods.flowUnitOfMeasure));
-                        }
-                    }
-                }
+    private void BuildTableIngredients(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid) {
+        foreach (var flow in table.flow) {
+            if (flow.amount >= 0f) {
+                break;
             }
 
-            foreach (var row in contents.recipes) {
-                if (row.fixedBuildings != 0 && row.entity != null) {
-                    using (gui.EnterRow()) {
-                        gui.BuildFactorioObjectIcon(row.recipe);
-                        using (gui.EnterGroup(default, RectAllocator.LeftAlign, spacing: 0)) {
-                            gui.BuildText(row.recipe.locName);
-                            gui.BuildText(row.entity.locName + ": " + DataUtils.FormatAmount(row.fixedBuildings, UnitOfMeasure.None));
-                        }
-                    }
-                }
-
-                if (row.subgroup != null) {
-                    BuildPageTooltip(gui, row.subgroup);
-                }
-            }
+            grid.Next();
+            BuildGoodsIcon(gui, flow.goods, flow.link, -flow.amount, ProductDropdownType.Ingredient, null, context, HintLocations.OnProducingRecipes);
         }
+    }
 
-        private static readonly Dictionary<WarningFlags, string> WarningsMeaning = new Dictionary<WarningFlags, string>
-        {
-            {WarningFlags.DeadlockCandidate, "Contains recursive links that cannot be matched. No solution exists."},
-            {WarningFlags.OverproductionRequired, "This model cannot be solved exactly, it requires some overproduction. You can allow overproduction for any link. This recipe contains one of the possible candidates."},
-            {WarningFlags.EntityNotSpecified, "Crafter not specified. Solution is inaccurate." },
-            {WarningFlags.FuelNotSpecified, "Fuel not specified. Solution is inaccurate." },
-            {WarningFlags.FuelWithTemperatureNotLinked, "This recipe uses fuel with temperature. Should link with producing entity to determine temperature."},
-            {WarningFlags.FuelTemperatureExceedsMaximum, "Fluid temperature is higher than generator maximum. Some energy is wasted."},
-            {WarningFlags.FuelDoesNotProvideEnergy, "This fuel cannot provide any energy to this building. The building won't work."},
-            {WarningFlags.FuelUsageInputLimited, "This building has max fuel consumption. The rate at which it works is limited by it."},
-            {WarningFlags.TemperatureForIngredientNotMatch, "This recipe does care about ingredient temperature, and the temperature range does not match"},
-            {WarningFlags.ReactorsNeighborsFromPrefs, "Assumes reactor formation from preferences"},
-            {WarningFlags.AssumesNauvisSolarRatio, "Energy production values assumes Nauvis solar ration (70% power output). Don't forget accumulators."},
-            {WarningFlags.RecipeTickLimit, "Production is limited to 60 recipes per second (1/tick). This interacts weirdly with productivity bonus - actual productivity may be imprecise and may depend on your setup - test your setup before committing to it."},
-            {WarningFlags.ExceedsBuiltCount, "This recipe requires more buildings than are currently built."}
-        };
-
-        private static readonly (Icon icon, SchemeColor color)[] tagIcons = [
-            (Icon.Empty, SchemeColor.BackgroundTextFaint),
-            (Icon.Check, SchemeColor.Green),
-            (Icon.Warning, SchemeColor.Secondary),
-            (Icon.Error, SchemeColor.Error),
-            (Icon.Edit, SchemeColor.Primary),
-            (Icon.Help, SchemeColor.BackgroundText),
-            (Icon.Time, SchemeColor.BackgroundText),
-            (Icon.DarkMode, SchemeColor.BackgroundText),
-            (Icon.Settings, SchemeColor.BackgroundText),
-        ];
-
-
-
-        protected override void BuildContent(ImGui gui) {
-            if (model == null) {
-                return;
-            }
-
-            BuildSummary(gui, model);
-            gui.AllocateSpacing();
-            flatHierarchyBuilder.Build(gui);
-            gui.SetMinWidth(flatHierarchyBuilder.width);
-        }
-
-        private void AddDesiredProductAtLevel(ProductionTable table) => SelectMultiObjectPanel.Select(
-            Database.goods.all.Except(table.linkMap.Where(p => p.Value.amount != 0).Select(p => p.Key)), "Add desired product", product => {
-                if (table.linkMap.TryGetValue(product, out var existing)) {
-                    if (existing.amount != 0) {
-                        return;
-                    }
-
-                    existing.RecordUndo().amount = 1f;
+    private void DrawRecipeTagSelect(ImGui gui, RecipeRow recipe) {
+        using (gui.EnterRow()) {
+            for (int i = 0; i < tagIcons.Length; i++) {
+                var (icon, color) = tagIcons[i];
+                bool selected = i == recipe.tag;
+                gui.BuildIcon(icon, color: selected ? SchemeColor.Background : color);
+                if (selected) {
+                    gui.DrawRectangle(gui.lastRect, color);
                 }
                 else {
-                    table.RecordUndo().links.Add(new ProductionLink(table, product) { amount = 1f });
-                }
-            });
-
-        private void BuildSummary(ImGui gui, ProductionTable table) {
-            bool isRoot = table == model;
-            if (!isRoot && !table.containsDesiredProducts) {
-                return;
-            }
-
-            int elementsPerRow = MathUtils.Floor((flatHierarchyBuilder.width - 2f) / 4f);
-            gui.spacing = 1f;
-            Padding pad = new Padding(1f, 0.2f);
-            using (gui.EnterGroup(pad)) {
-                gui.BuildText("Desired products and amounts (Use negative for input goal):");
-                using var grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
-                foreach (var link in table.links.ToList()) {
-                    if (link.amount != 0f) {
-                        grid.Next();
-                        DrawDesiredProduct(gui, link);
+                    var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.BackgroundAlt, SchemeColor.BackgroundAlt);
+                    if (evt) {
+                        recipe.RecordUndo(true).tag = i;
                     }
                 }
+            }
+        }
+    }
 
-                grid.Next();
-                if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-                    AddDesiredProductAtLevel(table);
+    protected override void BuildHeader(ImGui gui) {
+        base.BuildHeader(gui);
+        flatHierarchyBuilder.BuildHeader(gui);
+    }
+
+    protected override void BuildPageTooltip(ImGui gui, ProductionTable contents) {
+        foreach (var link in contents.links) {
+            if (link.amount != 0f) {
+                using (gui.EnterRow()) {
+                    gui.BuildFactorioObjectIcon(link.goods);
+                    using (gui.EnterGroup(default, RectAllocator.LeftAlign, spacing: 0)) {
+                        gui.BuildText(link.goods.locName);
+                        gui.BuildText(DataUtils.FormatAmount(link.amount, link.goods.flowUnitOfMeasure));
+                    }
                 }
+            }
+        }
+
+        foreach (var row in contents.recipes) {
+            if (row.fixedBuildings != 0 && row.entity != null) {
+                using (gui.EnterRow()) {
+                    gui.BuildFactorioObjectIcon(row.recipe);
+                    using (gui.EnterGroup(default, RectAllocator.LeftAlign, spacing: 0)) {
+                        gui.BuildText(row.recipe.locName);
+                        gui.BuildText(row.entity.locName + ": " + DataUtils.FormatAmount(row.fixedBuildings, UnitOfMeasure.None));
+                    }
+                }
+            }
+
+            if (row.subgroup != null) {
+                BuildPageTooltip(gui, row.subgroup);
+            }
+        }
+    }
+
+    private static readonly Dictionary<WarningFlags, string> WarningsMeaning = new Dictionary<WarningFlags, string>
+    {
+        {WarningFlags.DeadlockCandidate, "Contains recursive links that cannot be matched. No solution exists."},
+        {WarningFlags.OverproductionRequired, "This model cannot be solved exactly, it requires some overproduction. You can allow overproduction for any link. This recipe contains one of the possible candidates."},
+        {WarningFlags.EntityNotSpecified, "Crafter not specified. Solution is inaccurate." },
+        {WarningFlags.FuelNotSpecified, "Fuel not specified. Solution is inaccurate." },
+        {WarningFlags.FuelWithTemperatureNotLinked, "This recipe uses fuel with temperature. Should link with producing entity to determine temperature."},
+        {WarningFlags.FuelTemperatureExceedsMaximum, "Fluid temperature is higher than generator maximum. Some energy is wasted."},
+        {WarningFlags.FuelDoesNotProvideEnergy, "This fuel cannot provide any energy to this building. The building won't work."},
+        {WarningFlags.FuelUsageInputLimited, "This building has max fuel consumption. The rate at which it works is limited by it."},
+        {WarningFlags.TemperatureForIngredientNotMatch, "This recipe does care about ingredient temperature, and the temperature range does not match"},
+        {WarningFlags.ReactorsNeighborsFromPrefs, "Assumes reactor formation from preferences"},
+        {WarningFlags.AssumesNauvisSolarRatio, "Energy production values assumes Nauvis solar ration (70% power output). Don't forget accumulators."},
+        {WarningFlags.RecipeTickLimit, "Production is limited to 60 recipes per second (1/tick). This interacts weirdly with productivity bonus - actual productivity may be imprecise and may depend on your setup - test your setup before committing to it."},
+        {WarningFlags.ExceedsBuiltCount, "This recipe requires more buildings than are currently built."}
+    };
+
+    private static readonly (Icon icon, SchemeColor color)[] tagIcons = [
+        (Icon.Empty, SchemeColor.BackgroundTextFaint),
+        (Icon.Check, SchemeColor.Green),
+        (Icon.Warning, SchemeColor.Secondary),
+        (Icon.Error, SchemeColor.Error),
+        (Icon.Edit, SchemeColor.Primary),
+        (Icon.Help, SchemeColor.BackgroundText),
+        (Icon.Time, SchemeColor.BackgroundText),
+        (Icon.DarkMode, SchemeColor.BackgroundText),
+        (Icon.Settings, SchemeColor.BackgroundText),
+    ];
+
+
+
+    protected override void BuildContent(ImGui gui) {
+        if (model == null) {
+            return;
+        }
+
+        BuildSummary(gui, model);
+        gui.AllocateSpacing();
+        flatHierarchyBuilder.Build(gui);
+        gui.SetMinWidth(flatHierarchyBuilder.width);
+    }
+
+    private void AddDesiredProductAtLevel(ProductionTable table) => SelectMultiObjectPanel.Select(
+        Database.goods.all.Except(table.linkMap.Where(p => p.Value.amount != 0).Select(p => p.Key)), "Add desired product", product => {
+            if (table.linkMap.TryGetValue(product, out var existing)) {
+                if (existing.amount != 0) {
+                    return;
+                }
+
+                existing.RecordUndo().amount = 1f;
+            }
+            else {
+                table.RecordUndo().links.Add(new ProductionLink(table, product) { amount = 1f });
+            }
+        });
+
+    private void BuildSummary(ImGui gui, ProductionTable table) {
+        bool isRoot = table == model;
+        if (!isRoot && !table.containsDesiredProducts) {
+            return;
+        }
+
+        int elementsPerRow = MathUtils.Floor((flatHierarchyBuilder.width - 2f) / 4f);
+        gui.spacing = 1f;
+        Padding pad = new Padding(1f, 0.2f);
+        using (gui.EnterGroup(pad)) {
+            gui.BuildText("Desired products and amounts (Use negative for input goal):");
+            using var grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
+            foreach (var link in table.links.ToList()) {
+                if (link.amount != 0f) {
+                    grid.Next();
+                    DrawDesiredProduct(gui, link);
+                }
+            }
+
+            grid.Next();
+            if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
+                AddDesiredProductAtLevel(table);
+            }
+        }
+        if (gui.isBuilding) {
+            gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
+        }
+
+        if (table.flow.Length > 0 && table.flow[0].amount < 0) {
+            using (gui.EnterGroup(pad)) {
+                gui.BuildText(isRoot ? "Summary ingredients:" : "Import ingredients:");
+                var grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
+                BuildTableIngredients(gui, table, table, ref grid);
+                grid.Dispose();
             }
             if (gui.isBuilding) {
                 gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
             }
+        }
 
-            if (table.flow.Length > 0 && table.flow[0].amount < 0) {
-                using (gui.EnterGroup(pad)) {
-                    gui.BuildText(isRoot ? "Summary ingredients:" : "Import ingredients:");
-                    var grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
-                    BuildTableIngredients(gui, table, table, ref grid);
-                    grid.Dispose();
-                }
-                if (gui.isBuilding) {
-                    gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
-                }
+        if (table.flow.Length > 0 && table.flow[^1].amount > 0) {
+            ImGui.Context? context = null;
+            ImGuiUtils.InlineGridBuilder grid = default;
+            void initializeGrid(ImGui gui) {
+                context = gui.EnterGroup(pad);
+                gui.BuildText(isRoot ? "Extra products:" : "Export products:");
+                grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
             }
 
-            if (table.flow.Length > 0 && table.flow[^1].amount > 0) {
-                ImGui.Context? context = null;
-                ImGuiUtils.InlineGridBuilder grid = default;
-                void initializeGrid(ImGui gui) {
-                    context = gui.EnterGroup(pad);
-                    gui.BuildText(isRoot ? "Extra products:" : "Export products:");
-                    grid = gui.EnterInlineGrid(3f, 1f, elementsPerRow);
-                }
+            BuildTableProducts(gui, table, table, ref grid, true, initializeGrid);
 
-                BuildTableProducts(gui, table, table, ref grid, true, initializeGrid);
+            if (context != null) {
+                grid.Dispose();
+                context.Value.Dispose();
 
-                if (context != null) {
-                    grid.Dispose();
-                    context.Value.Dispose();
-
-                    if (gui.isBuilding) {
-                        gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
-                    }
+                if (gui.isBuilding) {
+                    gui.DrawRectangle(gui.lastRect, SchemeColor.Background, RectangleBorder.Thin);
                 }
             }
         }

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -4,117 +4,116 @@ using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public abstract class ProjectPageView : Scrollable {
-        protected ProjectPageView() : base(true, true, false) {
-            headerContent = new ImGui(BuildHeader, default, RectAllocator.LeftAlign);
-            bodyContent = new ImGui(BuildContent, default, RectAllocator.LeftAlign, true);
-        }
+namespace Yafc;
+public abstract class ProjectPageView : Scrollable {
+    protected ProjectPageView() : base(true, true, false) {
+        headerContent = new ImGui(BuildHeader, default, RectAllocator.LeftAlign);
+        bodyContent = new ImGui(BuildContent, default, RectAllocator.LeftAlign, true);
+    }
 
-        public readonly ImGui headerContent;
-        public readonly ImGui bodyContent;
-        private float contentWidth, headerHeight, contentHeight;
-        private SearchQuery searchQuery;
-        protected abstract void BuildHeader(ImGui gui);
-        protected abstract void BuildContent(ImGui gui);
+    public readonly ImGui headerContent;
+    public readonly ImGui bodyContent;
+    private float contentWidth, headerHeight, contentHeight;
+    private SearchQuery searchQuery;
+    protected abstract void BuildHeader(ImGui gui);
+    protected abstract void BuildContent(ImGui gui);
 
-        public virtual void Rebuild(bool visualOnly = false) {
-            headerContent.Rebuild();
-            bodyContent.Rebuild();
-        }
+    public virtual void Rebuild(bool visualOnly = false) {
+        headerContent.Rebuild();
+        bodyContent.Rebuild();
+    }
 
-        protected virtual void ModelContentsChanged(bool visualOnly) => Rebuild(visualOnly);
+    protected virtual void ModelContentsChanged(bool visualOnly) => Rebuild(visualOnly);
 
-        public abstract void BuildPageTooltip(ImGui gui, ProjectPageContents contents);
+    public abstract void BuildPageTooltip(ImGui gui, ProjectPageContents contents);
 
-        public abstract void SetModel(ProjectPage? page);
+    public abstract void SetModel(ProjectPage? page);
 
-        public virtual float CalculateWidth() => headerContent.width;
+    public virtual float CalculateWidth() => headerContent.width;
 
-        public virtual void SetSearchQuery(SearchQuery query) {
-            searchQuery = query;
-            Rebuild();
-        }
+    public virtual void SetSearchQuery(SearchQuery query) {
+        searchQuery = query;
+        Rebuild();
+    }
 
-        public ProjectPageView CreateSecondaryView() => (ProjectPageView)Activator.CreateInstance(GetType())!;
+    public ProjectPageView CreateSecondaryView() => (ProjectPageView)Activator.CreateInstance(GetType())!;
 
-        public void Build(ImGui gui, Vector2 visibleSize) {
-            if (gui.isBuilding) {
-                gui.spacing = 0f;
-                var position = gui.AllocateRect(0f, 0f, 0f).Position;
-                var headerSize = headerContent.CalculateState(visibleSize.X - ScrollbarSize, gui.pixelsPerUnit);
-                contentWidth = headerSize.X;
-                headerHeight = headerSize.Y;
-                var headerRect = gui.AllocateRect(visibleSize.X, headerHeight);
-                position.Y += headerHeight;
-                var contentSize = bodyContent.CalculateState(visibleSize.X - ScrollbarSize, gui.pixelsPerUnit);
-                if (contentSize.X > contentWidth) {
-                    contentWidth = contentSize.X;
-                }
-
-                contentHeight = contentSize.Y;
-                gui.DrawPanel(headerRect, headerContent);
-            }
-            else {
-                _ = gui.AllocateRect(contentWidth, headerHeight);
+    public void Build(ImGui gui, Vector2 visibleSize) {
+        if (gui.isBuilding) {
+            gui.spacing = 0f;
+            var position = gui.AllocateRect(0f, 0f, 0f).Position;
+            var headerSize = headerContent.CalculateState(visibleSize.X - ScrollbarSize, gui.pixelsPerUnit);
+            contentWidth = headerSize.X;
+            headerHeight = headerSize.Y;
+            var headerRect = gui.AllocateRect(visibleSize.X, headerHeight);
+            position.Y += headerHeight;
+            var contentSize = bodyContent.CalculateState(visibleSize.X - ScrollbarSize, gui.pixelsPerUnit);
+            if (contentSize.X > contentWidth) {
+                contentWidth = contentSize.X;
             }
 
-            // use bottom padding to enable scrolling past the last row
-            base.Build(gui, visibleSize.Y - headerHeight, true);
+            contentHeight = contentSize.Y;
+            gui.DrawPanel(headerRect, headerContent);
+        }
+        else {
+            _ = gui.AllocateRect(contentWidth, headerHeight);
         }
 
-        protected override Vector2 MeasureContent(float _, ImGui gui) => new Vector2(contentWidth, contentHeight);
+        // use bottom padding to enable scrolling past the last row
+        base.Build(gui, visibleSize.Y - headerHeight, true);
+    }
 
-        protected override void PositionContent(ImGui gui, Rect viewport) {
-            headerContent.offset = new Vector2(-scrollX, 0);
-            bodyContent.offset = -scroll;
-            gui.DrawPanel(viewport, bodyContent);
-        }
+    protected override Vector2 MeasureContent(float _, ImGui gui) => new Vector2(contentWidth, contentHeight);
 
-        public virtual bool ControlKey(SDL.SDL_Scancode code) => false;
+    protected override void PositionContent(ImGui gui, Rect viewport) {
+        headerContent.offset = new Vector2(-scrollX, 0);
+        bodyContent.offset = -scroll;
+        gui.DrawPanel(viewport, bodyContent);
+    }
 
-        public MemoryDrawingSurface GenerateFullPageScreenshot() {
-            var headerSize = headerContent.contentSize;
-            var bodySize = bodyContent.contentSize;
-            Vector2 fullSize = new Vector2(CalculateWidth(), headerSize.Y + bodySize.Y);
-            MemoryDrawingSurface surface = new MemoryDrawingSurface(fullSize, 22);
-            surface.Clear(SchemeColor.Background.ToSdlColor());
-            headerContent.Present(surface, new Rect(default, headerSize), new Rect(default, headerSize), null);
-            Rect bodyRect = new Rect(0f, headerSize.Y, bodySize.X, bodySize.Y);
-            var prevOffset = bodyContent.offset;
-            bodyContent.offset = Vector2.Zero;
-            bodyContent.Present(surface, bodyRect, bodyRect, null);
-            bodyContent.offset = prevOffset;
-            return surface;
+    public virtual bool ControlKey(SDL.SDL_Scancode code) => false;
+
+    public MemoryDrawingSurface GenerateFullPageScreenshot() {
+        var headerSize = headerContent.contentSize;
+        var bodySize = bodyContent.contentSize;
+        Vector2 fullSize = new Vector2(CalculateWidth(), headerSize.Y + bodySize.Y);
+        MemoryDrawingSurface surface = new MemoryDrawingSurface(fullSize, 22);
+        surface.Clear(SchemeColor.Background.ToSdlColor());
+        headerContent.Present(surface, new Rect(default, headerSize), new Rect(default, headerSize), null);
+        Rect bodyRect = new Rect(0f, headerSize.Y, bodySize.X, bodySize.Y);
+        var prevOffset = bodyContent.offset;
+        bodyContent.offset = Vector2.Zero;
+        bodyContent.Present(surface, bodyRect, bodyRect, null);
+        bodyContent.offset = prevOffset;
+        return surface;
+    }
+}
+
+public abstract class ProjectPageView<T> : ProjectPageView where T : ProjectPageContents {
+    protected T model { get; private set; } = null!; // TODO, null-forgiving: This can clearly be null, but lots of things assume it can't.
+    protected ProjectPage? projectPage;
+
+    protected override void BuildHeader(ImGui gui) {
+        if (projectPage?.modelError != null && gui.BuildErrorRow(projectPage.modelError)) {
+            projectPage.modelError = null;
         }
     }
 
-    public abstract class ProjectPageView<T> : ProjectPageView where T : ProjectPageContents {
-        protected T model { get; private set; } = null!; // TODO, null-forgiving: This can clearly be null, but lots of things assume it can't.
-        protected ProjectPage? projectPage;
-
-        protected override void BuildHeader(ImGui gui) {
-            if (projectPage?.modelError != null && gui.BuildErrorRow(projectPage.modelError)) {
-                projectPage.modelError = null;
-            }
+    public override void SetModel(ProjectPage? page) {
+        if (projectPage != null) {
+            projectPage.contentChanged -= ModelContentsChanged;
         }
 
-        public override void SetModel(ProjectPage? page) {
-            if (projectPage != null) {
-                projectPage.contentChanged -= ModelContentsChanged;
-            }
-
-            InputSystem.Instance.SetKeyboardFocus(this);
-            projectPage = page;
-            model = (T)page?.content!; // TODO, null-forgiving: This can clearly be null, but lots of things assume it can't.
-            if (model != null && projectPage != null) {
-                projectPage.contentChanged += ModelContentsChanged;
-                ModelContentsChanged(false);
-            }
+        InputSystem.Instance.SetKeyboardFocus(this);
+        projectPage = page;
+        model = (T)page?.content!; // TODO, null-forgiving: This can clearly be null, but lots of things assume it can't.
+        if (model != null && projectPage != null) {
+            projectPage.contentChanged += ModelContentsChanged;
+            ModelContentsChanged(false);
         }
-
-        public override void BuildPageTooltip(ImGui gui, ProjectPageContents contents) => BuildPageTooltip(gui, (T)contents);
-
-        protected abstract void BuildPageTooltip(ImGui gui, T contents);
     }
+
+    public override void BuildPageTooltip(ImGui gui, ProjectPageContents contents) => BuildPageTooltip(gui, (T)contents);
+
+    protected abstract void BuildPageTooltip(ImGui gui, T contents);
 }

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -7,397 +7,396 @@ using System.Threading.Tasks;
 using Yafc.Model;
 using Yafc.UI;
 
-namespace Yafc {
-    public class SummaryView : ProjectPageView<Summary> {
-        /// <summary>Some padding to have the contents of the first column not 'stick' to the rest of the UI</summary>
-        private readonly Padding FirstColumnPadding = new Padding(1f, 1.5f, 0, 0);
-        private static float firstColumnWidth;
+namespace Yafc;
+public class SummaryView : ProjectPageView<Summary> {
+    /// <summary>Some padding to have the contents of the first column not 'stick' to the rest of the UI</summary>
+    private readonly Padding FirstColumnPadding = new Padding(1f, 1.5f, 0, 0);
+    private static float firstColumnWidth;
 
-        private class SummaryScrollArea(GuiBuilder builder) : ScrollArea(DefaultHeight, builder, horizontal: true) {
-            private static readonly float DefaultHeight = 10;
+    private class SummaryScrollArea(GuiBuilder builder) : ScrollArea(DefaultHeight, builder, horizontal: true) {
+        private static readonly float DefaultHeight = 10;
 
-            public new void Build(ImGui gui) =>
-                // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (3) padding probably)
-                Build(gui, gui.valid && gui.parent is not null ? gui.parent.contentSize.Y - Font.header.size - Font.text.size - 3 : DefaultHeight);
+        public new void Build(ImGui gui) =>
+            // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (3) padding probably)
+            Build(gui, gui.valid && gui.parent is not null ? gui.parent.contentSize.Y - Font.header.size - Font.text.size - 3 : DefaultHeight);
+    }
+
+    private class SummaryTabColumn : TextDataColumn<ProjectPage> {
+        public SummaryTabColumn() : base("Tab", firstColumnWidth) {
         }
 
-        private class SummaryTabColumn : TextDataColumn<ProjectPage> {
-            public SummaryTabColumn() : base("Tab", firstColumnWidth) {
+        public override void BuildElement(ImGui gui, ProjectPage page) {
+            width = firstColumnWidth;
+
+            if (page?.contentType != typeof(ProductionTable)) {
+                return;
             }
 
-            public override void BuildElement(ImGui gui, ProjectPage page) {
-                width = firstColumnWidth;
-
-                if (page?.contentType != typeof(ProductionTable)) {
-                    return;
-                }
-
-                using (gui.EnterGroup(new Padding(0.5f, 0.2f, 0.2f, 0.5f))) {
-                    gui.spacing = 0.2f;
-                    if (page.icon != null) {
-                        gui.BuildIcon(page.icon.icon, FirstColumnIconSize);
-                    }
-                    else {
-                        _ = gui.AllocateRect(0f, FirstColumnIconSize);
-                    }
-
-                    gui.BuildText(page.name);
-                }
-            }
-        }
-
-        private sealed class SummaryDataColumn : TextDataColumn<ProjectPage> {
-            private readonly SummaryView view;
-
-            public SummaryDataColumn(SummaryView view) : base("Linked", float.MaxValue) => this.view = view;
-
-            public override void BuildElement(ImGui gui, ProjectPage page) {
-                if (page?.contentType != typeof(ProductionTable)) {
-                    return;
-                }
-
-                ProductionTable table = (ProductionTable)page.content;
-                using var grid = gui.EnterInlineGrid(ElementWidth, ElementSpacing);
-                foreach ((string name, GoodDetails details, bool enoughProduced) in view.GoodsToDisplay()) {
-                    ProductionLink? link = table.links.Find(x => x.goods.name == name);
-                    grid.Next();
-                    if (link != null) {
-                        if (link.amount != 0f) {
-                            DrawProvideProduct(gui, link, page, details, enoughProduced);
-                        }
-                    }
-                    else {
-                        if (Array.Exists(table.flow, x => x.goods.name == name)) {
-                            ProductionTableFlow flow = Array.Find(table.flow, x => x.goods.name == name);
-                            if (Math.Abs(flow.amount) > Epsilon) {
-
-                                DrawRequestProduct(gui, flow, enoughProduced);
-                            }
-                        }
-                    }
-                }
-            }
-
-            private static void DrawProvideProduct(ImGui gui, ProductionLink element, ProjectPage page, GoodDetails goodInfo, bool enoughProduced) {
-                SchemeColor iconColor;
-                if (element.amount > 0 && enoughProduced) {
-                    // Production matches consumption
-                    iconColor = SchemeColor.Primary;
-                }
-                else if (element.amount < 0 && goodInfo.extraProduced == -element.amount) {
-                    // Extra produced matches input goal
-                    iconColor = SchemeColor.Primary;
+            using (gui.EnterGroup(new Padding(0.5f, 0.2f, 0.2f, 0.5f))) {
+                gui.spacing = 0.2f;
+                if (page.icon != null) {
+                    gui.BuildIcon(page.icon.icon, FirstColumnIconSize);
                 }
                 else {
-                    // Production and consumption does not match
+                    _ = gui.AllocateRect(0f, FirstColumnIconSize);
+                }
+
+                gui.BuildText(page.name);
+            }
+        }
+    }
+
+    private sealed class SummaryDataColumn : TextDataColumn<ProjectPage> {
+        private readonly SummaryView view;
+
+        public SummaryDataColumn(SummaryView view) : base("Linked", float.MaxValue) => this.view = view;
+
+        public override void BuildElement(ImGui gui, ProjectPage page) {
+            if (page?.contentType != typeof(ProductionTable)) {
+                return;
+            }
+
+            ProductionTable table = (ProductionTable)page.content;
+            using var grid = gui.EnterInlineGrid(ElementWidth, ElementSpacing);
+            foreach ((string name, GoodDetails details, bool enoughProduced) in view.GoodsToDisplay()) {
+                ProductionLink? link = table.links.Find(x => x.goods.name == name);
+                grid.Next();
+                if (link != null) {
+                    if (link.amount != 0f) {
+                        DrawProvideProduct(gui, link, page, details, enoughProduced);
+                    }
+                }
+                else {
+                    if (Array.Exists(table.flow, x => x.goods.name == name)) {
+                        ProductionTableFlow flow = Array.Find(table.flow, x => x.goods.name == name);
+                        if (Math.Abs(flow.amount) > Epsilon) {
+
+                            DrawRequestProduct(gui, flow, enoughProduced);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void DrawProvideProduct(ImGui gui, ProductionLink element, ProjectPage page, GoodDetails goodInfo, bool enoughProduced) {
+            SchemeColor iconColor;
+            if (element.amount > 0 && enoughProduced) {
+                // Production matches consumption
+                iconColor = SchemeColor.Primary;
+            }
+            else if (element.amount < 0 && goodInfo.extraProduced == -element.amount) {
+                // Extra produced matches input goal
+                iconColor = SchemeColor.Primary;
+            }
+            else {
+                // Production and consumption does not match
+                iconColor = SchemeColor.Error;
+            }
+
+            gui.allocator = RectAllocator.Stretch;
+            gui.spacing = 0f;
+            DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
+            GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, ButtonDisplayStyle.ProductionTableScaled(iconColor));
+            if (evt == GoodsWithAmountEvent.TextEditing && amount.Value != 0) {
+                SetProviderAmount(element, page, amount.Value);
+            }
+            else if (evt == GoodsWithAmountEvent.LeftButtonClick) {
+                SetProviderAmount(element, page, YafcRounding(goodInfo.sum));
+            }
+        }
+        private static void DrawRequestProduct(ImGui gui, ProductionTableFlow flow, bool enoughExtraProduced) {
+            SchemeColor iconColor;
+            if (flow.amount > Epsilon) {
+                if (!enoughExtraProduced) {
+                    // Not enough in extra production, while being depended on
                     iconColor = SchemeColor.Error;
                 }
-
-                gui.allocator = RectAllocator.Stretch;
-                gui.spacing = 0f;
-                DisplayAmount amount = new(element.amount, element.goods.flowUnitOfMeasure);
-                GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, amount, ButtonDisplayStyle.ProductionTableScaled(iconColor));
-                if (evt == GoodsWithAmountEvent.TextEditing && amount.Value != 0) {
-                    SetProviderAmount(element, page, amount.Value);
-                }
-                else if (evt == GoodsWithAmountEvent.LeftButtonClick) {
-                    SetProviderAmount(element, page, YafcRounding(goodInfo.sum));
-                }
-            }
-            private static void DrawRequestProduct(ImGui gui, ProductionTableFlow flow, bool enoughExtraProduced) {
-                SchemeColor iconColor;
-                if (flow.amount > Epsilon) {
-                    if (!enoughExtraProduced) {
-                        // Not enough in extra production, while being depended on
-                        iconColor = SchemeColor.Error;
-                    }
-                    else {
-                        // Enough extra product produced
-                        iconColor = SchemeColor.Green;
-                    }
-                }
                 else {
-                    // Flow amount negative or (almost, due to rounding errors) zero, just a regular request (nothing to indicate)
-                    iconColor = SchemeColor.None;
-                }
-
-                gui.allocator = RectAllocator.Stretch;
-                gui.spacing = 0f;
-                _ = gui.BuildFactorioObjectWithAmount(flow.goods, new(-flow.amount, flow.goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(iconColor));
-            }
-
-            internal static Task SetProviderAmount(ProductionLink element, ProjectPage page, float newAmount) {
-                element.RecordUndo().amount = newAmount;
-                return page.RunSolveJob();
-            }
-        }
-
-        private static readonly float Epsilon = 1e-5f;
-        private static readonly float ElementWidth = 3;
-        private static readonly float ElementSpacing = 1;
-        private static readonly float FirstColumnIconSize = 1.5f;
-
-        private struct GoodDetails {
-            public float totalProvided;
-            public float totalNeeded;
-            public float extraProduced;
-            public float sum;
-        }
-
-        private Project project;
-        private SearchQuery searchQuery;
-
-        private readonly SummaryScrollArea scrollArea;
-        private readonly SummaryDataColumn goodsColumn;
-        private readonly DataGrid<ProjectPage> mainGrid;
-
-        private Dictionary<string, GoodDetails> allGoods = [];
-
-        private IEnumerable<(string name, GoodDetails details, bool enoughProduced)> GoodsToDisplay() {
-            foreach (KeyValuePair<string, GoodDetails> goodInfo in allGoods) {
-                if (!searchQuery.Match(goodInfo.Key)) {
-                    continue;
-                }
-
-                float amountAvailable = YafcRounding((goodInfo.Value.totalProvided > 0 ? goodInfo.Value.totalProvided : 0) + goodInfo.Value.extraProduced);
-                float amountNeeded = YafcRounding((goodInfo.Value.totalProvided < 0 ? -goodInfo.Value.totalProvided : 0) + goodInfo.Value.totalNeeded);
-                if (model == null || (model.showOnlyIssues && (Math.Abs(amountAvailable - amountNeeded) < Epsilon || amountNeeded == 0))) {
-                    continue;
-                }
-
-                bool enoughProduced = amountAvailable >= amountNeeded;
-                yield return (goodInfo.Key, goodInfo.Value, enoughProduced);
-            }
-        }
-
-        private IEnumerable<(string name, GoodDetails details, float excess)> GoodsToBalance() {
-            foreach (KeyValuePair<string, GoodDetails> goodInfo in allGoods) {
-                float amountAvailable = YafcRounding((goodInfo.Value.totalProvided > 0 ? goodInfo.Value.totalProvided : 0) + goodInfo.Value.extraProduced);
-                float amountNeeded = YafcRounding((goodInfo.Value.totalProvided < 0 ? -goodInfo.Value.totalProvided : 0) + goodInfo.Value.totalNeeded);
-                if (Math.Abs(amountAvailable - amountNeeded) < Epsilon || amountNeeded == 0) {
-                    continue;
-                }
-
-                yield return (goodInfo.Key, goodInfo.Value, amountAvailable - amountNeeded);
-            }
-        }
-
-        public SummaryView(Project project) {
-            goodsColumn = new SummaryDataColumn(this);
-            TextDataColumn<ProjectPage>[] columns = new TextDataColumn<ProjectPage>[]
-            {
-                new SummaryTabColumn(),
-                goodsColumn,
-            };
-            scrollArea = new SummaryScrollArea(BuildScrollArea);
-            mainGrid = new DataGrid<ProjectPage>(columns);
-
-            SetProject(project);
-        }
-
-        [MemberNotNull(nameof(project))]
-        public void SetProject(Project project) {
-            if (this.project != null) {
-                this.project.metaInfoChanged -= Recalculate;
-                foreach (ProjectPage page in this.project.pages) {
-                    page.contentChanged -= Recalculate;
+                    // Enough extra product produced
+                    iconColor = SchemeColor.Green;
                 }
             }
+            else {
+                // Flow amount negative or (almost, due to rounding errors) zero, just a regular request (nothing to indicate)
+                iconColor = SchemeColor.None;
+            }
 
-            this.project = project;
+            gui.allocator = RectAllocator.Stretch;
+            gui.spacing = 0f;
+            _ = gui.BuildFactorioObjectWithAmount(flow.goods, new(-flow.amount, flow.goods.flowUnitOfMeasure), ButtonDisplayStyle.ProductionTableScaled(iconColor));
+        }
 
-            project.metaInfoChanged += Recalculate;
-            foreach (ProjectPage page in project.pages) {
-                page.contentChanged += Recalculate;
+        internal static Task SetProviderAmount(ProductionLink element, ProjectPage page, float newAmount) {
+            element.RecordUndo().amount = newAmount;
+            return page.RunSolveJob();
+        }
+    }
+
+    private static readonly float Epsilon = 1e-5f;
+    private static readonly float ElementWidth = 3;
+    private static readonly float ElementSpacing = 1;
+    private static readonly float FirstColumnIconSize = 1.5f;
+
+    private struct GoodDetails {
+        public float totalProvided;
+        public float totalNeeded;
+        public float extraProduced;
+        public float sum;
+    }
+
+    private Project project;
+    private SearchQuery searchQuery;
+
+    private readonly SummaryScrollArea scrollArea;
+    private readonly SummaryDataColumn goodsColumn;
+    private readonly DataGrid<ProjectPage> mainGrid;
+
+    private Dictionary<string, GoodDetails> allGoods = [];
+
+    private IEnumerable<(string name, GoodDetails details, bool enoughProduced)> GoodsToDisplay() {
+        foreach (KeyValuePair<string, GoodDetails> goodInfo in allGoods) {
+            if (!searchQuery.Match(goodInfo.Key)) {
+                continue;
+            }
+
+            float amountAvailable = YafcRounding((goodInfo.Value.totalProvided > 0 ? goodInfo.Value.totalProvided : 0) + goodInfo.Value.extraProduced);
+            float amountNeeded = YafcRounding((goodInfo.Value.totalProvided < 0 ? -goodInfo.Value.totalProvided : 0) + goodInfo.Value.totalNeeded);
+            if (model == null || (model.showOnlyIssues && (Math.Abs(amountAvailable - amountNeeded) < Epsilon || amountNeeded == 0))) {
+                continue;
+            }
+
+            bool enoughProduced = amountAvailable >= amountNeeded;
+            yield return (goodInfo.Key, goodInfo.Value, enoughProduced);
+        }
+    }
+
+    private IEnumerable<(string name, GoodDetails details, float excess)> GoodsToBalance() {
+        foreach (KeyValuePair<string, GoodDetails> goodInfo in allGoods) {
+            float amountAvailable = YafcRounding((goodInfo.Value.totalProvided > 0 ? goodInfo.Value.totalProvided : 0) + goodInfo.Value.extraProduced);
+            float amountNeeded = YafcRounding((goodInfo.Value.totalProvided < 0 ? -goodInfo.Value.totalProvided : 0) + goodInfo.Value.totalNeeded);
+            if (Math.Abs(amountAvailable - amountNeeded) < Epsilon || amountNeeded == 0) {
+                continue;
+            }
+
+            yield return (goodInfo.Key, goodInfo.Value, amountAvailable - amountNeeded);
+        }
+    }
+
+    public SummaryView(Project project) {
+        goodsColumn = new SummaryDataColumn(this);
+        TextDataColumn<ProjectPage>[] columns = new TextDataColumn<ProjectPage>[]
+        {
+            new SummaryTabColumn(),
+            goodsColumn,
+        };
+        scrollArea = new SummaryScrollArea(BuildScrollArea);
+        mainGrid = new DataGrid<ProjectPage>(columns);
+
+        SetProject(project);
+    }
+
+    [MemberNotNull(nameof(project))]
+    public void SetProject(Project project) {
+        if (this.project != null) {
+            this.project.metaInfoChanged -= Recalculate;
+            foreach (ProjectPage page in this.project.pages) {
+                page.contentChanged -= Recalculate;
             }
         }
 
-        protected override void BuildPageTooltip(ImGui gui, Summary contents) {
+        this.project = project;
+
+        project.metaInfoChanged += Recalculate;
+        foreach (ProjectPage page in project.pages) {
+            page.contentChanged += Recalculate;
         }
+    }
 
-        protected override void BuildHeader(ImGui gui) {
-            base.BuildHeader(gui);
+    protected override void BuildPageTooltip(ImGui gui, Summary contents) {
+    }
 
-            gui.allocator = RectAllocator.Center;
-            gui.BuildText("Production Sheet Summary", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
-            gui.allocator = RectAllocator.LeftAlign;
-        }
+    protected override void BuildHeader(ImGui gui) {
+        base.BuildHeader(gui);
 
-        private float CalculateFirstColumWidth(ImGui gui) {
-            // At the least the icons should fit
-            float width = FirstColumnIconSize;
+        gui.allocator = RectAllocator.Center;
+        gui.BuildText("Production Sheet Summary", new TextBlockDisplayStyle(Font.header, Alignment: RectAlignment.Middle));
+        gui.allocator = RectAllocator.LeftAlign;
+    }
 
-            foreach (Guid displayPage in project.displayPages) {
-                ProjectPage? page = project.FindPage(displayPage);
-                if (page?.contentType != typeof(ProductionTable)) {
-                    continue;
-                }
+    private float CalculateFirstColumWidth(ImGui gui) {
+        // At the least the icons should fit
+        float width = FirstColumnIconSize;
 
-                Vector2 textSize = gui.GetTextDimensions(out _, page.name);
-                width = MathF.Max(width, textSize.X);
+        foreach (Guid displayPage in project.displayPages) {
+            ProjectPage? page = project.FindPage(displayPage);
+            if (page?.contentType != typeof(ProductionTable)) {
+                continue;
             }
 
-            // Include padding to perfectly match
-            return width + FirstColumnPadding.left + FirstColumnPadding.right;
+            Vector2 textSize = gui.GetTextDimensions(out _, page.name);
+            width = MathF.Max(width, textSize.X);
         }
 
-        protected override async void BuildContent(ImGui gui) {
-            using (gui.EnterRow()) {
-                gui.AllocateRect(0, 2); // Increase row height to 2, for vertical centering.
-                if (gui.BuildCheckBox("Only show issues", model?.showOnlyIssues ?? false, out bool newValue)) {
-                    model!.showOnlyIssues = newValue; // null-forgiving: when model is null, the page is no longer being displayed, so no clicks can happen.
-                    Recalculate();
+        // Include padding to perfectly match
+        return width + FirstColumnPadding.left + FirstColumnPadding.right;
+    }
+
+    protected override async void BuildContent(ImGui gui) {
+        using (gui.EnterRow()) {
+            gui.AllocateRect(0, 2); // Increase row height to 2, for vertical centering.
+            if (gui.BuildCheckBox("Only show issues", model?.showOnlyIssues ?? false, out bool newValue)) {
+                model!.showOnlyIssues = newValue; // null-forgiving: when model is null, the page is no longer being displayed, so no clicks can happen.
+                Recalculate();
+            }
+
+            using (gui.EnterRowWithHelpIcon("Attempt to match production and consumption of all linked products on the displayed pages.\n\nYou will often have to click this button multiple times to fully balance production.", false)) {
+                if (gui.BuildButton("Auto balance")) {
+                    await AutoBalance();
+                }
+            }
+        }
+        gui.AllocateSpacing();
+
+        if (gui.isBuilding) {
+            firstColumnWidth = CalculateFirstColumWidth(gui);
+        }
+
+        scrollArea.Build(gui);
+    }
+
+    private async Task AutoBalance() {
+        try {
+            // The things we've already updated, and the error each had before their previous update.
+            Queue<ProductionLink> updateOrder = [];
+            Dictionary<ProductionLink, float> previousUpdates = [];
+            int negativeFeedbackCount = 0;
+            for (int i = 0; i < 1000; i++) { // No matter what else happens, give up after 1000 clicks.
+                float? oldExcess = null;
+                GoodDetails details;
+                float excess;
+                ProductionLink? link;
+                while (true) {
+                    // Look for a product that (a) has a mismatch, (b) has exactly one link in the displayed pages, and (c) hasn't been updated yet.
+                    (details, excess, link) = GoodsToBalance()
+                        // Find the link
+                        .Select(x => (x.details, x.excess, link: DisplayTables.Select(t => t.links.FirstOrDefault(l => l.goods.name == x.name && l.amount != 0)).WhereNotNull().SingleOrDefault(false)))
+                        // Find an item with exactly one link that hasn't been updated yet. (Or has been removed to allow it to be updated again.)
+                        .FirstOrDefault(x => x.link != null && !previousUpdates.ContainsKey(x.link));
+                    if (link != null) { break; }
+                    if (updateOrder.Count == 0) {
+                        return;
+                    }
+                    // If nothing was found, allow the least-recently updated product to be updated again, but remember its previous state so we can tell if we're making progress.
+                    ProductionLink removedLink = updateOrder.Dequeue();
+                    oldExcess = previousUpdates[removedLink];
+                    previousUpdates.Remove(removedLink);
                 }
 
-                using (gui.EnterRowWithHelpIcon("Attempt to match production and consumption of all linked products on the displayed pages.\n\nYou will often have to click this button multiple times to fully balance production.", false)) {
-                    if (gui.BuildButton("Auto balance")) {
-                        await AutoBalance();
+                if (oldExcess - Math.Abs(excess) <= Epsilon) {
+                    // TODO: The negative feedback detection sometimes gets triggered, but sometimes the `updateOrder.Count == 0` check gets triggered instead.
+                    // This probably needs to be revisited when fixing https://github.com/shpaass/yafc-ce/issues/169
+                    // The previous positive difference for this product is less than the current (supposedly better) positive difference.
+                    if (++negativeFeedbackCount > 3) {
+                        return; // Too many negative feedbacks detected; give up.
+                    }
+                    else { // Skip this for now, in hopes of getting a better result later.
+                        updateOrder.Enqueue(link);
+                        previousUpdates[link] = Math.Abs(excess);
+                        continue;
                     }
                 }
-            }
-            gui.AllocateSpacing();
 
-            if (gui.isBuilding) {
-                firstColumnWidth = CalculateFirstColumWidth(gui);
-            }
+                updateOrder.Enqueue(link);
+                previousUpdates[link] = Math.Abs(excess);
 
-            scrollArea.Build(gui);
+                await SummaryDataColumn.SetProviderAmount(link, (ProjectPage)link.owner.owner, details.sum);
+            }
+            _ = model.showOnlyIssues;
         }
-
-        private async Task AutoBalance() {
-            try {
-                // The things we've already updated, and the error each had before their previous update.
-                Queue<ProductionLink> updateOrder = [];
-                Dictionary<ProductionLink, float> previousUpdates = [];
-                int negativeFeedbackCount = 0;
-                for (int i = 0; i < 1000; i++) { // No matter what else happens, give up after 1000 clicks.
-                    float? oldExcess = null;
-                    GoodDetails details;
-                    float excess;
-                    ProductionLink? link;
-                    while (true) {
-                        // Look for a product that (a) has a mismatch, (b) has exactly one link in the displayed pages, and (c) hasn't been updated yet.
-                        (details, excess, link) = GoodsToBalance()
-                            // Find the link
-                            .Select(x => (x.details, x.excess, link: DisplayTables.Select(t => t.links.FirstOrDefault(l => l.goods.name == x.name && l.amount != 0)).WhereNotNull().SingleOrDefault(false)))
-                            // Find an item with exactly one link that hasn't been updated yet. (Or has been removed to allow it to be updated again.)
-                            .FirstOrDefault(x => x.link != null && !previousUpdates.ContainsKey(x.link));
-                        if (link != null) { break; }
-                        if (updateOrder.Count == 0) {
-                            return;
-                        }
-                        // If nothing was found, allow the least-recently updated product to be updated again, but remember its previous state so we can tell if we're making progress.
-                        ProductionLink removedLink = updateOrder.Dequeue();
-                        oldExcess = previousUpdates[removedLink];
-                        previousUpdates.Remove(removedLink);
-                    }
-
-                    if (oldExcess - Math.Abs(excess) <= Epsilon) {
-                        // TODO: The negative feedback detection sometimes gets triggered, but sometimes the `updateOrder.Count == 0` check gets triggered instead.
-                        // This probably needs to be revisited when fixing https://github.com/shpaass/yafc-ce/issues/169
-                        // The previous positive difference for this product is less than the current (supposedly better) positive difference.
-                        if (++negativeFeedbackCount > 3) {
-                            return; // Too many negative feedbacks detected; give up.
-                        }
-                        else { // Skip this for now, in hopes of getting a better result later.
-                            updateOrder.Enqueue(link);
-                            previousUpdates[link] = Math.Abs(excess);
-                            continue;
-                        }
-                    }
-
-                    updateOrder.Enqueue(link);
-                    previousUpdates[link] = Math.Abs(excess);
-
-                    await SummaryDataColumn.SetProviderAmount(link, (ProjectPage)link.owner.owner, details.sum);
-                }
-                _ = model.showOnlyIssues;
-            }
-            finally {
-                // HACK: Nothing left to change, but force a recalculate anyway, so the user doesn't have to view all the tabs before clicking Auto balance again.
-                // Sometimes this will cause updates that require an additional button click.
-                // This is probably related to https://github.com/shpaass/yafc-ce/issues/169
-                foreach (ProjectPage page in DisplayPages) {
-                    await page.RunSolveJob();
-                }
-            }
-        }
-
-        private IEnumerable<ProductionTable> DisplayTables => project.displayPages.Select(p => project.FindPage(p)?.content as ProductionTable).WhereNotNull();
-        private IEnumerable<ProjectPage> DisplayPages => DisplayTables.Select(t => (ProjectPage)t.owner);
-
-        private void BuildScrollArea(ImGui gui) {
+        finally {
+            // HACK: Nothing left to change, but force a recalculate anyway, so the user doesn't have to view all the tabs before clicking Auto balance again.
+            // Sometimes this will cause updates that require an additional button click.
+            // This is probably related to https://github.com/shpaass/yafc-ce/issues/169
             foreach (ProjectPage page in DisplayPages) {
-                _ = mainGrid.BuildRow(gui, page);
+                await page.RunSolveJob();
             }
         }
+    }
 
-        private void Recalculate() => Recalculate(false);
+    private IEnumerable<ProductionTable> DisplayTables => project.displayPages.Select(p => project.FindPage(p)?.content as ProductionTable).WhereNotNull();
+    private IEnumerable<ProjectPage> DisplayPages => DisplayTables.Select(t => (ProjectPage)t.owner);
 
-        private void Recalculate(bool visualOnly) {
-            Dictionary<string, GoodDetails> newGoods = [];
-            foreach (Guid displayPage in project.displayPages) {
-                ProjectPage? page = project.FindPage(displayPage);
-                ProductionTable? content = page?.content as ProductionTable;
-                if (content == null) {
-                    continue;
+    private void BuildScrollArea(ImGui gui) {
+        foreach (ProjectPage page in DisplayPages) {
+            _ = mainGrid.BuildRow(gui, page);
+        }
+    }
+
+    private void Recalculate() => Recalculate(false);
+
+    private void Recalculate(bool visualOnly) {
+        Dictionary<string, GoodDetails> newGoods = [];
+        foreach (Guid displayPage in project.displayPages) {
+            ProjectPage? page = project.FindPage(displayPage);
+            ProductionTable? content = page?.content as ProductionTable;
+            if (content == null) {
+                continue;
+            }
+
+            foreach (ProductionLink link in content.links) {
+                if (link.amount != 0f) {
+                    GoodDetails value = newGoods.GetValueOrDefault(link.goods.name);
+                    value.totalProvided += YafcRounding(link.amount); ;
+                    newGoods[link.goods.name] = value;
                 }
+            }
 
-                foreach (ProductionLink link in content.links) {
-                    if (link.amount != 0f) {
-                        GoodDetails value = newGoods.GetValueOrDefault(link.goods.name);
-                        value.totalProvided += YafcRounding(link.amount); ;
-                        newGoods[link.goods.name] = value;
-                    }
+            foreach (ProductionTableFlow flow in content.flow) {
+                if (flow.amount < -Epsilon) {
+                    GoodDetails value = newGoods.GetValueOrDefault(flow.goods.name);
+                    value.totalNeeded -= YafcRounding(flow.amount); ;
+                    value.sum -= YafcRounding(flow.amount); ;
+                    newGoods[flow.goods.name] = value;
                 }
-
-                foreach (ProductionTableFlow flow in content.flow) {
-                    if (flow.amount < -Epsilon) {
+                else if (flow.amount > Epsilon) {
+                    if (!content.links.Exists(x => x.goods == flow.goods)) {
+                        // Only count extras if not linked
                         GoodDetails value = newGoods.GetValueOrDefault(flow.goods.name);
-                        value.totalNeeded -= YafcRounding(flow.amount); ;
-                        value.sum -= YafcRounding(flow.amount); ;
+                        value.extraProduced += YafcRounding(flow.amount);
+                        value.sum -= YafcRounding(flow.amount);
                         newGoods[flow.goods.name] = value;
                     }
-                    else if (flow.amount > Epsilon) {
-                        if (!content.links.Exists(x => x.goods == flow.goods)) {
-                            // Only count extras if not linked
-                            GoodDetails value = newGoods.GetValueOrDefault(flow.goods.name);
-                            value.extraProduced += YafcRounding(flow.amount);
-                            value.sum -= YafcRounding(flow.amount);
-                            newGoods[flow.goods.name] = value;
-                        }
-                    }
                 }
             }
+        }
 
-            int count = 0;
-            foreach (KeyValuePair<string, GoodDetails> entry in newGoods) {
-                float amountAvailable = YafcRounding((entry.Value.totalProvided > 0 ? entry.Value.totalProvided : 0) + entry.Value.extraProduced);
-                float amountNeeded = YafcRounding((entry.Value.totalProvided < 0 ? -entry.Value.totalProvided : 0) + entry.Value.totalNeeded);
-                if (model != null && model.showOnlyIssues && (Math.Abs(amountAvailable - amountNeeded) < Epsilon || amountNeeded == 0)) {
-                    continue;
-                }
-                count++;
+        int count = 0;
+        foreach (KeyValuePair<string, GoodDetails> entry in newGoods) {
+            float amountAvailable = YafcRounding((entry.Value.totalProvided > 0 ? entry.Value.totalProvided : 0) + entry.Value.extraProduced);
+            float amountNeeded = YafcRounding((entry.Value.totalProvided < 0 ? -entry.Value.totalProvided : 0) + entry.Value.totalNeeded);
+            if (model != null && model.showOnlyIssues && (Math.Abs(amountAvailable - amountNeeded) < Epsilon || amountNeeded == 0)) {
+                continue;
             }
-
-            goodsColumn.width = count * (ElementWidth + ElementSpacing);
-
-            allGoods = newGoods;
-
-            Rebuild(visualOnly);
-            scrollArea.RebuildContents();
+            count++;
         }
 
-        // Convert/truncate value as shown in UI to prevent slight mismatches
-        private static float YafcRounding(float value) {
-            _ = DataUtils.TryParseAmount(DataUtils.FormatAmount(value, UnitOfMeasure.PerSecond), out float result, UnitOfMeasure.PerSecond);
-            return result;
-        }
+        goodsColumn.width = count * (ElementWidth + ElementSpacing);
 
-        public override void SetSearchQuery(SearchQuery query) {
-            searchQuery = query;
-            bodyContent.Rebuild();
-            scrollArea.Rebuild();
-        }
+        allGoods = newGoods;
+
+        Rebuild(visualOnly);
+        scrollArea.RebuildContents();
+    }
+
+    // Convert/truncate value as shown in UI to prevent slight mismatches
+    private static float YafcRounding(float value) {
+        _ = DataUtils.TryParseAmount(DataUtils.FormatAmount(value, UnitOfMeasure.PerSecond), out float result, UnitOfMeasure.PerSecond);
+        return result;
+    }
+
+    public override void SetSearchQuery(SearchQuery query) {
+        searchQuery = query;
+        bodyContent.Rebuild();
+        scrollArea.Rebuild();
     }
 }

--- a/Yafc/YafcLib.cs
+++ b/Yafc/YafcLib.cs
@@ -9,58 +9,57 @@ using Yafc.Model;
 using Yafc.Parser;
 using Yafc.UI;
 
-namespace Yafc {
-    public static class YafcLib {
-        public static Version version { get; private set; }
-        public static string initialWorkDir;
+namespace Yafc;
+public static class YafcLib {
+    public static Version version { get; private set; }
+    public static string initialWorkDir;
 
-        static YafcLib() {
-            initialWorkDir = Directory.GetCurrentDirectory();
-            Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
-            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-            var v = Assembly.GetExecutingAssembly().GetName().Version!;
-            version = new Version(v.Major, v.Minor, v.Build, v.Revision);
-            Project.currentYafcVersion = version;
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                NativeLibrary.SetDllImportResolver(typeof(SDL).Assembly, DllResolver);
-                NativeLibrary.SetDllImportResolver(typeof(Ui).Assembly, DllResolver);
-                NativeLibrary.SetDllImportResolver(typeof(FactorioDataSource).Assembly, DllResolver);
-            }
+    static YafcLib() {
+        initialWorkDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        var v = Assembly.GetExecutingAssembly().GetName().Version!;
+        version = new Version(v.Major, v.Minor, v.Build, v.Revision);
+        Project.currentYafcVersion = version;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            NativeLibrary.SetDllImportResolver(typeof(SDL).Assembly, DllResolver);
+            NativeLibrary.SetDllImportResolver(typeof(Ui).Assembly, DllResolver);
+            NativeLibrary.SetDllImportResolver(typeof(FactorioDataSource).Assembly, DllResolver);
+        }
+    }
+
+    private static string GetLinuxMappedLibraryName(string libraryname) => libraryname switch {
+        "lua52" => "liblua52.so",
+        "SDL2.dll" => "SDL2-2.0.so.0",
+        "SDL2_ttf.dll" => "SDL2_ttf-2.0.so.0",
+        "SDL2_image.dll" => "SDL2_image-2.0.so.0",
+        _ => libraryname,
+    };
+
+    private static string GetOsxMappedLibraryName(string libraryname) => libraryname switch {
+        "lua52" => "liblua52.dylib",
+        "SDL2.dll" => "libSDL2.dylib",
+        "SDL2_ttf.dll" => "libSDL2_ttf.dylib",
+        "SDL2_image.dll" => "libSDL2_image.dylib",
+        _ => libraryname,
+    };
+
+    private static IntPtr DllResolver(string libraryname, Assembly assembly, DllImportSearchPath? searchpath) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+            libraryname = GetLinuxMappedLibraryName(libraryname);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+            libraryname = GetOsxMappedLibraryName(libraryname);
         }
 
-        private static string GetLinuxMappedLibraryName(string libraryname) => libraryname switch {
-            "lua52" => "liblua52.so",
-            "SDL2.dll" => "SDL2-2.0.so.0",
-            "SDL2_ttf.dll" => "SDL2_ttf-2.0.so.0",
-            "SDL2_image.dll" => "SDL2_image-2.0.so.0",
-            _ => libraryname,
-        };
+        return NativeLibrary.Load(libraryname, assembly, DllImportSearchPath.SafeDirectories);
+    }
 
-        private static string GetOsxMappedLibraryName(string libraryname) => libraryname switch {
-            "lua52" => "liblua52.dylib",
-            "SDL2.dll" => "libSDL2.dylib",
-            "SDL2_ttf.dll" => "libSDL2_ttf.dylib",
-            "SDL2_image.dll" => "libSDL2_image.dylib",
-            _ => libraryname,
-        };
-
-        private static IntPtr DllResolver(string libraryname, Assembly assembly, DllImportSearchPath? searchpath) {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                libraryname = GetLinuxMappedLibraryName(libraryname);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                libraryname = GetOsxMappedLibraryName(libraryname);
-            }
-
-            return NativeLibrary.Load(libraryname, assembly, DllImportSearchPath.SafeDirectories);
-        }
-
-        public static void RegisterDefaultAnalysis() {
-            Analysis.RegisterAnalysis(Milestones.Instance);
-            Analysis.RegisterAnalysis(AutomationAnalysis.Instance);
-            Analysis.RegisterAnalysis(TechnologyScienceAnalysis.Instance);
-            Analysis.RegisterAnalysis(CostAnalysis.Instance);
-            Analysis.RegisterAnalysis(CostAnalysis.InstanceAtMilestones);
-        }
+    public static void RegisterDefaultAnalysis() {
+        Analysis.RegisterAnalysis(Milestones.Instance);
+        Analysis.RegisterAnalysis(AutomationAnalysis.Instance);
+        Analysis.RegisterAnalysis(TechnologyScienceAnalysis.Instance);
+        Analysis.RegisterAnalysis(CostAnalysis.Instance);
+        Analysis.RegisterAnalysis(CostAnalysis.InstanceAtMilestones);
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 // The purpose of the changelog is to provide a concise overview of what was changed.
 // The purpose of the changelog format is to make it more organized.
 // Versioning follows the x.y.z pattern. Since 0.8.0, the increment has the following meaning:
-// z - it's a bugfix release 
+// z - it's a bugfix release
 // y - it's a feature release
 // x - it's backwards-incompatible
 //
@@ -12,7 +12,7 @@
 //         Then go the changes in the existing behavior. They usually start with "Update".
 //     Bugfixes:
 //         Bugfixes go there.
-//     Internal changes: 
+//     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.10.0
@@ -171,7 +171,7 @@ Date: April 11th 2024
     Fixes:
         - YAFC no longer crashes with flib 0.14.
         - YAFC no longer crashes on a fresh install.
-        - The Release Candidates (RC) bring confusion to versioning, so they are no longer used. 
+        - The Release Candidates (RC) bring confusion to versioning, so they are no longer used.
           The next version after 0.6.3-RC2 will be 0.6.4.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.2
@@ -189,7 +189,7 @@ Date: March 2024
 Version: 0.6.1
 Date: Feb 2024
     Changes:
-        - Add the option to specify the number of buildings that are built for a recipe. 
+        - Add the option to specify the number of buildings that are built for a recipe.
           If the solution requires more than that number of buildings, a warning will be shown.
         - Add filtering by factorio-type. For instance, "tree item" or "tree tech".
         - Make the milestone list scrollable and make it support more milestones.

--- a/licenses.txt
+++ b/licenses.txt
@@ -497,7 +497,7 @@ THE SOFTWARE.
 ### Or-tools ###
 https://github.com/google/or-tools
 
-  
+
 
                                  Apache License
                            Version 2.0, January 2004
@@ -700,8 +700,8 @@ https://github.com/google/or-tools
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
-   
+
+
 ### Roboto font family ###
 https://github.com/googlefonts/roboto
 
@@ -906,7 +906,7 @@ https://github.com/googlefonts/roboto
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
 
 ### Google material design icons ###
 https://github.com/google/material-design-icons
@@ -1113,8 +1113,8 @@ https://github.com/google/material-design-icons
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
-   
+
+
 ### Serpent ###
 https://github.com/pkulchenko/serpent
 


### PR DESCRIPTION
Problem: 
The level of code-nesting in Yafc is excessive. It leaves too much dead space at the start of each line.

Solution: 
This PR is a part of the refactor to reduce the number of spaces at the start of each line.
This particular PR establishes file-scoped namespaces as the preferred ones, and applies this preference to the whole codebase by running a Code Cleanup that should've addressed only this issue. The Code Cleanup also removed some unused `using`s, so it might be not as clear-cut as I thought.

Details:
I set the line in the `.editorconfig` that considers non-file-scoped namespaces a warning, and then I applied Code Cleanup with the only inspection in it to fix warnings and errors from `.editorconfig`. 
The only other directive of that level is `dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:error`,
but @DaleStan said when he did this change, that there are no more entries that require change for that particular directive.

Therefore, the only thing that Code Cleanup _should've_ fixed in the whole solution is the namespaces to be file-scoped. It turns out it also removed some unused `using`s.

Overall, this PR removed 4 spaces in front of many lines in Yafc.

QA: Successfully opened, edited, saved, and closed a pY-AE project.