### PR TITLE
ci: Add a pre-push hook that checks formatting

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+export YAFC_FORMAT_COMMAND="dotnet format --verify-no-changes --diagnostics IDE0055 --severity info --verbosity normal"
+echo "Checking the formatting with \"$YAFC_FORMAT_COMMAND\"."
+echo "Please run it without \"--verify-no-changes\" if you want to apply the fixes. You can skip this check by adding '--no-verify' to 'git push'."
+echo ""
+eval " $YAFC_FORMAT_COMMAND"

--- a/Docs/ContributorsGuide.md
+++ b/Docs/ContributorsGuide.md
@@ -2,6 +2,9 @@
 
 Here are a couple of things to make your experience in the community more enjoyable. 
 
+## Set up environment
+* Please inspect and run [set-up-git-hooks.sh](/set-up-git-hooks.sh) once. It sets up a formatting check to be run before `git push`.
+
 ## Coding
 * For the conventions that we use, please refer to the [Code Style](/Docs/CodeStyle.md).
 * In Visual Studio, you can check some of the rules by running Code Cleanup, or Format Document with "Ctrl+K, Ctrl+D".

--- a/set-up-git-hooks.sh
+++ b/set-up-git-hooks.sh
@@ -1,0 +1,9 @@
+# This file sets up a part of the environment that cannot
+# be set up automatically due to security concerns.
+
+# This line sets up a git-hooks directory.
+# Hooks are the commands that run when you do certain
+# things in the repository.
+# See: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+# Feel free to check the hooks before running this command.
+git config core.hooksPath .githooks


### PR DESCRIPTION
Add a pre-push hook that checks formatting.

Add a script that enables this hook. It cannot be enabled automatically due to git security. Essentially, every contributor needs to run that script once on their machine to enable that hook.

Update the documentation to mention the script.

Fixes #295 ([Devops] Investigate git hooks for dotnet format)

Essentially, this PR prevents the issue where you pushed the code and discovered that the formatting check doesn't pass only at the PR stage.
