### PR TITLE
refactor: convert a public string to a property

### DIFF
--- a/Docs/CodeStyle.md
+++ b/Docs/CodeStyle.md
@@ -28,11 +28,6 @@ The main idea is to keep the code maintainable and readable.
 * In the programmers' haven, there is always a free spot for those who write tests.
 * If you add a TODO, then please describe the details in the commit message, or ideally in a github issue. That increases the chances of the TODOs being addressed.
 
-#### Difference with C# conventions
-Our conventions differ from the [Microsoft C# conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names)
-due to legacy serialization and personal preferences.  
-The most notable difference that is not controlled by [.editorconfig](/.editorconfig) is that class properties are named in camelCase.
-
 #### Blank lines
 Blank lines help to separate code into thematic chunks. 
 We suggest to leave blank lines around code blocks like methods and keywords.  

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -183,14 +183,14 @@ public class Project : ModelObject {
         var currentGuid = currentPage.guid;
         int currentVisualIndex = displayPages.IndexOf(currentGuid);
 
-        return pagesByGuid[displayPages[forward ? NextVisualIndex() : PreviousVisualIndex()]];
+        return pagesByGuid[displayPages[forward ? nextVisualIndex() : previousVisualIndex()]];
 
-        int NextVisualIndex() {
+        int nextVisualIndex() {
             int naiveNextVisualIndex = currentVisualIndex + 1;
             return naiveNextVisualIndex >= displayPages.Count ? 0 : naiveNextVisualIndex;
         }
 
-        int PreviousVisualIndex() {
+        int previousVisualIndex() {
             int naivePreviousVisualIndex = currentVisualIndex - 1;
             return naivePreviousVisualIndex < 0 ? displayPages.Count - 1 : naivePreviousVisualIndex;
         }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -122,14 +122,14 @@ internal partial class FactorioDataDeserializer {
         }
 
         Module[] universalModulesArray = [.. universalModules];
-        IEnumerable<Module> FilteredModules(Recipe item) {
+        IEnumerable<Module> filteredModules(Recipe item) {
             // When the blacklist is available, filter out modules that are in this blacklist
-            Func<Module, bool> AllowedModulesFilter(Recipe key) => module
+            Func<Module, bool> allowedModulesFilter(Recipe key) => module
                 => module.moduleSpecification.limitation_blacklist == null || !module.moduleSpecification.limitation_blacklist.Contains(key);
 
-            return universalModulesArray.Where(AllowedModulesFilter(item));
+            return universalModulesArray.Where(allowedModulesFilter(item));
         }
-        recipeModules.Seal(FilteredModules);
+        recipeModules.Seal(filteredModules);
 
         allModules.AddRange(allObjects.OfType<Module>());
         progress.Report(("Loading", "Loading fluids"));
@@ -233,8 +233,8 @@ internal partial class FactorioDataDeserializer {
     }
 
     private unsafe Icon CreateIconFromSpec(Dictionary<(string mod, string path), IntPtr> cache, params FactorioIconPart[] spec) {
-        const int IconSize = IconCollection.IconSize;
-        nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, IconSize, IconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
+        const int iconSize = IconCollection.IconSize;
+        nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, iconSize, iconSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);
         _ = SDL.SDL_SetSurfaceBlendMode(targetSurface, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
 
         foreach (var icon in spec) {
@@ -262,8 +262,8 @@ internal partial class FactorioDataDeserializer {
                                 SDL.SDL_FreeSurface(old);
                             }
 
-                            if (surface.h > IconSize * 2) {
-                                image = SoftwareScaler.DownscaleIcon(image, IconSize);
+                            if (surface.h > iconSize * 2) {
+                                image = SoftwareScaler.DownscaleIcon(image, iconSize);
                             }
                         }
                         cache[modpath] = image;
@@ -276,10 +276,10 @@ internal partial class FactorioDataDeserializer {
             }
 
             ref var sdlSurface = ref RenderingUtils.AsSdlSurface(image);
-            int targetSize = icon.scale == 1f ? IconSize : MathUtils.Ceil(icon.size * icon.scale) * (IconSize / 32); // TODO research formula
+            int targetSize = icon.scale == 1f ? iconSize : MathUtils.Ceil(icon.size * icon.scale) * (iconSize / 32); // TODO research formula
             _ = SDL.SDL_SetSurfaceColorMod(image, MathUtils.FloatToByte(icon.r), MathUtils.FloatToByte(icon.g), MathUtils.FloatToByte(icon.b));
             //SDL.SDL_SetSurfaceAlphaMod(image, MathUtils.FloatToByte(icon.a));
-            int basePosition = (IconSize - targetSize) / 2;
+            int basePosition = (iconSize - targetSize) / 2;
             SDL.SDL_Rect targetRect = new SDL.SDL_Rect {
                 x = basePosition,
                 y = basePosition,
@@ -288,11 +288,11 @@ internal partial class FactorioDataDeserializer {
             };
 
             if (icon.x != 0) {
-                targetRect.x = MathUtils.Clamp(targetRect.x + MathUtils.Round(icon.x * IconSize / icon.size), 0, IconSize - targetRect.w);
+                targetRect.x = MathUtils.Clamp(targetRect.x + MathUtils.Round(icon.x * iconSize / icon.size), 0, iconSize - targetRect.w);
             }
 
             if (icon.y != 0) {
-                targetRect.y = MathUtils.Clamp(targetRect.y + MathUtils.Round(icon.y * IconSize / icon.size), 0, IconSize - targetRect.h);
+                targetRect.y = MathUtils.Clamp(targetRect.y + MathUtils.Round(icon.y * iconSize / icon.size), 0, iconSize - targetRect.h);
             }
 
             SDL.SDL_Rect srcRect = new SDL.SDL_Rect {

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -503,7 +503,7 @@ internal partial class LuaContext : IDisposable {
 
         foreach (string mod in modorder) {
             required.Clear();
-            FactorioDataSource.currentLoadingMod = mod;
+            FactorioDataSource.CurrentLoadingMod = mod;
             progress.Report((header, mod));
             byte[] bytes = FactorioDataSource.ReadModFile(mod, fileName);
 

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -190,7 +190,7 @@ public class ShoppingListScreen : PseudoScreen {
         Queue<FactorioObject> decompositionQueue = new Queue<FactorioObject>();
         Dictionary<FactorioObject, float> decomposeResult = [];
 
-        void AddDecomposition(FactorioObject obj, float amount) {
+        void addDecomposition(FactorioObject obj, float amount) {
             if (!decomposeResult.TryGetValue(obj, out float prev)) {
                 decompositionQueue.Enqueue(obj);
             }
@@ -199,7 +199,7 @@ public class ShoppingListScreen : PseudoScreen {
         }
 
         foreach (var (item, count) in list.data) {
-            AddDecomposition(item, count);
+            addDecomposition(item, count);
         }
 
         int steps = 0;
@@ -207,7 +207,7 @@ public class ShoppingListScreen : PseudoScreen {
             var elem = decompositionQueue.Dequeue();
             float amount = decomposeResult[elem];
             if (elem is Entity e && e.itemsToPlace.Length == 1) {
-                AddDecomposition(e.itemsToPlace[0], amount);
+                addDecomposition(e.itemsToPlace[0], amount);
             }
             else if (elem is Recipe rec) {
                 if (rec.HasIngredientVariants()) {
@@ -215,11 +215,11 @@ public class ShoppingListScreen : PseudoScreen {
                 }
 
                 foreach (var ingredient in rec.ingredients) {
-                    AddDecomposition(ingredient.goods, ingredient.amount * amount);
+                    addDecomposition(ingredient.goods, ingredient.amount * amount);
                 }
             }
             else if (elem is Goods g && (g.usages.Length <= 5 || (g is Item item && (item.factorioType != "item" || item.placeResult != null))) && (rec = FindSingleProduction(g.production)!) != null) {
-                AddDecomposition(g.production[0], amount / rec.GetProductionPerRecipe(g));
+                addDecomposition(g.production[0], amount / rec.GetProductionPerRecipe(g));
             }
             else {
                 continue;

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -410,7 +410,7 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
             }
 
             errorScroll.RebuildContents();
-            errorMod = FactorioDataSource.currentLoadingMod;
+            errorMod = FactorioDataSource.CurrentLoadingMod;
             if (ex is LuaException lua) {
                 errorMessage = lua.Message;
             }

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -27,7 +27,7 @@ public class AutoPlannerView : ProjectPageView<AutoPlanner> {
         List<AutoPlannerGoal> goal = [];
         string pageName = "Auto planner";
 
-        void Page1(ImGui gui, ref bool valid) {
+        void page1(ImGui gui, ref bool valid) {
             gui.BuildText("This is an experimental feature and may lack functionality. Unfortunately, after some prototyping it wasn't very useful to work with. More research required.",
                 TextBlockDisplayStyle.ErrorText);
             gui.BuildText("Enter page name:");
@@ -64,7 +64,7 @@ public class AutoPlannerView : ProjectPageView<AutoPlanner> {
             valid = !string.IsNullOrEmpty(pageName) && goal.Count > 0;
         }
 
-        pages.Add(Page1);
+        pages.Add(page1);
         return () => {
             var planner = MainScreen.Instance.AddProjectPage("Auto planner", goal[0].item, typeof(AutoPlanner), false, false);
             (planner.content as AutoPlanner).goals.AddRange(goal);


### PR DESCRIPTION
Fixed the [suppressed CA2211](https://github.com/shpaass/yafc-ce/blob/master/Yafc.Parser/FactorioDataSource.cs#L37).

Also noticed that I wrote camelCase properties as the rule when they actually are not PascalCase only because the legacy code uses them. So I clarified it by removing that part from the code style. Essentially, use PascalCase properties if the class does not use camelCase ones.

I've also fixed the violations of the inspection IDE1006.
