### PR TITLE
Add per-recipe setting to show/hide the total I/O

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -457,6 +457,7 @@ public abstract class EntityWithModules : Entity {
 public class EntityCrafter : EntityWithModules {
     public int itemInputs { get; internal set; }
     public int fluidInputs { get; internal set; } // fluid inputs for recipe, not including power
+    public bool hasVectorToPlaceResult { get; internal set; }
     public Goods[]? inputs { get; internal set; }
     public RecipeOrTechnology[] recipes { get; internal set; } = null!; // null-forgiving: Set in the first step of CalculateMaps
     private float _craftingSpeed = 1;

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -358,7 +358,7 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
     /// <summary>
     /// If <see langword="true"/>, the total item consumption and production signals are shown.
     /// </summary>
-    public bool showIO { get; set; } = false;
+    public bool showTotalIO { get; set; } = false;
     /// <summary>
     /// If <see langword="true"/>, the enabled checkbox for this recipe is checked.
     /// </summary>

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -356,6 +356,10 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
     }
     public int? builtBuildings { get; set; }
     /// <summary>
+    /// If <see langword="true"/>, the total item consumption and production signals are shown.
+    /// </summary>
+    public bool showIO { get; set; } = false;
+    /// <summary>
     /// If <see langword="true"/>, the enabled checkbox for this recipe is checked.
     /// </summary>
     public bool enabled { get; set; } = true;

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -258,10 +258,6 @@ public class ProjectPreferences(Project owner) : ModelObject<Project>(owner) {
     /// The scale to use when drawing icons that have information stored in their background color, stored as a ratio from 0 to 1.
     /// </summary>
     public float iconScale { get; set; } = .9f;
-    /// <summary>
-    /// The <see cref="Database.itemInput"/> and <see cref="Database.itemOutput"/> pseudo-items will be displayed at or above this ingredient/product count.
-    /// </summary>
-    public int minForTotalItems { get; set; } = 3;
 
     protected internal override void AfterDeserialize() {
         base.AfterDeserialize();

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -289,6 +289,10 @@ internal partial class FactorioDataDeserializer {
                     crafter.fluidInputs = CountFluidBoxes(fluidBoxes, true);
                 }
 
+                if (table.Get("vector_to_place_result", out LuaTable? hasVectorToPlaceResult)) {
+                    crafter.hasVectorToPlaceResult = hasVectorToPlaceResult != null;
+                }
+
                 Recipe? fixedRecipe = null;
 
                 if (table.Get("fixed_recipe", out string? fixedRecipeName)) {
@@ -359,6 +363,9 @@ internal partial class FactorioDataDeserializer {
                 if (table.Get("input_fluid_box", out LuaTable? _)) {
                     drill.fluidInputs = 1;
                 }
+
+                // All drills have/require the vector_to_place_result to drop their items
+                drill.hasVectorToPlaceResult = true;
 
                 foreach (string resource in resourceCategories.ArrayElements<string>()) {
                     recipeCrafters.Add(drill, SpecialNames.MiningRecipe + resource);

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -142,7 +142,7 @@ public class PreferencesScreen : PseudoScreen {
             }
         }
 
-        float textBoxHeight; // measure the height of a text box, for use when drawing the minForTotalItems input box.
+        float textBoxHeight; // measure the height of a text box, for use when drawing the item consumption input box.
         using (gui.EnterRow()) {
             gui.BuildText("Reactor layout:", topOffset: 0.5f);
             if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
@@ -157,31 +157,6 @@ public class PreferencesScreen : PseudoScreen {
                 }
             }
             textBoxHeight = gui.lastRect.Height;
-        }
-
-        string ioItemMessage = "The I and O items represent the total item input or item output of a recipe row.\nRecipes with at least this many item ingredients or item products will show the pseudo-items after all their real ingredients/products.";
-        using (gui.EnterRowWithHelpIcon(ioItemMessage)) {
-            float captionWidth = gui.GetTextDimensions(out _, "Minimum recipe ingredients or products").X;
-            using (gui.EnterFixedPositioning(captionWidth, 0, new())) { // the height will grow to fit the controls
-                gui.BuildText("Minimum recipe ingredients or products");
-                using (gui.EnterRow(0)) {
-                    // Allocate the horizontal space now but draw the icons first, so the text can be drawn vertically centered.
-                    Rect textRect = gui.AllocateTextRect(out _, "to display the ", TextBlockDisplayStyle.Default());
-                    gui.BuildFactorioObjectButton(Database.itemInput, ButtonDisplayStyle.Default);
-                    gui.BuildFactorioObjectButton(Database.itemOutput, ButtonDisplayStyle.Default);
-                    textRect.Height = gui.lastRect.Height;
-                    gui.DrawText(textRect, "to display the ");
-                    gui.BuildText(" summary items");
-                }
-            }
-            float spacing = (gui.lastRect.Height - textBoxHeight) / 2;
-            using (gui.RemainingRow().EnterFixedPositioning(0, gui.lastRect.Height, new())) {
-                gui.AllocateSpacing(spacing - .5f); // draw the box vertically centered, rather than top-aligned (without this) or full height (without EnterFixedPositioning)
-                if (gui.BuildIntegerInput(prefs.minForTotalItems, out int newValue2)) {
-                    prefs.RecordUndo().minForTotalItems = newValue2;
-                    gui.Rebuild();
-                }
-            }
         }
 
         gui.AllocateSpacing();

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -142,7 +142,6 @@ public class PreferencesScreen : PseudoScreen {
             }
         }
 
-        float textBoxHeight; // measure the height of a text box, for use when drawing the item consumption input box.
         using (gui.EnterRow()) {
             gui.BuildText("Reactor layout:", topOffset: 0.5f);
             if (gui.BuildTextInput(settings.reactorSizeX + "x" + settings.reactorSizeY, out string newSize, null, delayed: true)) {
@@ -156,7 +155,6 @@ public class PreferencesScreen : PseudoScreen {
                     settings.reactorSizeY = sizeY;
                 }
             }
-            textBoxHeight = gui.lastRect.Height;
         }
 
         gui.AllocateSpacing();

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -134,8 +134,8 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                             view.BuildShoppingList(recipe);
                         }
 
-                        if (imgui.BuildCheckBox("Show item Input/Output", recipe.showIO, out bool newShowIO)) {
-                            recipe.RecordUndo().showIO = newShowIO;
+                        if (imgui.BuildCheckBox("Show total Input/Output", recipe.showTotalIO, out bool newShowTotalIO)) {
+                            recipe.RecordUndo().showTotalIO = newShowTotalIO;
                         }
 
                         if (imgui.BuildCheckBox("Enabled", recipe.enabled, out bool newEnabled)) {
@@ -542,7 +542,7 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
                 }
-                if (recipe.fixedIngredient == Database.itemInput || recipe.showIO) {
+                if (recipe.fixedIngredient == Database.itemInput || recipe.showTotalIO) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemInput : null, null, recipe.Ingredients.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.None);
@@ -563,7 +563,7 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
                 }
-                if (recipe.fixedProduct == Database.itemOutput || recipe.showIO) {
+                if (recipe.fixedProduct == Database.itemOutput || recipe.showTotalIO) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemOutput : null, null, recipe.Products.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.None);

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -134,6 +134,10 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                             view.BuildShoppingList(recipe);
                         }
 
+                        if (imgui.BuildCheckBox("Show item Input/Output", recipe.showIO, out bool newShowIO)) {
+                            recipe.RecordUndo().showIO = newShowIO;
+                        }
+
                         if (imgui.BuildCheckBox("Enabled", recipe.enabled, out bool newEnabled)) {
                             recipe.RecordUndo().enabled = newEnabled;
                         }
@@ -538,7 +542,7 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
                 }
