### PR TITLE
feat: Add preferences for "change-recipe-productivity" technology unlocks

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -522,7 +522,7 @@ public class EntityContainer : Entity {
 public class Technology : RecipeOrTechnology { // Technology is very similar to recipe
     public float count { get; internal set; } // TODO support formula count
     public Technology[] prerequisites { get; internal set; } = [];
-    public Recipe[] unlockRecipes { get; internal set; } = [];
+    public List<Recipe> unlockRecipes { get; internal set; } = [];
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Technologies;
     public override string type => "Technology";
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -155,6 +155,7 @@ public class Recipe : RecipeOrTechnology {
     public AllowedEffects allowedEffects { get; internal set; }
     public string[]? allowedModuleCategories { get; internal set; }
     public Technology[] technologyUnlock { get; internal set; } = [];
+    public Dictionary<Technology, float> technologyProductivity { get; internal set; } = [];
     public bool HasIngredientVariants() {
         foreach (var ingredient in ingredients) {
             if (ingredient.variants != null) {
@@ -523,6 +524,7 @@ public class Technology : RecipeOrTechnology { // Technology is very similar to 
     public float count { get; internal set; } // TODO support formula count
     public Technology[] prerequisites { get; internal set; } = [];
     public List<Recipe> unlockRecipes { get; internal set; } = [];
+    public Dictionary<Recipe, float> changeRecipeProductivity { get; internal set; } = [];
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Technologies;
     public override string type => "Technology";
 

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -221,6 +221,7 @@ public class ProjectSettings(Project project) : ModelObject<Project>(project) {
     public float miningProductivity { get; set; }
     public float researchSpeedBonus { get; set; }
     public float researchProductivity { get; set; }
+    public Dictionary<Technology, int> productivityTechnologyLevels { get; } = [];
     public int reactorSizeX { get; set; } = 2;
     public int reactorSizeY { get; set; } = 2;
     public float PollutionCostModifier { get; set; } = 0;

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -125,14 +125,14 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
             }
             else if (recipe is Technology) {
                 productivity += Project.current.settings.researchProductivity;
-            } 
+            }
             else if (recipe is Recipe actualRecipe) {
-                Dictionary<Technology,int> levels = Project.current.settings.productivityTechnologyLevels;
+                Dictionary<Technology, int> levels = Project.current.settings.productivityTechnologyLevels;
                 foreach ((Technology productivityTechnology, float changePerLevel) in actualRecipe.technologyProductivity) {
                     if (!levels.TryGetValue(productivityTechnology, out int productivityTechLevel)) {
                         continue;
                     }
-                    
+
                     productivity += changePerLevel * productivityTechLevel;
                 }
             }

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Yafc.Model;
@@ -124,6 +125,16 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
             }
             else if (recipe is Technology) {
                 productivity += Project.current.settings.researchProductivity;
+            } 
+            else if (recipe is Recipe actualRecipe) {
+                Dictionary<Technology,int> levels = Project.current.settings.productivityTechnologyLevels;
+                foreach ((Technology productivityTechnology, float changePerLevel) in actualRecipe.technologyProductivity) {
+                    if (!levels.TryGetValue(productivityTechnology, out int productivityTechLevel)) {
+                        continue;
+                    }
+                    
+                    productivity += changePerLevel * productivityTechLevel;
+                }
             }
 
             if (entity is EntityReactor reactor && reactor.reactorNeighborBonus > 0f) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -129,6 +129,19 @@ internal partial class FactorioDataDeserializer {
                         
                         break;
                     }
+
+                    case "change-recipe-productivity": {
+                        if (!GetRef<Recipe>(modifier, "recipe", out var recipe)) {
+                            continue;
+                        }
+
+                        float change = modifier.Get("change", 0f);
+
+                        technology.changeRecipeProductivity.Add(recipe, change);
+                        recipe.technologyProductivity.Add(technology, change);
+
+                        break;
+                    }
                 }
             }
         }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -121,27 +121,27 @@ internal partial class FactorioDataDeserializer {
             foreach (LuaTable modifier in modifiers.ArrayElements<LuaTable>()) {
                 switch (modifier.Get("type", "")) {
                     case "unlock-recipe": {
-                        if (!GetRef<Recipe>(modifier, "recipe", out var recipe)) {
-                            continue;
-                        }
+                            if (!GetRef<Recipe>(modifier, "recipe", out var recipe)) {
+                                continue;
+                            }
 
-                        technology.unlockRecipes.Add(recipe);
-                        
-                        break;
-                    }
+                            technology.unlockRecipes.Add(recipe);
+
+                            break;
+                        }
 
                     case "change-recipe-productivity": {
-                        if (!GetRef<Recipe>(modifier, "recipe", out var recipe)) {
-                            continue;
+                            if (!GetRef<Recipe>(modifier, "recipe", out var recipe)) {
+                                continue;
+                            }
+
+                            float change = modifier.Get("change", 0f);
+
+                            technology.changeRecipeProductivity.Add(recipe, change);
+                            recipe.technologyProductivity.Add(technology, change);
+
+                            break;
                         }
-
-                        float change = modifier.Get("change", 0f);
-
-                        technology.changeRecipeProductivity.Add(recipe, change);
-                        recipe.technologyProductivity.Add(technology, change);
-
-                        break;
-                    }
                 }
             }
         }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -118,9 +118,19 @@ internal partial class FactorioDataDeserializer {
         }
 
         if (table.Get("effects", out LuaTable? modifiers)) {
-            technology.unlockRecipes = modifiers.ArrayElements<LuaTable>()
-            .Select(x => x.Get("type", out string? type) && type == "unlock-recipe" && GetRef<Recipe>(x, "recipe", out var recipe) ? recipe : null).WhereNotNull()
-            .ToArray();
+            foreach (LuaTable modifier in modifiers.ArrayElements<LuaTable>()) {
+                switch (modifier.Get("type", "")) {
+                    case "unlock-recipe": {
+                        if (!GetRef<Recipe>(modifier, "recipe", out var recipe)) {
+                            continue;
+                        }
+
+                        technology.unlockRecipes.Add(recipe);
+                        
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/Yafc.UI/ImGui/ImGuiLayout.cs
+++ b/Yafc.UI/ImGui/ImGuiLayout.cs
@@ -289,7 +289,7 @@ public partial class ImGui {
 
         public void Dispose() {
             gui.enableDrawing = initialDrawState;
-            gui.state.top = maximumBottom;
+            gui.state.top = Math.Max(gui.state.top, maximumBottom);
         }
     }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -531,7 +531,7 @@ public class ObjectTooltip : Tooltip {
             }
         }
 
-        if (technology.unlockRecipes.Length > 0) {
+        if (technology.unlockRecipes.Count > 0) {
             BuildSubHeader(gui, "Unlocks recipes");
             using (gui.EnterGroup(contentPadding)) {
                 BuildIconRow(gui, technology.unlockRecipes, 2);

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Yafc.Model;
 using Yafc.UI;
 
@@ -70,6 +72,19 @@ public class PreferencesScreen : PseudoScreen {
             DisplayAmount amount = new(Project.current.settings.researchProductivity, UnitOfMeasure.Percent);
             if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput) && amount.Value >= 0) {
                 Project.current.settings.RecordUndo().researchProductivity = amount.Value;
+            }
+        }
+        
+        IEnumerable<Technology> productivityTech = Database.technologies.all
+            .Where(x => x.changeRecipeProductivity.Count != 0)
+            .OrderBy(x => x.locName);
+        foreach (var tech in productivityTech) {
+            using (gui.EnterRow()) {
+                gui.BuildText($"{tech.locName} Level: ", topOffset: 0.5f);
+                int currentLevel = Project.current.settings.productivityTechnologyLevels.GetValueOrDefault(tech, 0);
+                if (gui.BuildIntegerInput(currentLevel, out int newLevel) && newLevel >= 0) {
+                    Project.current.settings.RecordUndo().productivityTechnologyLevels[tech] = newLevel;
+                }
             }
         }
     }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -74,7 +74,7 @@ public class PreferencesScreen : PseudoScreen {
                 Project.current.settings.RecordUndo().researchProductivity = amount.Value;
             }
         }
-        
+
         IEnumerable<Technology> productivityTech = Database.technologies.all
             .Where(x => x.changeRecipeProductivity.Count != 0)
             .OrderBy(x => x.locName);

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -80,6 +80,7 @@ public class PreferencesScreen : PseudoScreen {
             .OrderBy(x => x.locName);
         foreach (var tech in productivityTech) {
             using (gui.EnterRow()) {
+                gui.BuildFactorioObjectButton(tech, ButtonDisplayStyle.Default);
                 gui.BuildText($"{tech.locName} Level: ", topOffset: 0.5f);
                 int currentLevel = Project.current.settings.productivityTechnologyLevels.GetValueOrDefault(tech, 0);
                 if (gui.BuildIntegerInput(currentLevel, out int newLevel) && newLevel >= 0) {


### PR DESCRIPTION
I was playing over the weekend and needed this to plan out my factory, based on the discussion in #331 this would be option 3
I had to move the "done" button to the top of the screen to avoid it overlapping with the levels, and I couldn't quite figure out how to make a scrollable box

I'm happy to split the PR into the parsing/calculating change vs the UI change if you think there's a nicer UI to be had :) 

<details><summary>Screenshots</summary>
<p>

Preferences screen:
(I have some WIP commits that fix the icon rendering too, I'll clean them up soon)
![image](https://github.com/user-attachments/assets/ec4e7295-c7c6-4295-abab-db90390db1ad)


No tech unlocked:
![image](https://github.com/user-attachments/assets/c3190395-1ff3-4c98-8305-55702ae64cad)

Level 10 plastic (+100% productivity) unlocked:
![image](https://github.com/user-attachments/assets/38c75200-f59c-4011-8e19-7e1cb037ae82)

</p>
</details> 