### PR TITLE
Support non-Space Age games

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Date:
     Bugfixes:
         - Recipes no longer have excessive question marks in their names
         - Moved mining and research bonuses have to the Preferences screen.
+        - Support games without the Space Age DLC again.
     Internal changes:
         - Added rudimentary tools for drawing tab controls.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I checked all of the #320 commits to see if they would a hard dependency on the Space Age DLC. And I only found the one commit that adds the mods by default.

As far as I could figure out, there is no need to forcefully add these mods: when they are enabled in mod-list.json they get loaded. No other code is depending on these mods, all related code adds support when it is encountered when loading the mods.

I tested by loading both a Space Age and a non-Space Age project (with the mods enabled/disabled) without issues.

So in the end the fix for #323 is fairly straightforward :relieved: 