-                if (recipe.fixedIngredient == Database.itemInput || recipe.Ingredients.Count() >= Project.current.preferences.minForTotalItems) {
+                if (recipe.fixedIngredient == Database.itemInput || recipe.showIO) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemInput : null, null, recipe.Ingredients.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.None);
@@ -559,7 +563,7 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
                 }
-                if (recipe.fixedProduct == Database.itemOutput || recipe.Products.Count() >= Project.current.preferences.minForTotalItems) {
+                if (recipe.fixedProduct == Database.itemOutput || recipe.showIO) {
                     grid.Next();
                     view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemOutput : null, null, recipe.Products.Where(i => i.Goods is Item).Sum(i => i.Amount),
                         ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.None);

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
         - Add pseudo-items representing a recipe's total sushi-inputs and sushi-outputs.
+          They can be toggled on/off in the LMB of the recipe.
     Bugfixes:
         - Fixed counts are hidden on disabled recipes, since editing them won't work properly.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As discussed in #338 it might be more convenient to make the recipe total I/O configurable per recipe, sicne we cannot figure out a 'catch all' that covers all of the seablock, py and space-age, etc. mods...

The screenshot shows the same recipe twice, one with I/O enabled and one disabled:
![image](https://github.com/user-attachments/assets/4f62fd0c-e65a-4f8a-be28-6c94331d6e91)
*Note that the label is renamed to "Show total Input/Output"*
