### PR TITLE
fix: Hide non-functional fixed counts on disabled recipe rows.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,8 @@ Version:
 Date:
     Features:
         - Add pseudo-items representing a recipe's total sushi-inputs and sushi-outputs.
+    Bugfixes:
+        - Fixed counts are hidden on disabled recipes, since editing them won't work properly.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.1.0
 Date: October 29th 2024


### PR DESCRIPTION
Yafc thought it was a good idea to show me
![image](https://github.com/user-attachments/assets/4021f559-3479-4016-ada3-d780863ed694)
(Set a fixed fuel consumption, then disable the recipe)

None of those inputs work usefully, and making them work would require significant refactoring, so the fixed counts are now hidden on disabled recipes. The "Clear fixed recipe multiplier" button still works, but if you want to make any other changes to the fixed multiplier, you have to enable the recipe first.