### PR TITLE
Move mining and research bonuses to preferences

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -353,9 +353,10 @@ public class Special : Goods {
     internal string? virtualSignal { get; set; }
     internal bool power;
     internal bool isResearch;
+    internal bool isVoid;
     public override bool isPower => power;
     public override string type => isPower ? "Power" : "Special";
-    public override UnitOfMeasure flowUnitOfMeasure => isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
+    public override UnitOfMeasure flowUnitOfMeasure => isVoid ? UnitOfMeasure.None : isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.SpecialGoods;
     public override bool showInExplorers => !isResearch;
 

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -545,7 +545,7 @@ public static partial class DataUtils {
         }
 
         if (amount == 0f) {
-            return "0";
+            return prefix + "0" + unitSuffix + suffix;
         }
 
         _ = amountBuilder.Clear();

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -61,6 +61,7 @@ internal partial class FactorioDataDeserializer {
         fuels.Add(SpecialNames.Heat, heat);
 
         voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
+        voidEnergy.isVoid = true;
         fuels.Add(SpecialNames.Void, voidEnergy);
         rootAccessible.Add(voidEnergy);
 

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -39,13 +39,14 @@ public partial class ImGui {
     private readonly List<DrawCommand<Icon>> icons = [];
     private readonly List<DrawCommand<IRenderable>> renderables = [];
     private readonly List<DrawCommand<IPanel>> panels = [];
+    internal bool enableDrawing { get; private set; } = true;
     public SchemeColor initialTextColor { get; set; } = SchemeColor.BackgroundText;
     public SchemeColor boxColor { get; set; } = SchemeColor.None;
     public RectangleBorder boxShadow { get; set; } = RectangleBorder.None;
     public Padding initialPadding { get; set; }
 
     public void DrawRectangle(Rect rect, SchemeColor color, RectangleBorder border = RectangleBorder.None) {
-        if (action != ImGuiAction.Build) {
+        if (action != ImGuiAction.Build || !enableDrawing) {
             return;
         }
 
@@ -53,7 +54,7 @@ public partial class ImGui {
     }
 
     public void DrawIcon(Rect rect, Icon icon, SchemeColor color) {
-        if (action != ImGuiAction.Build || icon == Icon.None) {
+        if (action != ImGuiAction.Build || icon == Icon.None || !enableDrawing) {
             return;
         }
 
@@ -61,7 +62,7 @@ public partial class ImGui {
     }
 
     public void DrawRenderable(Rect rect, IRenderable? renderable, SchemeColor color) {
-        if (action != ImGuiAction.Build || renderable == null) {
+        if (action != ImGuiAction.Build || renderable == null || !enableDrawing) {
             return;
         }
 

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -80,6 +80,10 @@ internal partial class ImGuiTextInputHelper(ImGui gui) : IKeyboardFocus {
             SetCaret(0, this.text.Length);
         }
 
+        if (!gui.enableDrawing) {
+            return false;
+        }
+
         switch (gui.action) {
             case ImGuiAction.MouseDown:
                 if (gui.actionParameter != SDL.SDL_BUTTON_LEFT) {

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -42,6 +42,9 @@ public static class ImGuiUtils {
         if (button == 0) {
             button = (uint)InputSystem.Instance.mouseDownButton;
         }
+        if (!gui.enableDrawing) {
+            return ButtonEvent.None;
+        }
 
         switch (gui.action) {
             case ImGuiAction.MouseMove:
@@ -64,6 +67,10 @@ public static class ImGuiUtils {
 
     public static bool BuildLink(this ImGui gui, string text) {
         gui.BuildText(text, TextBlockDisplayStyle.Default(SchemeColor.Link));
+        if (!gui.enableDrawing) {
+            return ButtonEvent.None;
+        }
+
         var rect = gui.lastRect;
         switch (gui.action) {
             case ImGuiAction.MouseMove:
@@ -381,6 +388,10 @@ public static class ImGuiUtils {
         Rect handleRect = new Rect(sliderRect.X + handleStart, sliderRect.Y, 1f, sliderRect.Height);
         bool update = false;
         newValue = value;
+
+        if (!gui.enableDrawing) {
+            return false;
+        }
 
         switch (gui.action) {
             case ImGuiAction.Build:

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -392,7 +392,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         }
 
         if (gui.BuildContextMenuButton("Preferences") && gui.CloseDropdown()) {
-            PreferencesScreen.Show();
+            PreferencesScreen.ShowPreviousState();
         }
 
         if (gui.BuildContextMenuButton("Summary") && gui.CloseDropdown()) {

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -53,6 +53,11 @@ public class MilestonesPanel : PseudoScreen {
                 MilestonesEditor.Show();
             }
 
+            if (gui.BuildButton("Edit tech progression settings")) {
+                Close();
+                PreferencesScreen.ShowProgression();
+            }
+
             if (gui.RemainingRow().BuildButton("Done")) {
                 Close();
             }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -58,6 +58,29 @@ public class PreferencesScreen : PseudoScreen {
                 gui.Rebuild();
             }, width: 25f);
 
+            gui.AllocateSpacing();
+            using (gui.EnterRow()) {
+                gui.BuildText("Mining productivity bonus: ", topOffset: 0.5f);
+                DisplayAmount amount = new(Project.current.settings.miningProductivity, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
+                    Project.current.settings.RecordUndo().miningProductivity = amount.Value;
+                }
+            }
+            using (gui.EnterRow()) {
+                gui.BuildText("Research speed bonus: ", topOffset: 0.5f);
+                DisplayAmount amount = new(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
+                    Project.current.settings.RecordUndo().researchSpeedBonus = amount.Value;
+                }
+            }
+            using (gui.EnterRow()) {
+                gui.BuildText("Research productivity bonus: ", topOffset: 0.5f);
+                DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
+                    Project.current.settings.RecordUndo().researchProductivity = amount.Value;
+                }
+            }
+
             controller.StartNextAllocatePass(!onProgressionPage);
 
             gui.BuildText("Unit of time:", Font.subheader);

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 using Yafc.Model;
 using Yafc.UI;
 
@@ -6,94 +7,124 @@ namespace Yafc;
 
 public class PreferencesScreen : PseudoScreen {
     private static readonly PreferencesScreen Instance = new PreferencesScreen();
+    private bool onProgressionPage;
 
     public override void Build(ImGui gui) {
         BuildHeader(gui, "Preferences");
-        gui.BuildText("Unit of time:", Font.subheader);
+        gui.AllocateSpacing();
+
+        // Draw tabs
+        Rect generalRect = new(gui.statePosition.TopLeft, new((gui.statePosition.Width + .8f) / 2 - .8f, 2.25f));
+        Rect progressionRect = generalRect + new Vector2(generalRect.Width + .8f, 0);
+        gui.DrawText(generalRect, "General", RectAlignment.Middle);
+        gui.DrawText(progressionRect, "Progression", RectAlignment.Middle);
+        if (onProgressionPage) {
+            gui.DrawRectangle(progressionRect, SchemeColor.Secondary);
+            if (gui.BuildButton(generalRect, SchemeColor.Primary, SchemeColor.PrimaryAlt)) {
+                onProgressionPage = false;
+            }
+        }
+        else {
+            if (gui.BuildButton(progressionRect, SchemeColor.Primary, SchemeColor.PrimaryAlt)) {
+                onProgressionPage = true;
+            }
+            gui.DrawRectangle(generalRect, SchemeColor.Secondary);
+        }
+        gui.DrawRectangle(new(gui.statePosition.X, gui.statePosition.Y + 2.25f, gui.statePosition.Width, .25f), SchemeColor.Secondary);
+        gui.AllocateRect(0, 2.5f, 0); // Allocate (vertical) space for the tabs
+
         var prefs = Project.current.preferences;
         var settings = Project.current.settings;
-        using (gui.EnterRow()) {
-            if (gui.BuildRadioButton("Second", prefs.time == 1)) {
-                prefs.RecordUndo(true).time = 1;
-            }
 
-            if (gui.BuildRadioButton("Minute", prefs.time == 60)) {
-                prefs.RecordUndo(true).time = 60;
-            }
-
-            if (gui.BuildRadioButton("Hour", prefs.time == 3600)) {
-                prefs.RecordUndo(true).time = 3600;
-            }
-
-            if (gui.BuildRadioButton("Custom", prefs.time is not 1 and not 60 and not 3600)) {
-                prefs.RecordUndo(true).time = 0;
-            }
-
-            if (gui.BuildIntegerInput(prefs.time, out int newTime)) {
-                prefs.RecordUndo(true).time = newTime;
-            }
-        }
-        gui.AllocateSpacing(1f);
-        gui.BuildText("Item production/consumption:", Font.subheader);
-        BuildUnitPerTime(gui, false, prefs);
-        gui.BuildText("Fluid production/consumption:", Font.subheader);
-        BuildUnitPerTime(gui, true, prefs);
-
-        using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
-            gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
-            DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
-            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
-                settings.RecordUndo().PollutionCostModifier = amount.Value;
+        // Allocate both pages, draw current page
+        using (var controller = gui.StartOverlappingAllocations(onProgressionPage)) {
+            ChooseObject(gui, "Default belt:", Database.allBelts, prefs.defaultBelt, s => {
+                prefs.RecordUndo().defaultBelt = s;
                 gui.Rebuild();
-            }
-        }
-
-        string iconScaleMessage = "Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.";
-
-        using (gui.EnterRowWithHelpIcon(iconScaleMessage)) {
-            gui.BuildText("Display scale for linkable icons", topOffset: 0.5f);
-            DisplayAmount amount = new(prefs.iconScale, UnitOfMeasure.Percent);
-            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value > 0 && amount.Value <= 1) {
-                prefs.RecordUndo().iconScale = amount.Value;
+            });
+            ChooseObject(gui, "Default inserter:", Database.allInserters, prefs.defaultInserter, s => {
+                prefs.RecordUndo().defaultInserter = s;
                 gui.Rebuild();
-            }
-        }
+            });
 
-        ChooseObject(gui, "Default belt:", Database.allBelts, prefs.defaultBelt, s => {
-            prefs.RecordUndo().defaultBelt = s;
-            gui.Rebuild();
-        });
-        ChooseObject(gui, "Default inserter:", Database.allInserters, prefs.defaultInserter, s => {
-            prefs.RecordUndo().defaultInserter = s;
-            gui.Rebuild();
-        });
-
-        using (gui.EnterRow()) {
-            gui.BuildText("Inserter capacity:", topOffset: 0.5f);
-            if (gui.BuildIntegerInput(prefs.inserterCapacity, out int newCapacity)) {
-                prefs.RecordUndo().inserterCapacity = newCapacity;
-            }
-        }
-
-        using (gui.EnterRow()) {
-            gui.BuildText("Reactor layout:", topOffset: 0.5f);
-            if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
-                int px = newSize.IndexOf('x');
-                if (px < 0 && int.TryParse(newSize, out int value)) {
-                    settings.RecordUndo().reactorSizeX = value;
-                    settings.reactorSizeY = value;
-                }
-                else if (int.TryParse(newSize[..px], out int sizeX) && int.TryParse(newSize[(px + 1)..], out int sizeY)) {
-                    settings.RecordUndo().reactorSizeX = sizeX;
-                    settings.reactorSizeY = sizeY;
+            using (gui.EnterRow()) {
+                gui.BuildText("Inserter capacity:", topOffset: 0.5f);
+                if (gui.BuildIntegerInput(prefs.inserterCapacity, out int newCapacity)) {
+                    prefs.RecordUndo().inserterCapacity = newCapacity;
                 }
             }
-        }
-        ChooseObjectWithNone(gui, "Target technology for cost analysis: ", Database.technologies.all, prefs.targetTechnology, x => {
-            prefs.RecordUndo().targetTechnology = x;
-            gui.Rebuild();
-        }, width: 25f);
+            ChooseObjectWithNone(gui, "Target technology for cost analysis: ", Database.technologies.all, prefs.targetTechnology, x => {
+                prefs.RecordUndo().targetTechnology = x;
+                gui.Rebuild();
+            }, width: 25f);
 
+            controller.StartNextAllocatePass(!onProgressionPage);
+
+            gui.BuildText("Unit of time:", Font.subheader);
+            using (gui.EnterRow()) {
+                if (gui.BuildRadioButton("Second", prefs.time == 1)) {
+                    prefs.RecordUndo(true).time = 1;
+                }
+
+                if (gui.BuildRadioButton("Minute", prefs.time == 60)) {
+                    prefs.RecordUndo(true).time = 60;
+                }
+
+                if (gui.BuildRadioButton("Hour", prefs.time == 3600)) {
+                    prefs.RecordUndo(true).time = 3600;
+                }
+
+                if (gui.BuildRadioButton("Custom", prefs.time is not 1 and not 60 and not 3600)) {
+                    prefs.RecordUndo(true).time = 0;
+                }
+
+                if (gui.BuildIntegerInput(prefs.time, out int newTime)) {
+                    prefs.RecordUndo(true).time = newTime;
+                }
+            }
+            gui.AllocateSpacing(1f);
+            gui.BuildText("Item production/consumption:", Font.subheader);
+            BuildUnitPerTime(gui, false, prefs);
+            gui.BuildText("Fluid production/consumption:", Font.subheader);
+            BuildUnitPerTime(gui, true, prefs);
+
+            using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
+                gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
+                DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
+                    settings.RecordUndo().PollutionCostModifier = amount.Value;
+                    gui.Rebuild();
+                }
+            }
+
+            string iconScaleMessage = "Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.";
+
+            using (gui.EnterRowWithHelpIcon(iconScaleMessage)) {
+                gui.BuildText("Display scale for linkable icons", topOffset: 0.5f);
+                DisplayAmount amount = new(prefs.iconScale, UnitOfMeasure.Percent);
+                if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value > 0 && amount.Value <= 1) {
+                    prefs.RecordUndo().iconScale = amount.Value;
+                    gui.Rebuild();
+                }
+            }
+
+            using (gui.EnterRow()) {
+                gui.BuildText("Reactor layout:", topOffset: 0.5f);
+                if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
+                    int px = newSize.IndexOf('x');
+                    if (px < 0 && int.TryParse(newSize, out int value)) {
+                        settings.RecordUndo().reactorSizeX = value;
+                        settings.reactorSizeY = value;
+                    }
+                    else if (int.TryParse(newSize[..px], out int sizeX) && int.TryParse(newSize[(px + 1)..], out int sizeY)) {
+                        settings.RecordUndo().reactorSizeX = sizeX;
+                        settings.reactorSizeY = sizeY;
+                    }
+                }
+            }
+        }
+
+        gui.AllocateSpacing();
         if (gui.BuildButton("Done")) {
             Close();
         }
@@ -172,5 +203,13 @@ public class PreferencesScreen : PseudoScreen {
         }
     }
 
-    public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    public static void ShowProgression() {
+        Instance.onProgressionPage = true;
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
+    public static void ShowGeneral() {
+        Instance.onProgressionPage = false;
+        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    }
+    public static void ShowPreviousState() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
 }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -111,7 +111,7 @@ public class PreferencesScreen : PseudoScreen {
             gui.BuildText("Fluid production/consumption:", Font.subheader);
             BuildUnitPerTime(gui, true, prefs);
 
-            using (gui.EnterRowWithHelpIcon("0 for off, 100% for old default")) {
+            using (gui.EnterRowWithHelpIcon("0% for off, 100% for old default")) {
                 gui.BuildText("Pollution cost modifier", topOffset: 0.5f);
                 DisplayAmount amount = new(settings.PollutionCostModifier, UnitOfMeasure.Percent);
                 if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -169,29 +169,6 @@ public class ModuleFillerParametersScreen : PseudoScreen {
             }
         }
 
-        gui.AllocateSpacing();
-        using (gui.EnterRow()) {
-            gui.BuildText("Mining productivity bonus (project-wide setting): ");
-            DisplayAmount amount = new(Project.current.settings.miningProductivity, UnitOfMeasure.Percent);
-            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
-                Project.current.settings.RecordUndo().miningProductivity = amount.Value;
-            }
-        }
-        using (gui.EnterRow()) {
-            gui.BuildText("Research speed bonus (project-wide setting): ");
-            DisplayAmount amount = new(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent);
-            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
-                Project.current.settings.RecordUndo().researchSpeedBonus = amount.Value;
-            }
-        }
-        using (gui.EnterRow()) {
-            gui.BuildText("Research productivity bonus (project-wide setting): ");
-            DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
-            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.ModuleParametersTextInput) && amount.Value >= 0) {
-                Project.current.settings.RecordUndo().researchProductivity = amount.Value;
-            }
-        }
-
         if (gui.BuildButton("Done")) {
             Close();
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1309,7 +1309,7 @@ goodsHaveNoProduction:;
         }
 
         if (click && gui.CloseDropdown()) {
-            PreferencesScreen.Show();
+            PreferencesScreen.ShowProgression();
         }
     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,8 @@ Date:
         - Focus the built count and fixed count edit boxes when first opening them.
     Bugfixes:
         - Recipes no longer have excessive question marks in their names
+    Internal changes:
+        - Added rudimentary tools for drawing tab controls.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.0.1
 Date: October 23rd 2024

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Focus the built count and fixed count edit boxes when first opening them.
     Bugfixes:
         - Recipes no longer have excessive question marks in their names
+        - Moved mining and research bonuses have to the Preferences screen.
     Internal changes:
         - Added rudimentary tools for drawing tab controls.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #296 by splitting the preferences screen into two tabs, General and Progression, and then moving the research and mining bonuses to the Progression tab.

The tab-control tools are certainly rudimentary. I have thoughts on how to make them better, but I feel like I'm already squeezing enough tooling changes into fix/feature PRs.