### PR TITLE
Add a dark mode checkbox to the preferences.

### DIFF
--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -284,4 +284,10 @@ public static partial class Ui {
             }
         }
     }
+
+    internal static void ColorSchemeChanged() {
+        foreach (Window window in windows.Values) {
+            window.DarkModeChanged();
+        }
+    }
 }

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -183,6 +183,8 @@ public abstract class Window : IDisposable {
         }
     }
 
+    internal virtual void DarkModeChanged() { }
+
     public void ShowTooltip(Tooltip tooltip) {
         this.tooltip = tooltip;
         Rebuild();

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -7,8 +7,8 @@ using Serilog;
 namespace Yafc.UI;
 
 // Main window is resizable and hardware-accelerated unless forced to render via software by caller
-public abstract class WindowMain(Padding padding) : Window(padding) {
-    protected void Create(string title, int display, float initialWidth, float initialHeight, bool maximized, bool forceSoftwareRenderer) {
+public abstract class WindowMain(Padding padding, bool forceSoftwareRenderer) : Window(padding) {
+    protected void Create(string title, int display, float initialWidth, float initialHeight, bool maximized) {
         if (visible) {
             return;
         }
@@ -36,6 +36,14 @@ public abstract class WindowMain(Padding padding) : Window(padding) {
         WindowResize();
         surface = new MainWindowDrawingSurface(this, forceSoftwareRenderer);
         base.Create();
+    }
+
+    internal override void DarkModeChanged() {
+        if (surface != null) {
+            // Replace surface to (1) replace circleTexture, which is used for drawing shadows, and (2) invalidate the faded background from FadeDrawer.
+            surface.Dispose();
+            surface = new MainWindowDrawingSurface(this, forceSoftwareRenderer);
+        }
     }
 
     protected override void BuildContents(ImGui gui) {

--- a/Yafc.UI/Rendering/RenderingUtils.cs
+++ b/Yafc.UI/Rendering/RenderingUtils.cs
@@ -68,6 +68,7 @@ public static class RenderingUtils {
     public static void SetColorScheme(bool darkMode) {
         RenderingUtils.darkMode = darkMode;
         SchemeColors = darkMode ? DarkModeScheme : LightModeScheme;
+        Ui.ColorSchemeChanged();
         byte col = darkMode ? (byte)0 : (byte)255;
         _ = SDL.SDL_SetSurfaceColorMod(CircleSurface, col, col, col);
     }

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -46,7 +46,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     private readonly Dictionary<Type, ProjectPageView> registeredPageViews = [];
     private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = [];
 
-    public MainScreen(int display, Project project) : base(default) {
+    public MainScreen(int display, Project project) : base(default, Preferences.Instance.forceSoftwareRenderer) {
         summaryView = new SummaryView(project);
         RegisterPageView<ProductionTable>(new ProductionTableView());
         RegisterPageView<AutoPlanner>(new AutoPlannerView());
@@ -58,7 +58,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, collapsible: true);
 
         Create("Yet Another Factorio Calculator CE v" + YafcLib.version.ToString(3), display, Preferences.Instance.initialMainScreenWidth,
-            Preferences.Instance.initialMainScreenHeight, Preferences.Instance.maximizeMainScreen, Preferences.Instance.forceSoftwareRenderer);
+            Preferences.Instance.initialMainScreenHeight, Preferences.Instance.maximizeMainScreen);
         SetProject(project);
     }
 

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -145,6 +145,12 @@ public class PreferencesScreen : PseudoScreen {
                     }
                 }
             }
+
+            if (gui.BuildCheckBox("Dark mode", Preferences.Instance.darkMode, out bool newValue)) {
+                Preferences.Instance.darkMode = newValue;
+                Preferences.Instance.Save();
+                RenderingUtils.SetColorScheme(newValue);
+            }
         }
 
         gui.AllocateSpacing();

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version: 2.x
 Date:
     Features:
         - Focus the built count and fixed count edit boxes when first opening them.
+        - Add a dark mode checkbox to the preferences.
     Bugfixes:
         - Recipes no longer have excessive question marks in their names
         - Moved mining and research bonuses have to the Preferences screen.


### PR DESCRIPTION
The obvious change in Yafc/Windows/PreferencesScreen.cs is about 80% of the job, but with just that, the pseudoscreen shadows disappear until you close the main window. (Either by exiting or returning to the Welcome window.) The rest of the work links the style change to the surface replacement, so the shadows reappear. (And the background changes color properly.)