### PR TITLE
Focus input field when clicking set building count or set production count

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -443,6 +443,35 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
         }
     }
 
+    private SetKeyboardFocus _focusBuiltCount, _focusFixedCount;
+
+    /// <summary>
+    /// Returns <see cref="SetKeyboardFocus.Always"/> exactly once after each call to <see cref="FocusBuiltCountOnNextDraw"/>, to focus the newly created edit box on that draw cycle.
+    /// </summary>
+    public SetKeyboardFocus ShouldFocusBuiltCountThisTime() {
+        SetKeyboardFocus result = _focusBuiltCount;
+        _focusBuiltCount = SetKeyboardFocus.No;
+        return result;
+    }
+    /// <summary>
+    /// Call when preparing to add a built building count edit box, so the new box will be focused as part of the next draw loop.
+    /// </summary>
+    public void FocusBuiltCountOnNextDraw() => _focusBuiltCount = SetKeyboardFocus.Always;
+
+    /// <summary>
+    /// Returns <see cref="SetKeyboardFocus.Always"/> exactly once after each call to <see cref="FocusFixedCountOnNextDraw"/>, to focus the newly created edit box on that draw cycle.
+    /// </summary>
+    public SetKeyboardFocus ShouldFocusFixedCountThisTime() {
+        SetKeyboardFocus result = _focusFixedCount;
+        _focusFixedCount = SetKeyboardFocus.No;
+        return result;
+    }
+    /// <summary>
+    /// Call when preparing to add or move a fixed count edit box (building, fuel, ingredient, or product), so the new box will be focused as part of the next draw loop.
+    /// </summary>
+    public void FocusFixedCountOnNextDraw() => _focusFixedCount = SetKeyboardFocus.Always;
+
+
     // Computed variables
     internal RecipeParameters parameters { get; set; } = RecipeParameters.Empty;
     public double recipesPerSecond { get; internal set; }

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -295,8 +295,8 @@ public static class ImGuiUtils {
         return closed;
     }
 
-    public static bool BuildIntegerInput(this ImGui gui, int value, out int newValue, bool setInitialFocus = false) {
-        if (gui.BuildTextInput(value.ToString(), out string newText, null, delayed: true, setInitialFocus: setInitialFocus) && int.TryParse(newText, out newValue)) {
+    public static bool BuildIntegerInput(this ImGui gui, int value, out int newValue, SetKeyboardFocus setKeyboardFocus = SetKeyboardFocus.No) {
+        if (gui.BuildTextInput(value.ToString(), out string newText, null, delayed: true, setKeyboardFocus: setKeyboardFocus) && int.TryParse(newText, out newValue)) {
             return true;
         }
 
@@ -417,10 +417,10 @@ public static class ImGuiUtils {
         return true;
     }
 
-    public static bool BuildSearchBox(this ImGui gui, SearchQuery searchQuery, out SearchQuery newQuery, string placeholder = "Search", bool setInitialFocus = false) {
+    public static bool BuildSearchBox(this ImGui gui, SearchQuery searchQuery, out SearchQuery newQuery, string placeholder = "Search", SetKeyboardFocus setKeyboardFocus = SetKeyboardFocus.No) {
         newQuery = searchQuery;
 
-        if (gui.BuildTextInput(searchQuery.query, out string newText, placeholder, Icon.Search, setInitialFocus: setInitialFocus)) {
+        if (gui.BuildTextInput(searchQuery.query, out string newText, placeholder, Icon.Search, setKeyboardFocus: setKeyboardFocus)) {
             newQuery = new SearchQuery(newText);
             return true;
         }

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -89,8 +89,8 @@ public static class ImmediateWidgets {
         }
     }
 
-    public static bool BuildFloatInput(this ImGui gui, DisplayAmount amount, TextBoxDisplayStyle displayStyle, bool setInitialFocus = false) {
-        if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, displayStyle, true, setInitialFocus)
+    public static bool BuildFloatInput(this ImGui gui, DisplayAmount amount, TextBoxDisplayStyle displayStyle, SetKeyboardFocus setKeyboardFocus = SetKeyboardFocus.No) {
+        if (gui.BuildTextInput(DataUtils.FormatAmount(amount.Value, amount.Unit), out string newText, null, displayStyle, true, setKeyboardFocus)
             && DataUtils.TryParseAmount(newText, out float newValue, amount.Unit)) {
             amount.Value = newValue;
             return true;

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -316,13 +316,13 @@ public static class ImmediateWidgets {
     /// <param name="allowScroll">If <see langword="true"/>, the default, the user can adjust the value by using the scroll wheel while hovering over the editable text.
     /// If <see langword="false"/>, the scroll wheel will be ignored when hovering.</param>
     public static GoodsWithAmountEvent BuildFactorioObjectWithEditableAmount(this ImGui gui, FactorioObject? obj, DisplayAmount amount, ButtonDisplayStyle buttonDisplayStyle,
-        bool allowScroll = true, ObjectTooltipOptions tooltipOptions = default) {
+        bool allowScroll = true, ObjectTooltipOptions tooltipOptions = default, SetKeyboardFocus setKeyboardFocus = SetKeyboardFocus.No) {
 
         using var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f);
         group.SetWidth(3f);
         GoodsWithAmountEvent evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectButton(obj, buttonDisplayStyle, tooltipOptions);
 
-        if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput)) {
+        if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput, setKeyboardFocus)) {
             return GoodsWithAmountEvent.TextEditing;
         }
 

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -26,7 +26,7 @@ public class ProjectPageSettingsPanel : PseudoScreen {
     }
 
     private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
-        _ = gui.BuildTextInput(name, out name, "Input name", setInitialFocus: editingPage == null);
+        _ = gui.BuildTextInput(name, out name, "Input name", setKeyboardFocus: editingPage == null ? SetKeyboardFocus.OnFirstPanelDraw : SetKeyboardFocus.No);
         if (gui.BuildFactorioObjectButton(icon, new ButtonDisplayStyle(4f, MilestoneDisplay.None, SchemeColor.Grey) with { UseScaleSetting = false }) == Click.Left) {
             SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
         }

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -97,7 +97,7 @@ public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
 
     public override void Build(ImGui gui) {
         BuildHeader(gui, header);
-        if (gui.BuildSearchBox(list.filter, out var newFilter, "Start typing for search", setInitialFocus: true)) {
+        if (gui.BuildSearchBox(list.filter, out var newFilter, "Start typing for search", setKeyboardFocus: SetKeyboardFocus.OnFirstPanelDraw)) {
             list.filter = newFilter;
         }
 

--- a/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
@@ -71,7 +71,7 @@ public class ModuleTemplateConfiguration : PseudoScreen {
                 RefreshList();
             }
 
-            _ = gui.RemainingRow().BuildTextInput(newPageName, out newPageName, "Create new template", setInitialFocus: true);
+            _ = gui.RemainingRow().BuildTextInput(newPageName, out newPageName, "Create new template", setKeyboardFocus: SetKeyboardFocus.OnFirstPanelDraw);
         }
     }
 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -298,7 +298,8 @@ goodsHaveNoProduction:;
                 group.SetWidth(3f);
                 if (recipe.fixedBuildings > 0 && !recipe.fixedFuel && recipe.fixedIngredient == null && recipe.fixedProduct == null) {
                     DisplayAmount amount = recipe.fixedBuildings;
-                    GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled);
+                    GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled,
+                        setKeyboardFocus: recipe.ShouldFocusFixedCountThisTime());
 
                     if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
                         recipe.RecordUndo().fixedBuildings = amount.Value;
@@ -313,7 +314,9 @@ goodsHaveNoProduction:;
                 if (recipe.builtBuildings != null) {
                     DisplayAmount amount = recipe.builtBuildings.Value;
 
-                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }) && amount.Value >= 0) {
+                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }, recipe.ShouldFocusBuiltCountThisTime())
+                        && amount.Value >= 0) {
+
                         recipe.RecordUndo().builtBuildings = (int)amount.Value;
                     }
                 }
