### PR TITLE
Show total output for scrap

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -304,6 +304,7 @@ public abstract class Goods : FactorioObject {
     public FactorioObject[] miscSources { get; internal set; } = [];
     public Entity[] fuelFor { get; internal set; } = [];
     public abstract UnitOfMeasure flowUnitOfMeasure { get; }
+    public bool isLinkable { get; internal set; } = true;
 
     public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) => collector.Add(production.Concat(miscSources).ToArray(), DependencyList.Flags.Source);
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -66,7 +66,7 @@ public abstract class FactorioObject : IFactorioObjectWrapper, IComparable<Facto
 
     public int CompareTo(FactorioObject? other) => DataUtils.DefaultOrdering.Compare(this, other);
 
-    public virtual bool showInExplorers => true;
+    public bool showInExplorers { get; internal set; } = true;
 }
 
 public class FactorioIconPart(string path) {
@@ -361,8 +361,6 @@ public class Special : Goods {
     public override string type => isPower ? "Power" : "Special";
     public override UnitOfMeasure flowUnitOfMeasure => isVoid ? UnitOfMeasure.None : isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.SpecialGoods;
-    public override bool showInExplorers => !isResearch;
-
     public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
         if (isResearch) {
             collector.Add(Database.technologies.all.ToArray(), DependencyList.Flags.Source);

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -14,6 +14,8 @@ public static class Database {
     public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
     public static Goods voidEnergy { get; internal set; } = null!;
     public static Goods researchUnit { get; internal set; } = null!;
+    public static Goods itemInput { get; internal set; } = null!;
+    public static Goods itemOutput { get; internal set; } = null!;
     public static Goods electricity { get; internal set; } = null!;
     public static Recipe electricityGeneration { get; internal set; } = null!;
     public static Goods heat { get; internal set; } = null!;

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -258,6 +258,10 @@ public class ProjectPreferences(Project owner) : ModelObject<Project>(owner) {
     /// The scale to use when drawing icons that have information stored in their background color, stored as a ratio from 0 to 1.
     /// </summary>
     public float iconScale { get; set; } = .9f;
+    /// <summary>
+    /// The <see cref="Database.itemInput"/> and <see cref="Database.itemOutput"/> pseudo-items will be displayed at or above this ingredient/product count.
+    /// </summary>
+    public int minForTotalItems { get; set; } = 3;
 
     protected internal override void AfterDeserialize() {
         base.AfterDeserialize();

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -61,6 +61,7 @@ internal partial class FactorioDataDeserializer {
             obj.locName = locName;
             obj.locDescr = locDescr;
             obj.iconSpec = [new FactorioIconPart(icon)];
+            obj.isLinkable = false;
             obj.showInExplorers = false;
             rootAccessible.Add(obj);
 
@@ -76,6 +77,7 @@ internal partial class FactorioDataDeserializer {
 
         voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
         voidEnergy.isVoid = true;
+        voidEnergy.isLinkable = false;
         voidEnergy.showInExplorers = false;
         fuels.Add(SpecialNames.Void, voidEnergy);
         rootAccessible.Add(voidEnergy);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -28,6 +28,8 @@ internal partial class FactorioDataDeserializer {
     private readonly Special electricity;
     private readonly Special rocketLaunch;
     private readonly Special researchUnit;
+    private readonly Item totalItemOutput;
+    private readonly Item totalItemInput;
     private readonly EntityEnergy voidEntityEnergy;
     private readonly EntityEnergy laborEntityEnergy;
     private Entity? character;
@@ -53,6 +55,18 @@ internal partial class FactorioDataDeserializer {
             return obj;
         }
 
+        Item createSpecialItem(string name, string locName, string locDescr, string icon) {
+            Item obj = GetObject<Item>(name);
+            obj.factorioType = "special";
+            obj.locName = locName;
+            obj.locDescr = locDescr;
+            obj.iconSpec = [new FactorioIconPart(icon)];
+            obj.showInExplorers = false;
+            rootAccessible.Add(obj);
+
+            return obj;
+        }
+
         electricity = createSpecialObject(true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
             "__core__/graphics/icons/alerts/electricity-icon-unplugged.png", "signal-E");
         fuels.Add(SpecialNames.Electricity, electricity);
@@ -62,6 +76,7 @@ internal partial class FactorioDataDeserializer {
 
         voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
         voidEnergy.isVoid = true;
+        voidEnergy.showInExplorers = false;
         fuels.Add(SpecialNames.Void, voidEnergy);
         rootAccessible.Add(voidEnergy);
 
@@ -70,6 +85,7 @@ internal partial class FactorioDataDeserializer {
         researchUnit = createSpecialObject(false, SpecialNames.ResearchUnit, "Research",
             "This represents one unit of a research task.", "__base__/graphics/icons/compilatron.png", "signal-L");
         researchUnit.isResearch = true;
+        researchUnit.showInExplorers = false;
         Analysis.ExcludeFromAnalysis<CostAnalysis>(researchUnit);
 
         generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, "generating");
@@ -84,6 +100,9 @@ internal partial class FactorioDataDeserializer {
 
         voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
         laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
+
+        totalItemInput = createSpecialItem("item-total-input", "Total item consumption", "This item represents the combined total item input of a multi-ingredient recipe. It can be used to set or measure the number of sushi belts required to supply this recipe row.", "__base__/graphics/icons/signal/signal_I.png");
+        totalItemOutput = createSpecialItem("item-total-output", "Total item production", "This item represents the combined total item output of a multi-product recipe. It can be used to set or measure the number of sushi belts required to handle the products of this recipe row.", "__base__/graphics/icons/signal/signal_O.png");
     }
 
     private T GetObject<T>(string name) where T : FactorioObject, new() => GetObject<T, T>(name);
@@ -120,6 +139,8 @@ internal partial class FactorioDataDeserializer {
         Database.allSciencePacks = [.. sciencePacks];
         Database.voidEnergy = voidEnergy;
         Database.researchUnit = researchUnit;
+        Database.itemInput = totalItemInput;
+        Database.itemOutput = totalItemOutput;
         Database.electricity = electricity;
         Database.electricityGeneration = generatorProduction;
         Database.heat = heat;

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -142,6 +142,7 @@ public class PreferencesScreen : PseudoScreen {
             }
         }
 
+        float textBoxHeight; // measure the height of a text box, for use when drawing the minForTotalItems input box.
         using (gui.EnterRow()) {
             gui.BuildText("Reactor layout:", topOffset: 0.5f);
             if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
@@ -155,7 +156,35 @@ public class PreferencesScreen : PseudoScreen {
                     settings.reactorSizeY = sizeY;
                 }
             }
+            textBoxHeight = gui.lastRect.Height;
         }
+
+        string ioItemMessage = "The I and O items represent the total item input or item output of a recipe row.\nRecipes with at least this many item ingredients or item products will show the pseudo-items after all their real ingredients/products.";
+        using (gui.EnterRowWithHelpIcon(ioItemMessage)) {
+            float captionWidth = gui.GetTextDimensions(out _, "Minimum recipe ingredients or products").X;
+            using (gui.EnterFixedPositioning(captionWidth, 0, new())) { // the height will grow to fit the controls
+                gui.BuildText("Minimum recipe ingredients or products");
+                using (gui.EnterRow(0)) {
+                    // Allocate the horizontal space now but draw the icons first, so the text can be drawn vertically centered.
+                    Rect textRect = gui.AllocateTextRect(out _, "to display the ", TextBlockDisplayStyle.Default());
+                    gui.BuildFactorioObjectButton(Database.itemInput, ButtonDisplayStyle.Default);
+                    gui.BuildFactorioObjectButton(Database.itemOutput, ButtonDisplayStyle.Default);
+                    textRect.Height = gui.lastRect.Height;
+                    gui.DrawText(textRect, "to display the ");
+                    gui.BuildText(" summary items");
+                }
+            }
+            float spacing = (gui.lastRect.Height - textBoxHeight) / 2;
+            using (gui.RemainingRow().EnterFixedPositioning(0, gui.lastRect.Height, new())) {
+                gui.AllocateSpacing(spacing - .5f); // draw the box vertically centered, rather than top-aligned (without this) or full height (without EnterFixedPositioning)
+                if (gui.BuildIntegerInput(prefs.minForTotalItems, out int newValue2)) {
+                    prefs.RecordUndo().minForTotalItems = newValue2;
+                    gui.Rebuild();
+                }
+            }
+        }
+
+        gui.AllocateSpacing();
 
         if (gui.BuildCheckBox("Dark mode", Preferences.Instance.darkMode, out bool newValue)) {
             Preferences.Instance.darkMode = newValue;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -536,7 +536,7 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
                 }
-                if (recipe.Ingredients.Count() >= 3) {
+                if (recipe.fixedIngredient == Database.itemInput || recipe.Ingredients.Count() >= Project.current.preferences.minForTotalItems) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, Database.itemInput, null, recipe.Ingredients.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.None);
@@ -557,7 +557,7 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
                 }
-                if (recipe.Products.Count() >= 3) {
+                if (recipe.fixedProduct == Database.itemOutput || recipe.Products.Count() >= Project.current.preferences.minForTotalItems) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, Database.itemOutput, null, recipe.Products.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.None);

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -538,7 +538,7 @@ goodsHaveNoProduction:;
                 }
                 if (recipe.fixedIngredient == Database.itemInput || recipe.Ingredients.Count() >= Project.current.preferences.minForTotalItems) {
                     grid.Next();
-                    view.BuildGoodsIcon(gui, Database.itemInput, null, recipe.Ingredients.Where(i => i.Goods is Item).Sum(i => i.Amount),
+                    view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemInput : null, null, recipe.Ingredients.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.None);
                 }
             }
@@ -559,7 +559,7 @@ goodsHaveNoProduction:;
                 }
                 if (recipe.fixedProduct == Database.itemOutput || recipe.Products.Count() >= Project.current.preferences.minForTotalItems) {
                     grid.Next();
-                    view.BuildGoodsIcon(gui, Database.itemOutput, null, recipe.Products.Where(i => i.Goods is Item).Sum(i => i.Amount),
+                    view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemOutput : null, null, recipe.Products.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.None);
                 }
             }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -536,6 +536,11 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
                 }
+                if (recipe.Ingredients.Count() >= 3) {
+                    grid.Next();
+                    view.BuildGoodsIcon(gui, Database.itemInput, null, recipe.Ingredients.Where(i => i.Goods is Item).Sum(i => i.Amount),
+                        ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.None);
+                }
             }
             grid.Dispose();
         }
@@ -551,6 +556,11 @@ goodsHaveNoProduction:;
                 foreach (var (goods, amount, link) in recipe.Products) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
+                }
+                if (recipe.Products.Count() >= 3) {
+                    grid.Next();
+                    view.BuildGoodsIcon(gui, Database.itemOutput, null, recipe.Products.Where(i => i.Goods is Item).Sum(i => i.Amount),
+                        ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.None);
                 }
             }
             grid.Dispose();

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Features:
+        - Add pseudo-items representing a recipe's total sushi-inputs and sushi-outputs.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.1.0
 Date: October 29th 2024
     Features:


### PR DESCRIPTION
When drawing a recipe with several item inputs or outputs, the UI will add synthetic [I] or [O] items, representing the total sushi input or output:
![image](https://github.com/user-attachments/assets/36434894-c80d-4688-823d-0586b027ecb3)

The default count is three, but it can be changed in the preferences:
![image](https://github.com/user-attachments/assets/3f1d6265-bc07-412c-8342-83bb7d42735a)

These synthetic items can't be linked, but you can set a fixed count for them if you want a particular number of sushi-belts of production or consumption.