@@ -428,6 +431,7 @@ goodsHaveNoProduction:;
                     recipe.fixedFuel = false;
                     recipe.fixedIngredient = null;
                     recipe.fixedProduct = null;
+                    recipe.FocusFixedCountOnNextDraw();
                 }
             }
 
@@ -447,6 +451,7 @@ goodsHaveNoProduction:;
                 }
                 else if (gui.BuildButton("Set built building count") && gui.CloseDropdown()) {
                     recipe.RecordUndo().builtBuildings = Math.Max(0, Convert.ToInt32(Math.Ceiling(recipe.buildingCount)));
+                    recipe.FocusBuiltCountOnNextDraw();
                 }
             }
 
@@ -1016,6 +1021,7 @@ goodsHaveNoProduction:;
                                 default:
                                     break;
                             }
+                            recipe.FocusFixedCountOnNextDraw();
                             targetGui.Rebuild();
                         }
                     }
@@ -1151,7 +1157,9 @@ goodsHaveNoProduction:;
             && ((dropdownType == ProductDropdownType.Fuel && recipe.fixedFuel)
             || (dropdownType == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
             || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
-            evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions);
+
+            evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor), tooltipOptions: tooltipOptions,
+                setKeyboardFocus: recipe.ShouldFocusFixedCountThisTime());
         }
         else {
             evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor),

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -339,9 +339,16 @@ goodsHaveNoProduction:;
                 }
                 else if (recipe.fixedBuildings > 0) {
                     recipe.RecordUndo().fixedBuildings = 0;
+                    // Clear the keyboard focus: If we hide and then recreate the edit box without removing the focus, the UI system will restore the old value.
+                    // (If the focus was on a text box we aren't hiding, other code also removes the focus.)
+                    // To observe (prior to this fix), add a fixed or built count with a non-default value, clear it with right-click, and then click the "Set ... building count" button again.
+                    // The old behavior is that the non-default value is restored.
+                    InputSystem.Instance.currentKeyboardFocus?.FocusChanged(false);
                 }
                 else if (recipe.builtBuildings != null) {
                     recipe.RecordUndo().builtBuildings = null;
+                    // Clear the keyboard focus: as above
+                    InputSystem.Instance.currentKeyboardFocus?.FocusChanged(false);
                 }
             }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,8 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.x
 Date:
+    Features:
+        - Focus the built count and fixed count edit boxes when first opening them.
     Bugfixes:
         - Recipes no longer have excessive question marks in their names
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #297; I checked that the focusing the sheet name still happens when adding a new production sheet and doesn't happen when editing an existing sheet.

I also found a subtle UI wart and worked around it in 9da8948; it becomes more visible now that the fixed and built counts are focused more often.