### PR TITLE
Non-recipe quality selection

### DIFF
--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -28,7 +28,7 @@ public class ProductionTableContentTests {
         // assert will ensure the currently fixed value has not changed by more than 0.01%.
         static void testCombinations(RecipeRow row, ProductionTable table, Action assert) {
             foreach (EntityCrafter crafter in Database.allCrafters) {
-                row.entity = crafter;
+                row.entity = (crafter, Quality.Normal);
 
                 foreach (Goods fuel in crafter.energy.fuels) {
                     row.fuel = fuel;
@@ -70,7 +70,7 @@ public class ProductionTableContentTests {
         // Call assert for each combination. assert will ensure the currently fixed value has not changed by more than 0.01%.
         void testCombinations(RecipeRow row, ProductionTable table, Action assert) {
             foreach (EntityCrafter crafter in Database.allCrafters) {
-                row.entity = crafter;
+                row.entity = (crafter, Quality.Normal);
 
                 foreach (Goods fuel in crafter.energy.fuels) {
                     row.fuel = fuel;
@@ -140,7 +140,7 @@ public class ProductionTableContentTests {
 
         // The complicated tests for when the fixed value is expected to reset when fixed fuels are involved.
         Action testFuel(RecipeRow row, ProductionTable table) => () => {
-            if (row.entity.energy.fuels.Contains(oldFuel)) {
+            if (row.entity.target.energy.fuels.Contains(oldFuel)) {
                 Assert.Equal(fuelAmount, row.FuelInformation.Amount, fuelAmount * .0001);
                 assertCalls++;
             }

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -18,7 +18,7 @@ public class ProductionTableContentTests {
         RecipeRow row = table.GetAllRecipes().Single();
 
         table.modules.beacon = Database.allBeacons.Single();
-        table.modules.beaconModule = Database.allModules.Single(m => m.name == "speed-module");
+        table.modules.beaconModule = new(Database.allModules.Single(m => m.name == "speed-module"), Quality.Normal);
         table.modules.beaconsPerBuilding = 2;
         table.modules.autoFillPayback = MathF.Sqrt(float.MaxValue);
 
@@ -37,7 +37,7 @@ public class ProductionTableContentTests {
                         ModuleTemplateBuilder builder = new();
 
                         if (module != null) {
-                            builder.list.Add((module, 0));
+                            builder.list.Add((new(module, Quality.Normal), 0));
                         }
 
                         row.modules = builder.Build(row);
@@ -83,13 +83,13 @@ public class ProductionTableContentTests {
                                     // The ProductionTable.modules setter must notify all relevant recipes if it is added.
                                     _ = method.Invoke(table, [new ModuleFillerParameters(table) {
                                         beacon = beacon,
-                                        beaconModule = module,
+                                        beaconModule = new(module, Quality.Normal),
                                         beaconsPerBuilding = beaconCount,
                                     }]);
                                 }
                                 else {
                                     table.modules.beacon = beacon;
-                                    table.modules.beaconModule = module;
+                                    table.modules.beaconModule = new(module, Quality.Normal);
                                     table.modules.beaconsPerBuilding = beaconCount;
                                 }
                                 table.Solve((ProjectPage)table.owner).Wait();

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -17,7 +17,7 @@ public class ProductionTableContentTests {
         table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
-        table.modules.beacon = Database.allBeacons.Single();
+        table.modules.beacon = new(Database.allBeacons.Single(), Quality.Normal);
         table.modules.beaconModule = new(Database.allModules.Single(m => m.name == "speed-module"), Quality.Normal);
         table.modules.beaconsPerBuilding = 2;
         table.modules.autoFillPayback = MathF.Sqrt(float.MaxValue);
@@ -82,13 +82,13 @@ public class ProductionTableContentTests {
                                     // Pre-emptive code for if ProductionTable.modules is made writable.
                                     // The ProductionTable.modules setter must notify all relevant recipes if it is added.
                                     _ = method.Invoke(table, [new ModuleFillerParameters(table) {
-                                        beacon = beacon,
+                                        beacon = new(beacon, Quality.Normal),
                                         beaconModule = new(module, Quality.Normal),
                                         beaconsPerBuilding = beaconCount,
                                     }]);
                                 }
                                 else {
-                                    table.modules.beacon = beacon;
+                                    table.modules.beacon = new(beacon, Quality.Normal);
                                     table.modules.beaconModule = new(module, Quality.Normal);
                                     table.modules.beaconsPerBuilding = beaconCount;
                                 }

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -28,7 +28,7 @@ public class ProductionTableContentTests {
         // assert will ensure the currently fixed value has not changed by more than 0.01%.
         static void testCombinations(RecipeRow row, ProductionTable table, Action assert) {
             foreach (EntityCrafter crafter in Database.allCrafters) {
-                row.entity = (crafter, Quality.Normal);
+                row.entity = new(crafter, Quality.Normal);
 
                 foreach (Goods fuel in crafter.energy.fuels) {
                     row.fuel = fuel;
@@ -70,7 +70,7 @@ public class ProductionTableContentTests {
         // Call assert for each combination. assert will ensure the currently fixed value has not changed by more than 0.01%.
         void testCombinations(RecipeRow row, ProductionTable table, Action assert) {
             foreach (EntityCrafter crafter in Database.allCrafters) {
-                row.entity = (crafter, Quality.Normal);
+                row.entity = new(crafter, Quality.Normal);
 
                 foreach (Goods fuel in crafter.energy.fuels) {
                     row.fuel = fuel;

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -135,7 +135,7 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
                     minSize = crafter.size;
                 }
 
-                float power = crafter.energy.type == EntityEnergyType.Void ? 0f : recipe.time * crafter.power / (crafter.craftingSpeed * crafter.energy.effectivity);
+                float power = crafter.energy.type == EntityEnergyType.Void ? 0f : recipe.time * crafter.basePower / (crafter.baseCraftingSpeed * crafter.energy.effectivity);
 
                 if (power < minPower) {
                     minPower = power;

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -98,6 +98,7 @@ public class BlueprintSignal {
 public class BlueprintEntity {
     [JsonPropertyName("entity_number")] public int index { get; set; }
     public string? name { get; set; }
+    public string? quality { get; set; }
     public BlueprintPosition position { get; set; } = new BlueprintPosition();
     public int direction { get; set; }
     public string? recipe { get; set; }

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -105,7 +105,7 @@ public class BlueprintEntity {
     [JsonPropertyName("control_behavior")] public BlueprintControlBehavior? controlBehavior { get; set; }
     public BlueprintConnection? connections { get; set; }
     [JsonPropertyName("request_filters")] public List<BlueprintRequestFilter> requestFilters { get; } = [];
-    public Dictionary<string, int>? items { get; set; }
+    public List<BlueprintItem> items { get; } = [];
 
     public void Connect(BlueprintEntity other, bool red = true, bool secondPort = false, bool targetSecond = false) {
         ConnectSingle(other, red, secondPort, targetSecond);
@@ -168,4 +168,27 @@ public class BlueprintControlFilter {
     public BlueprintSignal signal { get; set; } = new BlueprintSignal();
     public int index { get; set; }
     public int count { get; set; }
+}
+
+[Serializable]
+public class BlueprintItem {
+    public BlueprintId id { get; } = new();
+    public BlueprintItemInventory items { get; } = new();
+}
+
+[Serializable]
+public class BlueprintId {
+    public string? name { get; set; }
+    public string? quality { get; set; }
+}
+
+[Serializable]
+public class BlueprintItemInventory {
+    [JsonPropertyName("in_inventory")] public List<BlueprintInventoryItem> inInventory { get; } = [];
+}
+
+[Serializable]
+public class BlueprintInventoryItem {
+    public int inventory { get; } = 4; // unknown magic number
+    public int stack { get; set; }
 }

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -189,6 +189,6 @@ public class BlueprintItemInventory {
 
 [Serializable]
 public class BlueprintInventoryItem {
-    public int inventory { get; } = 4; // unknown magic number
+    public int inventory { get; } = 4; // unknown magic number (probably 'modules', needs more investigating)
     public int stack { get; set; }
 }

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -478,7 +478,7 @@ public class EntityCrafter : EntityWithModules {
         get => _craftingSpeed * (1 + (factorioType == "lab" ? Project.current.settings.researchSpeedBonus : 0));
         internal set => _craftingSpeed = value;
     }
-    public EffectReceiver? effectReceiver { get; internal set; } = null!;
+    public EffectReceiver effectReceiver { get; internal set; } = null!;
 }
 
 public sealed class Quality : FactorioObject {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -529,6 +529,8 @@ public sealed class Quality : FactorioObject {
     // applies the standard +30% per level bonus, but with the exception that the result is floored to the nearest hundredth
     // Modules use this: a 25% normal bonus is a 32% uncommon bonus, not 32.5%.
     internal float ApplyModuleBonus(float baseValue) => MathF.Floor(ApplyStandardBonus(baseValue) * 100) / 100;
+    // applies the .2 per level beacon transmission bonus
+    internal float ApplyBeaconBonus(float baseValue) => baseValue + level * .2f;
 }
 
 /// <summary>
@@ -643,7 +645,8 @@ public class EntityReactor : EntityCrafter {
 }
 
 public class EntityBeacon : EntityWithModules {
-    public float beaconEfficiency { get; internal set; }
+    public float baseBeaconEfficiency { get; internal set; }
+    public float BeaconEfficiency(Quality quality) => quality.ApplyBeaconBonus(baseBeaconEfficiency);
     public float[] profile { get; internal set; } = null!;
 
     public float GetProfile(int numberOfBeacons) {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -414,8 +414,8 @@ public class Entity : FactorioObject {
     public float basePower { get; internal set; }
     public float Power(Quality quality)
         => factorioType is "boiler" or "reactor" or "generator" or "burner-generator" ? quality.ApplyStandardBonus(basePower)
+        : factorioType is "beacon" ? basePower * quality.BeaconConsumptionFactor
         : basePower;
-
     public EntityEnergy energy { get; internal set; } = null!; // TODO: Prove that this is always properly initialized. (Do we need an EntityWithEnergy type?)
     public Item[] itemsToPlace { get; internal set; } = null!; // null-forgiving: This is initialized in CalculateMaps.
     public int size { get; internal set; }
@@ -531,6 +531,11 @@ public sealed class Quality : FactorioObject {
     internal float ApplyModuleBonus(float baseValue) => MathF.Floor(ApplyStandardBonus(baseValue) * 100) / 100;
     // applies the .2 per level beacon transmission bonus
     internal float ApplyBeaconBonus(float baseValue) => baseValue + level * .2f;
+
+    public float StandardBonus => .3f * level;
+    public float AccumulatorCapacityBonus => level;
+    public float BeaconTransmissionBonus => .2f * level;
+    public float BeaconConsumptionFactor { get; internal set; }
 }
 
 /// <summary>

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -141,7 +141,8 @@ public abstract class RecipeOrTechnology : FactorioObject {
         return true;
     }
 
-    public virtual bool CanAcceptModule(Item _) => true;
+    public bool CanAcceptModule(ObjectWithQuality<Module> module) => CanAcceptModule(module.target);
+    public virtual bool CanAcceptModule(Module _) => true;
 }
 
 public enum FactorioObjectSpecialType {
@@ -176,7 +177,7 @@ public class Recipe : RecipeOrTechnology {
         }
     }
 
-    public override bool CanAcceptModule(Item module) => EntityWithModules.CanAcceptModule(((Module)module).moduleSpecification, allowedEffects, allowedModuleCategories);
+    public override bool CanAcceptModule(Module module) => EntityWithModules.CanAcceptModule(module.moduleSpecification, allowedEffects, allowedModuleCategories);
 }
 
 public class Mechanics : Recipe {
@@ -467,6 +468,7 @@ public abstract class EntityWithModules : Entity {
         return true;
     }
 
+    public bool CanAcceptModule<T>(ObjectWithQuality<T> module) where T : Module => CanAcceptModule(module.target.moduleSpecification);
     public bool CanAcceptModule(ModuleSpecification module) => CanAcceptModule(module, allowedEffects, allowedModuleCategories);
 }
 

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -61,8 +61,8 @@ public static partial class DataUtils {
             return Comparer<EntityEnergyType?>.Default.Compare(x.energy?.type, y.energy?.type);
         }
 
-        if (x.craftingSpeed != y.craftingSpeed) {
-            return y.craftingSpeed.CompareTo(x.craftingSpeed);
+        if (x.baseCraftingSpeed != y.baseCraftingSpeed) {
+            return y.baseCraftingSpeed.CompareTo(x.baseCraftingSpeed);
         }
 
         return x.Cost().CompareTo(y.Cost());

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -37,6 +37,7 @@ public static class Database {
     public static FactorioIdRange<RecipeOrTechnology> recipesAndTechnologies { get; internal set; } = null!;
     public static FactorioIdRange<Technology> technologies { get; internal set; } = null!;
     public static FactorioIdRange<Entity> entities { get; internal set; } = null!;
+    public static FactorioIdRange<Quality> qualities { get; internal set; } = null!;
     public static int constantCombinatorCapacity { get; internal set; } = 18;
 
     /// <summary>

--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -93,7 +93,7 @@ public class ModuleFillerParameters : ModelObject<ModelObject> {
 
         Action? result = null;
         foreach (RecipeRow recipe in table.GetAllRecipes()) {
-            if (crafter == null || crafter == recipe.entity) {
+            if (crafter == null || crafter == recipe.entity?.target) {
                 result += recipe.ModuleFillerParametersChanging();
             }
         }

--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -30,7 +30,6 @@ public record BeaconConfiguration(EntityBeacon? beacon, int beaconCount, Module?
 /// The settings (used by root <see cref="ProductionTable"/>s) for what modules and beacons should be used for a recipe, in the absence of any per-<see cref="RecipeRow"/> settings.
 /// </summary>
 /// <remarks>This class handles its own <see cref="DataUtils.RecordUndo{T}(T, bool)"/> calls.</remarks>
-[Serializable]
 public class ModuleFillerParameters : ModelObject<ModelObject> {
     private bool _fillMiners;
     private float _autoFillPayback;

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -105,7 +105,7 @@ public class ProductionTable : ProjectPageContents, IComparer<ProductionTableFlo
                 goto match;
             }
 
-            if (recipe.recipe.Match(query) || recipe.fuel.Match(query) || recipe.entity.Match(query)) {
+            if (recipe.recipe.Match(query) || recipe.fuel.Match(query) || (recipe.entity?.target).Match(query)) {
                 goto match;
             }
 
@@ -154,12 +154,12 @@ match:
         EntityCrafter? selectedFuelCrafter = GetSelectedFuelCrafter(recipe, selectedFuel);
         EntityCrafter? spentFuelRecipeCrafter = GetSpentFuelCrafter(recipe, spentFuel);
 
-        recipeRow.entity = selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
+        recipeRow.entity = (selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter), Quality.Normal);
 
         if (recipeRow.entity != null) {
             recipeRow.fuel = GetSelectedFuel(selectedFuel, recipeRow)
                 ?? GetFuelForSpentFuel(spentFuel, recipeRow)
-                ?? recipeRow.entity.energy?.fuels.AutoSelect(DataUtils.FavoriteFuel);
+                ?? recipeRow.entity.target.energy?.fuels.AutoSelect(DataUtils.FavoriteFuel);
         }
 
         foreach (Ingredient ingredient in recipeRow.recipe.ingredients) {
@@ -189,13 +189,13 @@ match:
             return null;
         }
 
-        return recipeRow.entity?.energy.fuels.Where(e => spentFuel.miscSources.Contains(e))
+        return recipeRow.entity?.target.energy.fuels.Where(e => spentFuel.miscSources.Contains(e))
             .AutoSelect(DataUtils.FavoriteFuel);
     }
 
     private static Goods? GetSelectedFuel(Goods? selectedFuel, [NotNull] RecipeRow recipeRow) =>
         // Skipping AutoSelect since there will only be one result at most.
-        recipeRow.entity?.energy?.fuels.FirstOrDefault(e => e == selectedFuel);
+        recipeRow.entity?.target.energy?.fuels.FirstOrDefault(e => e == selectedFuel);
 
     /// <summary>
     /// Get all <see cref="RecipeRow"/>s contained in this <see cref="ProductionTable"/>, in a depth-first ordering. (The same as in the UI when all nested tables are expanded.)

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -15,42 +15,42 @@ public struct ModuleEffects {
     public readonly float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
     public void AddModules(ObjectWithQuality<Module> module, float count, AllowedEffects allowedEffects) {
         ModuleSpecification spec = module.target.moduleSpecification;
+        Quality quality = module.quality;
         if (allowedEffects.HasFlags(AllowedEffects.Speed)) {
-            speed += spec.speed * count;
+            speed += spec.Speed(quality) * count;
         }
 
-        if (allowedEffects.HasFlags(AllowedEffects.Productivity) && spec.productivity > 0f) {
-            productivity += spec.productivity * count;
+        if (allowedEffects.HasFlags(AllowedEffects.Productivity) && spec.baseProductivity > 0f) {
+            productivity += spec.Productivity(quality) * count;
         }
 
         if (allowedEffects.HasFlags(AllowedEffects.Consumption)) {
-            consumption += spec.consumption * count;
+            consumption += spec.Consumption(quality) * count;
         }
     }
 
     public void AddModules(ObjectWithQuality<Module> module, float count) {
         ModuleSpecification spec = module.target.moduleSpecification;
-        speed += spec.speed * count;
+        Quality quality = module.quality;
+        speed += spec.Speed(quality) * count;
 
-        if (spec.productivity > 0f) {
-            productivity += spec.productivity * count;
+        if (spec.baseProductivity > 0f) {
+            productivity += spec.Productivity(quality) * count;
         }
 
-        consumption += spec.consumption * count;
+        consumption += spec.Consumption(quality) * count;
     }
 
     public readonly int GetModuleSoftLimit(ObjectWithQuality<Module> module, int hardLimit) {
         ModuleSpecification spec = module.target.moduleSpecification;
-        if (spec == null) {
-            return 0;
-        }
+        Quality quality = module.quality;
 
-        if (spec.productivity > 0f || spec.speed > 0f || spec.pollution < 0f) {
+        if (spec.baseProductivity > 0f || spec.baseSpeed > 0f || spec.basePollution < 0f) {
             return hardLimit;
         }
 
-        if (spec.consumption < 0f) {
-            return MathUtils.Clamp(MathUtils.Ceil(-(consumption + 0.8f) / spec.consumption), 0, hardLimit);
+        if (spec.baseConsumption < 0f) {
+            return MathUtils.Clamp(MathUtils.Ceil(-(consumption + 0.8f) / spec.Consumption(quality)), 0, hardLimit);
         }
 
         return 0;
@@ -541,12 +541,7 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
         CreateUndoSnapshot();
         modules = null;
     }
-    public void SetFixedModule(ObjectWithQuality<Module>? module) {
-        if (module == null) {
-            RemoveFixedModules();
-            return;
-        }
-
+    public void SetFixedModule(ObjectWithQuality<Module> module) {
         ModuleTemplateBuilder builder = modules?.GetBuilder() ?? new();
         builder.list = [(module, 0)];
         this.RecordUndo().modules = builder.Build(this);

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -75,7 +75,7 @@ public class ModuleTemplate : ModelObject<ModelObject> {
     /// <summary>
     /// The beacon to use, if any, for the associated <see cref="RecipeRow"/>.
     /// </summary>
-    public EntityBeacon? beacon { get; }
+    public ObjectWithQuality<EntityBeacon>? beacon { get; }
     /// <summary>
     /// The modules, if any, to directly insert into the crafting entity.
     /// </summary>
@@ -85,7 +85,7 @@ public class ModuleTemplate : ModelObject<ModelObject> {
     /// </summary>
     public ReadOnlyCollection<RecipeRowCustomModule> beaconList { get; private set; } = new([]); // Must be a distinct collection object to accommodate the deserializer.
 
-    private ModuleTemplate(ModelObject owner, EntityBeacon? beacon) : base(owner) => this.beacon = beacon;
+    private ModuleTemplate(ModelObject owner, ObjectWithQuality<EntityBeacon>? beacon) : base(owner) => this.beacon = beacon;
 
     public bool IsCompatibleWith([NotNullWhen(true)] RecipeRow? row) {
         if (row?.entity == null) {
@@ -141,7 +141,7 @@ public class ModuleTemplate : ModelObject<ModelObject> {
         if (beacon != null) {
             int beaconCount = CalcBeaconCount();
             if (beaconCount > 0) {
-                float beaconEfficiency = beacon.beaconEfficiency * beacon.GetProfile(beaconCount);
+                float beaconEfficiency = beacon.GetBeaconEfficiency() * beacon.target.GetProfile(beaconCount);
                 foreach (var module in beaconList) {
                     beaconedModules += module.fixedCount;
                     buffer.Add((module.module, module.fixedCount, true));
@@ -170,7 +170,7 @@ public class ModuleTemplate : ModelObject<ModelObject> {
             moduleCount += element.fixedCount;
         }
 
-        return ((moduleCount - 1) / beacon.moduleSlots) + 1;
+        return ((moduleCount - 1) / beacon.target.moduleSlots) + 1;
     }
 
     /// <summary>
@@ -203,7 +203,7 @@ public class ModuleTemplateBuilder {
     /// <summary>
     /// The beacon to be stored in <see cref="ModuleTemplate.beacon"/> after building.
     /// </summary>
-    public EntityBeacon? beacon { get; set; }
+    public ObjectWithQuality<EntityBeacon>? beacon { get; set; }
     /// <summary>
     /// The list of <see cref="Module"/>s and counts to be stored in <see cref="ModuleTemplate.list"/> after building.
     /// </summary>

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -58,7 +58,6 @@ public struct ModuleEffects {
 /// One module that is (or will be) applied to a <see cref="RecipeRow"/>, and the number of times it should appear.
 /// </summary>
 /// <remarks>Immutable. To modify, modify the owning <see cref="ModuleTemplate"/>.</remarks>
-[Serializable]
 public class RecipeRowCustomModule(ModuleTemplate owner, Module module, int fixedCount = 0) : ModelObject<ModuleTemplate>(owner) {
     public Module module { get; } = module ?? throw new ArgumentNullException(nameof(module));
     public int fixedCount { get; } = fixedCount;

--- a/Yafc.Model/Model/QualityExtensions.cs
+++ b/Yafc.Model/Model/QualityExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace Yafc.Model;
+
+public static class QualityExtensions {
+    public static float GetCraftingSpeed(this IObjectWithQuality<EntityCrafter> crafter) => crafter.target.CraftingSpeed(crafter.quality);
+
+    public static float GetPower(this IObjectWithQuality<Entity> entity) => entity.target.Power(entity.quality);
+}

--- a/Yafc.Model/Model/QualityExtensions.cs
+++ b/Yafc.Model/Model/QualityExtensions.cs
@@ -4,4 +4,6 @@ public static class QualityExtensions {
     public static float GetCraftingSpeed(this IObjectWithQuality<EntityCrafter> crafter) => crafter.target.CraftingSpeed(crafter.quality);
 
     public static float GetPower(this IObjectWithQuality<Entity> entity) => entity.target.Power(entity.quality);
+
+    public static float GetBeaconEfficiency(this IObjectWithQuality<EntityBeacon> beacon) => beacon.target.BeaconEfficiency(beacon.quality);
 }

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -28,7 +28,7 @@ public enum WarningFlags {
 }
 
 public struct UsedModule {
-    public (Module module, int count, bool beacon)[]? modules;
+    public (ObjectWithQuality<Module> module, int count, bool beacon)[]? modules;
     public Entity? beacon;
     public int beaconCount;
 }

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -60,10 +60,10 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
             productivity = 0f;
         }
         else {
-            recipeTime = recipe.time / entity.target.craftingSpeed;
+            recipeTime = recipe.time / entity.GetCraftingSpeed();
             productivity = entity.target.effectReceiver.baseEffect.productivity;
             EntityEnergy energy = entity.target.energy;
-            float energyUsage = entity.target.power;
+            float energyUsage = entity.GetPower();
             float energyPerUnitOfFuel = 0f;
 
             // Special case for fuel
@@ -109,8 +109,8 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
             // Special case for generators
             if (recipe.flags.HasFlags(RecipeFlags.ScaleProductionWithPower) && energyPerUnitOfFuel > 0 && entity.target.energy.type != EntityEnergyType.Void) {
                 if (energyUsage == 0) {
-                    fuelUsagePerSecondPerBuilding = energy.fuelConsumptionLimit;
-                    recipeTime = 1f / (energy.fuelConsumptionLimit * energyPerUnitOfFuel * energy.effectivity);
+                    fuelUsagePerSecondPerBuilding = energy.FuelConsumptionLimit(entity.quality);
+                    recipeTime = 1f / (energy.FuelConsumptionLimit(entity.quality) * energyPerUnitOfFuel * energy.effectivity);
                 }
                 else {
                     recipeTime = 1f / energyUsage;
@@ -159,9 +159,9 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
                 fuelUsagePerSecondPerBuilding += energy.drain / energyPerUnitOfFuel;
             }
 
-            if (fuelUsagePerSecondPerBuilding > energy.fuelConsumptionLimit) {
-                recipeTime *= fuelUsagePerSecondPerBuilding / energy.fuelConsumptionLimit;
-                fuelUsagePerSecondPerBuilding = energy.fuelConsumptionLimit;
+            if (fuelUsagePerSecondPerBuilding > energy.FuelConsumptionLimit(entity.quality)) {
+                recipeTime *= fuelUsagePerSecondPerBuilding / energy.FuelConsumptionLimit(entity.quality);
+                fuelUsagePerSecondPerBuilding = energy.FuelConsumptionLimit(entity.quality);
                 warningFlags |= WarningFlags.FuelUsageInputLimited;
             }
         }

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -29,7 +29,7 @@ public enum WarningFlags {
 
 public struct UsedModule {
     public (ObjectWithQuality<Module> module, int count, bool beacon)[]? modules;
-    public Entity? beacon;
+    public ObjectWithQuality<EntityBeacon>? beacon;
     public int beaconCount;
 }
 

--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -18,6 +18,24 @@ public class NoUndoAttribute : Attribute { }
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class DeserializeWithNonPublicConstructorAttribute : Attribute { }
 
+/// <summary>
+/// Represents a type that can be deserialized from JSON formats that do not match its current serialization format. This typically happens when an object changes
+/// between value (string/float), object, and array representations.
+/// </summary>
+/// <typeparam name="T">The type that is being defined with custom deserialization rules.</typeparam>
+internal interface ICustomJsonDeserializer<T> {
+    /// <summary>
+    /// Attempts to deserialize an object from custom (aka 'old') formats.
+    /// </summary>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> that points to the first token that might need custom deserialization. If the deserialization is successful,
+    /// this must be advanced to the last token that was consumed to deserialize the object. (e.g. If three tokens were used, advance this by two tokens.)</param>
+    /// <param name="result">If the deserialization was successful (this method returns <see langword="true"/>), this is set to the result of reading the consumed JSON tokens.
+    /// If unsuccessful, the output value of this parameter should not be used.</param>
+    /// <returns><see langword="true"/> when the custom deserialization was successful, and <see langword="false"/> when the default serializer should be used instead.</returns>
+    // This is a static method so it can be declared for types that do no have a default constructor.
+    static abstract bool Deserialize(ref Utf8JsonReader reader, DeserializationContext context, out T? result);
+}
+
 internal abstract class SerializationMap {
     private static readonly ILogger logger = Logging.GetLogger<SerializationMap>();
     public UndoSnapshot MakeUndoSnapshot(ModelObject target) {
@@ -270,9 +288,34 @@ internal static class SerializationMap<T> where T : class {
         return null;
     }
 
+    private interface ICustomDeserializerHelper {
+        bool Deserialize(ref Utf8JsonReader reader, DeserializationContext context, out T? deserializedObject);
+    }
+
+    private class CustomDeserializerHelper<U> : ICustomDeserializerHelper where U : ICustomJsonDeserializer<U> {
+        public bool Deserialize(ref Utf8JsonReader reader, DeserializationContext context, out T? deserializedObject) {
+            bool result = U.Deserialize(ref reader, context, out U? intermediate);
+            deserializedObject = (T?)(object?)intermediate;
+            return result;
+        }
+    }
+
     public static T? DeserializeFromJson(ModelObject? owner, ref Utf8JsonReader reader, DeserializationContext context) {
         if (reader.TokenType == JsonTokenType.Null) {
             return null;
+        }
+
+        if (typeof(ICustomJsonDeserializer<T>).IsAssignableFrom(typeof(T))) {
+            // I want to do `((ICustomJsonDeserializer<T>)T).Deserialize(...)`, but that isn't supported.
+            // This and its helper types call ICustomJsonDeserializer<T>.Deserialize by the least obscure method I could come up with.
+            var helper = (ICustomDeserializerHelper)Activator.CreateInstance(typeof(CustomDeserializerHelper<>).MakeGenericType(typeof(T), typeof(T)))!;
+            Utf8JsonReader savedState = reader;
+            if (helper.Deserialize(ref reader, context, out T? result)) {
+                // The custom deserializer was successful; return its result.
+                return result;
+            }
+            // The custom deserializer didn't want to deal with the input; return to the previous state and use the normal deserializer.
+            reader = savedState;
         }
 
         if (reader.TokenType != JsonTokenType.StartObject) {

--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -48,8 +48,8 @@ internal abstract class SerializationMap {
         UndoSnapshotReader snapshotReader = new(snapshot);
         ReadUndo(target, snapshotReader);
     }
-    public abstract void BuildUndo(object target, UndoSnapshotBuilder builder);
-    public abstract void ReadUndo(object target, UndoSnapshotReader reader);
+    public abstract void BuildUndo(object? target, UndoSnapshotBuilder builder);
+    public abstract void ReadUndo(object? target, UndoSnapshotReader reader);
 
     private static readonly Dictionary<Type, SerializationMap> undoBuilders = [];
     protected static int deserializingCount;
@@ -77,24 +77,28 @@ internal static class SerializationMap<T> where T : class {
     private static readonly ulong requiredConstructorFieldMask;
 
     public class SpecificSerializationMap : SerializationMap {
-        public override void BuildUndo(object target, UndoSnapshotBuilder builder) {
-            T t = (T)target;
+        public override void BuildUndo(object? target, UndoSnapshotBuilder builder) {
+            T? t = (T?)target;
 
-            foreach (var property in properties) {
-                if (property.type == PropertyType.Normal) {
-                    property.SerializeToUndoBuilder(t, builder);
+            if (t != null) {
+                foreach (var property in properties) {
+                    if (property.type == PropertyType.Normal) {
+                        property.SerializeToUndoBuilder(t, builder);
+                    }
                 }
             }
         }
 
-        public override void ReadUndo(object target, UndoSnapshotReader reader) {
+        public override void ReadUndo(object? target, UndoSnapshotReader reader) {
             try {
                 deserializingCount++;
-                T t = (T)target;
+                T? t = (T?)target;
 
-                foreach (var property in properties) {
-                    if (property.type == PropertyType.Normal) {
-                        property.DeserializeFromUndoBuilder(t, reader);
+                if (t != null) {
+                    foreach (var property in properties) {
+                        if (property.type == PropertyType.Normal) {
+                            property.DeserializeFromUndoBuilder(t, reader);
+                        }
                     }
                 }
             }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -15,7 +15,7 @@ namespace Yafc.Parser;
 internal partial class FactorioDataDeserializer {
     private static readonly ILogger logger = Logging.GetLogger<FactorioDataDeserializer>();
     private LuaTable raw = null!; // null-forgiving: Initialized at the beginning of LoadData.
-    private bool GetRef<T>(LuaTable table, string key, [MaybeNullWhen(false)] out T result) where T : FactorioObject, new() {
+    private bool GetRef<T>(LuaTable table, string key, [NotNullWhen(true)] out T? result) where T : FactorioObject, new() {
         result = null;
         if (!table.Get(key, out string? name)) {
             return false;
@@ -134,9 +134,13 @@ internal partial class FactorioDataDeserializer {
         DeserializePrototypes(raw, "recipe", DeserializeRecipe, progress, errorCollector);
         progress.Report(("Loading", "Loading technologies"));
         DeserializePrototypes(raw, "technology", DeserializeTechnology, progress, errorCollector);
-        progress.Report(("Loading", "Loading entities"));
-        LuaTable entityPrototypes = (LuaTable?)prototypes["entity"] ?? throw new ArgumentException("Could not load prototypes.item from data argument", nameof(prototypes));
+        progress.Report(("Loading", "Loading qualities"));
+        DeserializePrototypes(raw, "quality", DeserializeQuality, progress, errorCollector);
+        Quality.Normal = GetObject<Quality>("normal");
+        rootAccessible.Add(Quality.Normal);
 
+        progress.Report(("Loading", "Loading entities"));
+        LuaTable entityPrototypes = (LuaTable?)prototypes["entity"] ?? throw new ArgumentException("Could not load prototypes.entity from data argument", nameof(prototypes));
         foreach (object prototypeName in entityPrototypes.ObjectElements.Keys) {
             DeserializePrototypes(raw, (string)prototypeName, DeserializeEntity, progress, errorCollector);
         }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -382,11 +382,11 @@ internal partial class FactorioDataDeserializer {
             var effect = ParseEffect(moduleEffect);
             module.moduleSpecification = new ModuleSpecification {
                 category = table.Get("category", ""),
-                consumption = effect.consumption,
-                speed = effect.speed,
-                productivity = effect.productivity,
-                pollution = effect.pollution,
-                quality = effect.quality,
+                baseConsumption = effect.consumption,
+                baseSpeed = effect.speed,
+                baseProductivity = effect.productivity,
+                basePollution = effect.pollution,
+                baseQuality = effect.quality,
             };
         }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -155,7 +155,8 @@ internal partial class FactorioDataDeserializer {
         int firstTechnology = Skip(firstMechanics, FactorioObjectSortOrder.Mechanics);
         int firstEntity = Skip(firstTechnology, FactorioObjectSortOrder.Technologies);
         int firstTile = Skip(firstEntity, FactorioObjectSortOrder.Entities);
-        int last = Skip(firstTile, FactorioObjectSortOrder.Tiles);
+        int firstQuality = Skip(firstTile, FactorioObjectSortOrder.Tiles);
+        int last = Skip(firstQuality, FactorioObjectSortOrder.Qualities);
         if (last != allObjects.Count) {
             throw new Exception("Something is not right");
         }
@@ -170,6 +171,7 @@ internal partial class FactorioDataDeserializer {
         Database.recipesAndTechnologies = new FactorioIdRange<RecipeOrTechnology>(firstRecipe, firstEntity, allObjects);
         Database.technologies = new FactorioIdRange<Technology>(firstTechnology, firstEntity, allObjects);
         Database.entities = new FactorioIdRange<Entity>(firstEntity, firstTile, allObjects);
+        Database.qualities = new FactorioIdRange<Quality>(firstQuality, last, allObjects);
         Database.fluidVariants = fluidVariants;
 
         Database.allModules = [.. allModules];

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -198,7 +198,7 @@ internal partial class FactorioDataDeserializer {
                 break;
             case "beacon":
                 var beacon = GetObject<Entity, EntityBeacon>(name);
-                beacon.beaconEfficiency = table.Get("distribution_effectivity", 0f);
+                beacon.baseBeaconEfficiency = table.Get("distribution_effectivity", 0f);
                 beacon.profile = table.Get("profile", out LuaTable? profile) ? profile.ArrayElements<double>().Select(x => (float)x).ToArray() : [1f];
                 _ = table.Get("energy_usage", out usesPower);
                 ParseModules(table, beacon, AllowedEffects.None);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -50,6 +50,7 @@ internal partial class FactorioDataDeserializer {
             quality.nextQuality = GetObject<Quality>(nextQuality);
             quality.nextQuality.previousQuality = quality;
         }
+        quality.BeaconConsumptionFactor = table.Get("beacon_power_usage_multiplier", 1f);
         quality.level = table.Get("level", 0);
     }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -44,6 +44,15 @@ internal partial class FactorioDataDeserializer {
         technology.products = [new(researchUnit, 1)];
     }
 
+    private void DeserializeQuality(LuaTable table, ErrorCollector errorCollector) {
+        Quality quality = DeserializeCommon<Quality>(table, "quality");
+        if (table.Get("next", out string? nextQuality)) {
+            quality.nextQuality = GetObject<Quality>(nextQuality);
+            quality.nextQuality.previousQuality = quality;
+        }
+        quality.level = table.Get("level", 0);
+    }
+
     private void UpdateRecipeCatalysts() {
         foreach (var recipe in allObjects.OfType<Recipe>()) {
             foreach (var product in recipe.products) {
@@ -140,6 +149,13 @@ internal partial class FactorioDataDeserializer {
                             technology.changeRecipeProductivity.Add(recipe, change);
                             recipe.technologyProductivity.Add(technology, change);
 
+                            break;
+                        }
+
+                    case "unlock-quality": {
+                            if (GetRef(modifier, "quality", out Quality? quality)) {
+                                quality.technologyUnlock.Add(technology);
+                            }
                             break;
                         }
                 }

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -324,6 +324,7 @@ public static class ImGuiUtils {
 
     public struct InlineGridBuilder : IDisposable {
         private ImGui.Context savedContext;
+        private readonly RectAllocator savedAllocator;
         private readonly ImGui gui;
         private readonly int elementsPerRow;
         private readonly float elementWidth;
@@ -332,6 +333,7 @@ public static class ImGuiUtils {
 
         internal InlineGridBuilder(ImGui gui, float elementWidth, float spacing, int elementsPerRow) {
             savedContext = default;
+            savedAllocator = gui.allocator;
             this.gui = gui;
             this.spacing = spacing;
             gui.allocator = RectAllocator.LeftAlign;
@@ -360,7 +362,10 @@ public static class ImGuiUtils {
             savedContext.SetManualRect(new Rect((elementWidth + spacing) * currentRowIndex, 0f, elementWidth, 0f), RectAllocator.Stretch);
         }
 
-        public readonly void Dispose() => savedContext.Dispose();
+        public readonly void Dispose() {
+            savedContext.Dispose();
+            gui.allocator = savedAllocator;
+        }
     }
 
     public static InlineGridBuilder EnterInlineGrid(this ImGui gui, float elementWidth, float spacing = 0f, int maxElemCount = 0) => new InlineGridBuilder(

--- a/Yafc/Utils/ObjectDisplayStyles.cs
+++ b/Yafc/Utils/ObjectDisplayStyles.cs
@@ -1,4 +1,6 @@
-﻿namespace Yafc.UI;
+﻿using Yafc.Model;
+
+namespace Yafc.UI;
 
 /// <summary>
 /// Contains the display parameters for FactorioObjectIcons.

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -214,8 +214,8 @@ public class ObjectTooltip : Tooltip {
                 BuildSubHeader(gui, "Crafts");
                 using (gui.EnterGroup(contentPadding)) {
                     BuildIconRow(gui, crafter.recipes, 2);
-                    if (crafter.craftingSpeed != 1f) {
-                        gui.BuildText(DataUtils.FormatAmount(crafter.craftingSpeed, UnitOfMeasure.Percent, "Crafting speed: "));
+                    if (crafter.baseCraftingSpeed != 1f) {
+                        gui.BuildText(DataUtils.FormatAmount(crafter.baseCraftingSpeed, UnitOfMeasure.Percent, "Crafting speed: "));
                     }
 
                     var productivity = crafter.effectReceiver?.baseEffect.productivity ?? 0;
@@ -241,7 +241,7 @@ public class ObjectTooltip : Tooltip {
         }
 
         if (entity.energy != null) {
-            string energyUsage = EnergyDescriptions[entity.energy.type] + DataUtils.FormatAmount(entity.power, UnitOfMeasure.Megawatt);
+            string energyUsage = EnergyDescriptions[entity.energy.type] + DataUtils.FormatAmount(entity.basePower, UnitOfMeasure.Megawatt);
             if (entity.energy.drain > 0f) {
                 energyUsage += " + " + DataUtils.FormatAmount(entity.energy.drain, UnitOfMeasure.Megawatt);
             }
@@ -280,11 +280,11 @@ public class ObjectTooltip : Tooltip {
                 miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.beaconEfficiency, UnitOfMeasure.Percent);
                 break;
             case EntityAccumulator accumulator:
-                miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.accumulatorCapacity, UnitOfMeasure.Megajoule);
+                miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.baseAccumulatorCapacity, UnitOfMeasure.Megajoule);
                 break;
             case EntityCrafter solarPanel:
-                if (solarPanel.craftingSpeed > 0f && entity.factorioType == "solar-panel") {
-                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.craftingSpeed, UnitOfMeasure.Megawatt);
+                if (solarPanel.baseCraftingSpeed > 0f && entity.factorioType == "solar-panel") {
+                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.baseCraftingSpeed, UnitOfMeasure.Megawatt);
                 }
 
                 break;

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -277,7 +277,7 @@ public class ObjectTooltip : Tooltip {
                 miscText = "Swing time: " + DataUtils.FormatAmount(inserter.inserterSwingTime, UnitOfMeasure.Second);
                 break;
             case EntityBeacon beacon:
-                miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.beaconEfficiency, UnitOfMeasure.Percent);
+                miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.baseBeaconEfficiency, UnitOfMeasure.Percent);
                 break;
             case EntityAccumulator accumulator:
                 miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.baseAccumulatorCapacity, UnitOfMeasure.Megajoule);

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -125,6 +125,8 @@ public class ObjectTooltip : Tooltip {
     }
 
     protected override void BuildContents(ImGui gui) {
+        BuildCommon(target.target, gui);
+        Quality? targetQuality = (target as IObjectWithQuality<FactorioObject>)?.quality ?? Quality.Normal;
         switch (target.target) {
             case Technology technology:
                 BuildTechnology(technology, gui);
@@ -133,13 +135,13 @@ public class ObjectTooltip : Tooltip {
                 BuildRecipe(recipe, gui);
                 break;
             case Goods goods:
-                BuildGoods(goods, gui);
+                BuildGoods(goods, targetQuality, gui);
                 break;
             case Entity entity:
-                BuildEntity(entity, gui);
+                BuildEntity(entity, targetQuality, gui);
                 break;
-            default:
-                BuildCommon(target.target, gui);
+            case Quality quality:
+                BuildQuality(quality, gui);
                 break;
         }
     }
@@ -190,9 +192,7 @@ public class ObjectTooltip : Tooltip {
         {EntityEnergyType.SolidFuel, "Solid fuel energy usage: "},
     };
 
-    private void BuildEntity(Entity entity, ImGui gui) {
-        BuildCommon(entity, gui);
-
+    private static void BuildEntity(Entity entity, Quality quality, ImGui gui) {
         if (entity.loot.Length > 0) {
             BuildSubHeader(gui, "Loot");
             using (gui.EnterGroup(contentPadding)) {
@@ -214,8 +214,8 @@ public class ObjectTooltip : Tooltip {
                 BuildSubHeader(gui, "Crafts");
                 using (gui.EnterGroup(contentPadding)) {
                     BuildIconRow(gui, crafter.recipes, 2);
-                    if (crafter.baseCraftingSpeed != 1f) {
-                        gui.BuildText(DataUtils.FormatAmount(crafter.baseCraftingSpeed, UnitOfMeasure.Percent, "Crafting speed: "));
+                    if (crafter.CraftingSpeed(quality) != 1f) {
+                        gui.BuildText(DataUtils.FormatAmount(crafter.CraftingSpeed(quality), UnitOfMeasure.Percent, "Crafting speed: "));
                     }
 
                     var productivity = crafter.effectReceiver?.baseEffect.productivity ?? 0;
@@ -241,7 +241,7 @@ public class ObjectTooltip : Tooltip {
         }
 
         if (entity.energy != null) {
-            string energyUsage = EnergyDescriptions[entity.energy.type] + DataUtils.FormatAmount(entity.basePower, UnitOfMeasure.Megawatt);
+            string energyUsage = EnergyDescriptions[entity.energy.type] + DataUtils.FormatAmount(entity.Power(quality), UnitOfMeasure.Megawatt);
             if (entity.energy.drain > 0f) {
                 energyUsage += " + " + DataUtils.FormatAmount(entity.energy.drain, UnitOfMeasure.Megawatt);
             }
@@ -277,14 +277,14 @@ public class ObjectTooltip : Tooltip {
                 miscText = "Swing time: " + DataUtils.FormatAmount(inserter.inserterSwingTime, UnitOfMeasure.Second);
                 break;
             case EntityBeacon beacon:
-                miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.baseBeaconEfficiency, UnitOfMeasure.Percent);
+                miscText = "Beacon efficiency: " + DataUtils.FormatAmount(beacon.BeaconEfficiency(quality), UnitOfMeasure.Percent);
                 break;
             case EntityAccumulator accumulator:
-                miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.baseAccumulatorCapacity, UnitOfMeasure.Megajoule);
+                miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.AccumulatorCapacity(quality), UnitOfMeasure.Megajoule);
                 break;
             case EntityCrafter solarPanel:
                 if (solarPanel.baseCraftingSpeed > 0f && entity.factorioType == "solar-panel") {
-                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.baseCraftingSpeed, UnitOfMeasure.Megawatt);
+                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.CraftingSpeed(quality), UnitOfMeasure.Megawatt);
                 }
 
                 break;
@@ -297,8 +297,7 @@ public class ObjectTooltip : Tooltip {
         }
     }
 
-    private void BuildGoods(Goods goods, ImGui gui) {
-        BuildCommon(goods, gui);
+    private void BuildGoods(Goods goods, Quality quality, ImGui gui) {
         if (goods.showInExplorers) {
             using (gui.EnterGroup(contentPadding)) {
                 gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, TextBlockDisplayStyle.WrappedText);
@@ -365,23 +364,23 @@ public class ObjectTooltip : Tooltip {
                 BuildSubHeader(gui, "Module parameters");
                 using (gui.EnterGroup(contentPadding)) {
                     if (moduleSpecification.baseProductivity != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseProductivity, UnitOfMeasure.Percent, "Productivity: "));
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.Productivity(quality), UnitOfMeasure.Percent, "Productivity: "));
                     }
 
                     if (moduleSpecification.baseSpeed != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseSpeed, UnitOfMeasure.Percent, "Speed: "));
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.Speed(quality), UnitOfMeasure.Percent, "Speed: "));
                     }
 
                     if (moduleSpecification.baseConsumption != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseConsumption, UnitOfMeasure.Percent, "Consumption: "));
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.Consumption(quality), UnitOfMeasure.Percent, "Consumption: "));
                     }
 
                     if (moduleSpecification.basePollution != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.basePollution, UnitOfMeasure.Percent, "Pollution: "));
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.Pollution(quality), UnitOfMeasure.Percent, "Pollution: "));
                     }
 
                     if (moduleSpecification.baseQuality != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseQuality, UnitOfMeasure.Percent, "Quality: "));
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.Quality(quality), UnitOfMeasure.Percent, "Quality: "));
                     }
                 }
             }
@@ -393,7 +392,6 @@ public class ObjectTooltip : Tooltip {
     }
 
     private void BuildRecipe(RecipeOrTechnology recipe, ImGui gui) {
-        BuildCommon(recipe, gui);
         using (gui.EnterGroup(contentPadding, RectAllocator.LeftRow)) {
             gui.BuildIcon(Icon.Time, 2f, SchemeColor.BackgroundText);
             gui.BuildText(DataUtils.FormatAmount(recipe.time, UnitOfMeasure.Second));
@@ -501,11 +499,7 @@ public class ObjectTooltip : Tooltip {
 
     private void BuildTechnology(Technology technology, ImGui gui) {
         bool isResearchTriggerCraft = (technology.flags & RecipeFlags.HasResearchTriggerCraft) == RecipeFlags.HasResearchTriggerCraft;
-        if (isResearchTriggerCraft) {
-            BuildCommon(technology, gui);
-
-        }
-        else {
+        if (!isResearchTriggerCraft) {
             BuildRecipe(technology, gui);
         }
 
@@ -548,6 +542,35 @@ public class ObjectTooltip : Tooltip {
                     _ = gui.BuildFactorioObjectWithAmount(pack.goods, pack.amount, ButtonDisplayStyle.ProductionTableUnscaled);
                 }
             }
+        }
+    }
+
+    private static void BuildQuality(Quality quality, ImGui gui) {
+        BuildSubHeader(gui, "Quality bonuses");
+        if (quality == Quality.Normal) {
+            using (gui.EnterGroup(contentPadding)) {
+                gui.BuildText("Normal quality provides no bonuses.", TextBlockDisplayStyle.WrappedText);
+            }
+            return;
+        }
+        gui.allocator = RectAllocator.LeftAlign;
+        (string left, string right)[] text = [
+            ("Crafting speed:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
+            ("Accumulator capacity:", '+' + DataUtils.FormatAmount(quality.AccumulatorCapacityBonus, UnitOfMeasure.Percent)),
+            ("Module effects:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent) + '*'),
+            ("Beacon transmission efficiency:", '+' + DataUtils.FormatAmount(quality.BeaconTransmissionBonus, UnitOfMeasure.None))
+        ];
+
+        float rightWidth = text.Max(t => gui.GetTextDimensions(out _, t.right).X);
+
+        using (gui.EnterGroup(contentPadding)) {
+            gui.allocator = RectAllocator.LeftAlign;
+            foreach (var (left, right) in text) {
+                gui.BuildText(left);
+                Rect rect = new(gui.statePosition.Width - rightWidth, gui.lastRect.Y, rightWidth, gui.lastRect.Height);
+                gui.DrawText(rect, right);
+            }
+            gui.BuildText("* Only applied to beneficial module effects.", TextBlockDisplayStyle.WrappedText);
         }
     }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -364,24 +364,24 @@ public class ObjectTooltip : Tooltip {
             if (item is Module { moduleSpecification: ModuleSpecification moduleSpecification }) {
                 BuildSubHeader(gui, "Module parameters");
                 using (gui.EnterGroup(contentPadding)) {
-                    if (moduleSpecification.productivity != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.productivity, UnitOfMeasure.Percent, "Productivity: "));
+                    if (moduleSpecification.baseProductivity != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseProductivity, UnitOfMeasure.Percent, "Productivity: "));
                     }
 
-                    if (moduleSpecification.speed != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.speed, UnitOfMeasure.Percent, "Speed: "));
+                    if (moduleSpecification.baseSpeed != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseSpeed, UnitOfMeasure.Percent, "Speed: "));
                     }
 
-                    if (moduleSpecification.consumption != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.consumption, UnitOfMeasure.Percent, "Consumption: "));
+                    if (moduleSpecification.baseConsumption != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseConsumption, UnitOfMeasure.Percent, "Consumption: "));
                     }
 
-                    if (moduleSpecification.pollution != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.pollution, UnitOfMeasure.Percent, "Pollution: "));
+                    if (moduleSpecification.basePollution != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.basePollution, UnitOfMeasure.Percent, "Pollution: "));
                     }
 
-                    if (moduleSpecification.quality != 0f) {
-                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.quality, UnitOfMeasure.Percent, "Quality: "));
+                    if (moduleSpecification.baseQuality != 0f) {
+                        gui.BuildText(DataUtils.FormatAmount(moduleSpecification.baseQuality, UnitOfMeasure.Percent, "Quality: "));
                     }
                 }
             }

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -121,7 +121,7 @@ public class NeverEnoughItemsPanel : PseudoScreen, IComparer<NeverEnoughItemsPan
         foreach (var ingredient in recipe.ingredients) {
             if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, ButtonDisplayStyle.NeieSmall) == Click.Left) {
                 if (ingredient.variants != null) {
-                    gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton<Goods>(ingredient.variants, DataUtils.DefaultOrdering, SetItem, "Accepted fluid variants"));
+                    gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton(ingredient.variants, SetItem, new("Accepted fluid variants")));
                 }
                 else {
                     changing = ingredient.goods;

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -175,7 +175,7 @@ public class PreferencesScreen : PseudoScreen {
         using (gui.EnterRow()) {
             gui.BuildText(text, topOffset: 0.5f);
             if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
-                gui.BuildObjectSelectDropDown(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
+                gui.BuildObjectSelectDropDown(list, selectItem, new(text), width);
             }
         }
     }
@@ -188,7 +188,7 @@ public class PreferencesScreen : PseudoScreen {
         using (gui.EnterRow()) {
             gui.BuildText(text, topOffset: 0.5f);
             if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
-                gui.BuildObjectSelectDropDownWithNone(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
+                gui.BuildObjectSelectDropDownWithNone(list, selectItem, new(text), width);
             }
         }
     }
@@ -208,10 +208,10 @@ public class PreferencesScreen : PseudoScreen {
             gui.allocator = RectAllocator.RightRow;
             if (!fluid) {
                 if (gui.BuildButton("Set from belt")) {
-                    gui.BuildObjectSelectDropDown<EntityBelt>(Database.allBelts, DataUtils.DefaultOrdering, setBelt => {
+                    gui.BuildObjectSelectDropDown(Database.allBelts, setBelt => {
                         _ = preferences.RecordUndo(true);
                         preferences.itemUnit = setBelt.beltItemsPerSecond;
-                    }, "Select belt", extra: b => DataUtils.FormatAmount(b.beltItemsPerSecond, UnitOfMeasure.PerSecond));
+                    }, new("Select belt", DataUtils.DefaultOrdering, ExtraText: b => DataUtils.FormatAmount(b.beltItemsPerSecond, UnitOfMeasure.PerSecond)));
                 }
             }
             gui.BuildText("per second");

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -155,10 +155,10 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         public string Recipe { get; }
         public ObjectWithQuality? Building { get; }
         public float BuildingCount { get; }
-        public IEnumerable<string> Modules { get; }
+        public IEnumerable<ObjectWithQuality> Modules { get; }
         public string? Beacon { get; }
         public int BeaconCount { get; }
-        public IEnumerable<string> BeaconModules { get; }
+        public IEnumerable<ObjectWithQuality> BeaconModules { get; }
         public ExportMaterial Fuel { get; }
         public IEnumerable<ExportMaterial> Inputs { get; }
         public IEnumerable<ExportMaterial> Outputs { get; }
@@ -177,15 +177,15 @@ public class ProjectPageSettingsPanel : PseudoScreen {
                 Modules = BeaconModules = [];
             }
             else {
-                List<string> modules = [];
-                List<string> beaconModules = [];
+                List<ObjectWithQuality> modules = [];
+                List<ObjectWithQuality> beaconModules = [];
 
                 foreach (var (module, count, isBeacon) in row.usedModules.modules) {
                     if (isBeacon) {
-                        beaconModules.AddRange(Enumerable.Repeat(module.name, count));
+                        beaconModules.AddRange(Enumerable.Repeat<ObjectWithQuality>(module, count));
                     }
                     else {
-                        modules.AddRange(Enumerable.Repeat(module.name, count));
+                        modules.AddRange(Enumerable.Repeat<ObjectWithQuality>(module, count));
                     }
                 }
 
@@ -278,5 +278,6 @@ public class ProjectPageSettingsPanel : PseudoScreen {
 
     private record struct ObjectWithQuality(string Name, string Quality) {
         public static implicit operator ObjectWithQuality?(ObjectWithQuality<EntityCrafter>? value) => value == null ? default(ObjectWithQuality?) : new ObjectWithQuality(value.target.name, value.quality.name);
+        public static implicit operator ObjectWithQuality(ObjectWithQuality<Module> value) => new ObjectWithQuality(value.target.name, value.quality.name);
     }
 }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -156,7 +156,7 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         public ObjectWithQuality? Building { get; }
         public float BuildingCount { get; }
         public IEnumerable<ObjectWithQuality> Modules { get; }
-        public string? Beacon { get; }
+        public ObjectWithQuality? Beacon { get; }
         public int BeaconCount { get; }
         public IEnumerable<ObjectWithQuality> BeaconModules { get; }
         public ExportMaterial Fuel { get; }
@@ -170,7 +170,7 @@ public class ProjectPageSettingsPanel : PseudoScreen {
             Fuel = new ExportMaterial(row.fuel?.name ?? "<No fuel selected>", row.FuelInformation.Amount);
             Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.name ?? "Recipe disabled", i.Amount));
             Outputs = row.Products.Select(p => new ExportMaterial(p.Goods?.name ?? "Recipe disabled", p.Amount));
-            Beacon = row.usedModules.beacon?.name;
+            Beacon = row.usedModules.beacon;
             BeaconCount = row.usedModules.beaconCount;
 
             if (row.usedModules.modules is null) {
@@ -279,5 +279,6 @@ public class ProjectPageSettingsPanel : PseudoScreen {
     private record struct ObjectWithQuality(string Name, string Quality) {
         public static implicit operator ObjectWithQuality?(ObjectWithQuality<EntityCrafter>? value) => value == null ? default(ObjectWithQuality?) : new ObjectWithQuality(value.target.name, value.quality.name);
         public static implicit operator ObjectWithQuality(ObjectWithQuality<Module> value) => new ObjectWithQuality(value.target.name, value.quality.name);
+        public static implicit operator ObjectWithQuality?(ObjectWithQuality<EntityBeacon>? value) => value == null ? default(ObjectWithQuality?) : new ObjectWithQuality(value.target.name, value.quality.name);
     }
 }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -153,7 +153,7 @@ public class ProjectPageSettingsPanel : PseudoScreen {
 
     private class ExportRecipe {
         public string Recipe { get; }
-        public string Building { get; }
+        public ObjectWithQuality? Building { get; }
         public float BuildingCount { get; }
         public IEnumerable<string> Modules { get; }
         public string? Beacon { get; }
@@ -165,7 +165,7 @@ public class ProjectPageSettingsPanel : PseudoScreen {
 
         public ExportRecipe(RecipeRow row) {
             Recipe = row.recipe.name;
-            Building = row.entity?.name ?? "<No building selected>";
+            Building = row.entity;
             BuildingCount = row.buildingCount;
             Fuel = new ExportMaterial(row.fuel?.name ?? "<No fuel selected>", row.FuelInformation.Amount);
             Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.name ?? "Recipe disabled", i.Amount));
@@ -274,5 +274,9 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         if (collector.severity > ErrorSeverity.None) {
             ErrorListPanel.Show(collector);
         }
+    }
+
+    private record struct ObjectWithQuality(string Name, string Quality) {
+        public static implicit operator ObjectWithQuality?(ObjectWithQuality<EntityCrafter>? value) => value == null ? default(ObjectWithQuality?) : new ObjectWithQuality(value.target.name, value.quality.name);
     }
 }

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -36,6 +36,20 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
         => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
 
+    /// <summary>
+    /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>, or to clear the current selection by selecting
+    /// an extra "none" or "clear" option.
+    /// </summary>
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for the selected item when the panel is closed.
+    /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
+    public static void SelectQualityWithNone<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>?> selectItem, Quality? currentQuality, IComparer<T>? ordering = null,
+        string? noneTooltip = null) where T : FactorioObject
+        => Instance.SelectQuality(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip, currentQuality);
+
     protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
         if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ShowTypeInHeader = showTypeInHeader }) == Click.Left) {
             CloseWithResult(element);

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -64,10 +64,10 @@ public class ShoppingListScreen : PseudoScreen {
                 };
                 counts[shopItem] = prev + displayCount;
                 if (recipe.usedModules.modules != null) {
-                    foreach ((Module module, int moduleCount, bool beacon) in recipe.usedModules.modules) {
+                    foreach ((ObjectWithQuality<Module> module, int moduleCount, bool beacon) in recipe.usedModules.modules) {
                         if (!beacon) {
-                            _ = counts.TryGetValue(new ObjectWithQuality<FactorioObject>(module, Quality.Normal), out prev);
-                            counts[new ObjectWithQuality<FactorioObject>(module, Quality.Normal)] = prev + displayCount * moduleCount;
+                            _ = counts.TryGetValue(module, out prev);
+                            counts[module] = prev + displayCount * moduleCount;
                         }
                     }
                 }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -38,7 +38,7 @@ public class ShoppingListScreen : PseudoScreen {
 
     private void ElementDrawer(ImGui gui, (IObjectWithQuality<FactorioObject> obj, float count) element, int index) {
         using (gui.EnterRow()) {
-            gui.BuildFactorioObjectIcon(element.obj.target, new IconDisplayStyle(2, MilestoneDisplay.Contained, false));
+            gui.BuildFactorioObjectIcon(element.obj, new IconDisplayStyle(2, MilestoneDisplay.Contained, false));
             gui.RemainingRow().BuildText(DataUtils.FormatAmount(element.count, UnitOfMeasure.None, "x") + ": " + element.obj.target.locName);
         }
         _ = gui.BuildFactorioObjectButtonBackground(gui.lastRect, element.obj);

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -53,7 +53,7 @@ public class ShoppingListScreen : PseudoScreen {
         Dictionary<FactorioObject, int> counts = [];
         foreach (RecipeRow recipe in recipes) {
             if (recipe.entity != null) {
-                FactorioObject shopItem = recipe.entity.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity;
+                FactorioObject shopItem = recipe.entity.target.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity.target;
                 _ = counts.TryGetValue(shopItem, out int prev);
                 int builtCount = recipe.builtBuildings ?? (assumeAdequate ? MathUtils.Ceil(recipe.buildingCount) : 0);
                 int displayCount = displayState switch {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -204,16 +204,19 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
             switch (gui.BuildFactorioObjectWithEditableAmount(module, amount, ButtonDisplayStyle.ProductionTableUnscaled)) {
                 case GoodsWithAmountEvent.LeftButtonClick:
                     int idx = i; // Capture the current value of i.
-                    SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
+
+                    gui.BuildObjectQualitySelectDropDownWithNone(GetModules(beacon), sel => {
                         if (sel == null) {
                             list.RemoveAt(idx);
                         }
                         else {
-                            list[idx] = (new(sel, Quality.Normal), list[idx].fixedCount);
+                            list[idx] = (sel, list[idx].fixedCount);
                         }
-
                         gui.Rebuild();
-                    }, DataUtils.FavoriteModule);
+                    }, new("Select module", DataUtils.FavoriteModule), list[idx].module.quality, quality => {
+                        list[idx] = list[idx] with { module = new(list[idx].module.target, quality) };
+                        gui.Rebuild();
+                    });
                     break;
 
                 case GoodsWithAmountEvent.TextEditing when amount.Value >= 0:
@@ -236,10 +239,10 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
         grid.Next();
         if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-            gui.BuildObjectSelectDropDown(GetModules(beacon), sel => {
-                list.Add((new(sel, Quality.Normal), 0));
+            gui.BuildObjectQualitySelectDropDown(GetModules(beacon), sel => {
+                list.Add(new(sel, 0));
                 gui.Rebuild();
-            }, new("Select module", DataUtils.FavoriteModule));
+            }, new("Select module", DataUtils.FavoriteModule), Quality.Normal);
         }
     }
 

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -123,7 +123,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
             }
 
             if (recipe != null) {
-                float craftingSpeed = (recipe.entity?.target.craftingSpeed ?? 1f) * effects.speedMod;
+                float craftingSpeed = (recipe.entity?.GetCraftingSpeed() ?? 1f) * effects.speedMod;
                 gui.BuildText("Current effects:", Font.subheader);
                 gui.BuildText("Productivity bonus: " + DataUtils.FormatAmount(effects.productivity, UnitOfMeasure.Percent));
                 gui.BuildText("Speed bonus: " + DataUtils.FormatAmount(effects.speedMod - 1, UnitOfMeasure.Percent) + " (Crafting speed: " +
@@ -132,7 +132,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 string energyUsageLine = "Energy usage: " + DataUtils.FormatAmount(effects.energyUsageMod, UnitOfMeasure.Percent);
 
                 if (recipe.entity != null) {
-                    float power = effects.energyUsageMod * recipe.entity.target.power / recipe.entity.target.energy.effectivity;
+                    float power = effects.energyUsageMod * recipe.entity.GetPower() / recipe.entity.target.energy.effectivity;
                     if (!recipe.recipe.flags.HasFlagAny(RecipeFlags.UsesFluidTemperature | RecipeFlags.ScaleProductionWithPower) && recipe.entity != null) {
                         energyUsageLine += " (" + DataUtils.FormatAmount(power, UnitOfMeasure.Megawatt) + " per building)";
                     }

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -109,7 +109,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
                 var defaultFiller = recipe?.GetModuleFiller();
                 if (defaultFiller?.GetBeaconsForCrafter(recipe?.entity?.target) is BeaconConfiguration { beacon: not null, beaconModule: not null } beaconsToUse) {
-                    effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.GetProfile(beaconsToUse.beaconCount) * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
+                    effects.AddModules(beaconsToUse.beaconModule, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.GetProfile(beaconsToUse.beaconCount) * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
                 }
             }
             else {
@@ -199,7 +199,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
         var list = beacon != null ? modules!.beaconList : modules!.list;// null-forgiving: Both calls are from places where we know modules is not null
         for (int i = 0; i < list.Count; i++) {
             grid.Next();
-            (Module module, int fixedCount) = list[i];
+            (ObjectWithQuality<Module> module, int fixedCount) = list[i];
             DisplayAmount amount = fixedCount;
             switch (gui.BuildFactorioObjectWithEditableAmount(module, amount, ButtonDisplayStyle.ProductionTableUnscaled)) {
                 case GoodsWithAmountEvent.LeftButtonClick:
@@ -209,7 +209,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                             list.RemoveAt(idx);
                         }
                         else {
-                            list[idx] = (sel, list[idx].fixedCount);
+                            list[idx] = (new(sel, Quality.Normal), list[idx].fixedCount);
                         }
 
                         gui.Rebuild();
@@ -224,20 +224,20 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
             if (beacon == null) {
                 int count = Math.Min(remainingModules, fixedCount > 0 ? fixedCount : int.MaxValue);
                 if (count > 0) {
-                    effects.AddModules(module.moduleSpecification, count);
+                    effects.AddModules(module, count);
                     remainingModules -= count;
                 }
             }
             else {
                 int beaconCount = (modules.beaconList.Sum(x => x.fixedCount) - 1) / beacon.moduleSlots + 1;
-                effects.AddModules(module.moduleSpecification, fixedCount * beacon.beaconEfficiency * beacon.GetProfile(beaconCount));
+                effects.AddModules(module, fixedCount * beacon.beaconEfficiency * beacon.GetProfile(beaconCount));
             }
         }
 
         grid.Next();
         if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
             gui.BuildObjectSelectDropDown(GetModules(beacon), sel => {
-                list.Add((sel, 0));
+                list.Add((new(sel, Quality.Normal), 0));
                 gui.Rebuild();
             }, new("Select module", DataUtils.FavoriteModule));
         }

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -170,16 +170,16 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
     private void SelectBeacon(ImGui gui) {
         if (modules!.beacon is null) { // null-forgiving: Both calls are from places where we know modules is not null
-            gui.BuildObjectSelectDropDown<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
+            gui.BuildObjectSelectDropDown(Database.allBeacons, sel => {
                 modules.beacon = sel;
                 contents.Rebuild();
-            }, "Select beacon");
+            }, new("Select beacon"));
         }
         else {
-            gui.BuildObjectSelectDropDownWithNone<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
+            gui.BuildObjectSelectDropDownWithNone(Database.allBeacons, sel => {
                 modules.beacon = sel;
                 contents.Rebuild();
-            }, "Select beacon");
+            }, new("Select beacon"));
         }
     }
 
@@ -236,10 +236,10 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
         grid.Next();
         if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-            gui.BuildObjectSelectDropDown(GetModules(beacon), DataUtils.FavoriteModule, sel => {
+            gui.BuildObjectSelectDropDown(GetModules(beacon), sel => {
                 list.Add((sel, 0));
                 gui.Rebuild();
-            }, "Select module");
+            }, new("Select module", DataUtils.FavoriteModule));
         }
     }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -491,11 +491,13 @@ goodsHaveNoProduction:;
                             var modules = recipe.usedModules.modules;
 
                             if (modules != null) {
-                                entity.items = [];
-
+                                int idx = 0;
                                 foreach (var (module, count, beacon) in modules) {
                                     if (!beacon) {
-                                        entity.items[module.name] = count;
+                                        BlueprintItem item = new BlueprintItem { id = { name = module.target.name, quality = module.quality.name } };
+                                        item.items.inInventory.AddRange(Enumerable.Range(idx, count).Select(i => new BlueprintInventoryItem { stack = i }));
+                                        entity.items.Add(item);
+                                        idx += count;
                                     }
                                 }
                             }
@@ -637,14 +639,14 @@ goodsHaveNoProduction:;
                         wasBeacon = true;
 
                         if (recipe.usedModules.beacon != null) {
-                            drawItem(gui, recipe.usedModules.beacon, recipe.usedModules.beaconCount);
+                            drawItem(gui, new ObjectWithQuality<FactorioObject>(recipe.usedModules.beacon, Quality.Normal), recipe.usedModules.beaconCount);
                         }
                     }
                     drawItem(gui, module, count);
                 }
             }
 
-            void drawItem(ImGui gui, FactorioObject? item, int count) {
+            void drawItem(ImGui gui, IObjectWithQuality<FactorioObject>? item, int count) {
                 grid.Next();
                 switch (gui.BuildFactorioObjectWithAmount(item, count, ButtonDisplayStyle.ProductionTableUnscaled)) {
                     case Click.Left:
@@ -692,7 +694,7 @@ goodsHaveNoProduction:;
                 }
 
                 if (recipe.entity?.target.moduleSlots > 0) {
-                    dropGui.BuildInlineObjectListAndButton(modules, recipe.SetFixedModule, new("Select fixed module", DataUtils.FavoriteModule));
+                    dropGui.BuildInlineObjectListAndButton(modules, m => recipe.SetFixedModule(new(m, Quality.Normal)), new("Select fixed module", DataUtils.FavoriteModule));
                 }
 
                 if (moduleTemplateList.data.Count > 0) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -639,7 +639,7 @@ goodsHaveNoProduction:;
                         wasBeacon = true;
 
                         if (recipe.usedModules.beacon != null) {
-                            drawItem(gui, new ObjectWithQuality<FactorioObject>(recipe.usedModules.beacon, Quality.Normal), recipe.usedModules.beaconCount);
+                            drawItem(gui, recipe.usedModules.beacon, recipe.usedModules.beaconCount);
                         }
                     }
                     drawItem(gui, module, count);

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -381,16 +381,15 @@ goodsHaveNoProduction:;
         }
 
         private static void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity currentAccumulator) => gui.ShowDropDown(imGui
-            => imGui.BuildInlineObjectListAndButton<EntityAccumulator>(Database.allAccumulators, DataUtils.DefaultOrdering,
-                newAccumulator => recipe.RecordUndo().ChangeVariant(currentAccumulator, newAccumulator), "Select accumulator",
-                extra: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule)));
+            => imGui.BuildInlineObjectListAndButton(Database.allAccumulators, newAccumulator => recipe.RecordUndo().ChangeVariant(currentAccumulator, newAccumulator),
+                new("Select accumulator", ExtraText: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule))));
 
         private static void ShowEntityDropdown(ImGui imgui, RecipeRow recipe) => imgui.ShowDropDown(gui => {
             EntityCrafter? favoriteCrafter = recipe.recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
             if (favoriteCrafter == recipe.entity?.target) { favoriteCrafter = null; }
             bool willResetFixed = favoriteCrafter == null, willResetBuilt = willResetFixed && recipe.fixedBuildings == 0;
 
-            gui.BuildInlineObjectListAndButton(recipe.recipe.crafters, DataUtils.FavoriteCrafter, sel => {
+            gui.BuildInlineObjectListAndButton(recipe.recipe.crafters, sel => {
                 if (recipe.entity?.target == sel) {
                     return;
                 }
@@ -400,7 +399,7 @@ goodsHaveNoProduction:;
                 if (!sel.energy.fuels.Contains(recipe.fuel)) {
                     recipe.fuel = recipe.entity.target.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
                 }
-            }, "Select crafting entity", extra: x => DataUtils.FormatAmount(x.craftingSpeed, UnitOfMeasure.Percent));
+            }, new("Select crafting entity", DataUtils.FavoriteCrafter, ExtraText: x => DataUtils.FormatAmount(x.craftingSpeed, UnitOfMeasure.Percent)));
 
             gui.AllocateSpacing(0.5f);
 
@@ -669,7 +668,7 @@ goodsHaveNoProduction:;
                 }
 
                 if (recipe.entity?.target.moduleSlots > 0) {
-                    dropGui.BuildInlineObjectListAndButton(modules, DataUtils.FavoriteModule, recipe.SetFixedModule, "Select fixed module");
+                    dropGui.BuildInlineObjectListAndButton(modules, recipe.SetFixedModule, new("Select fixed module", DataUtils.FavoriteModule));
                 }
 
                 if (moduleTemplateList.data.Count > 0) {
@@ -830,8 +829,8 @@ goodsHaveNoProduction:;
                          : g => DataUtils.FormatAmount(g.fuelValue, UnitOfMeasure.Megajoule);
 
                     BuildFavorites(gui, recipe.fuel, "Add fuel to favorites");
-                    gui.BuildInlineObjectListAndButton(energy.fuels, DataUtils.FavoriteFuel,
-                        fuel => recipe.RecordUndo().fuel = fuel, "Select fuel", extra: fuelDisplayFunc);
+                    gui.BuildInlineObjectListAndButton(energy.fuels, fuel => recipe.RecordUndo().fuel = fuel,
+                        new("Select fuel", DataUtils.FavoriteFuel, ExtraText: fuelDisplayFunc));
                 }
             }
 
@@ -875,7 +874,7 @@ goodsHaveNoProduction:;
                 }
             }
             else if (type <= ProductDropdownType.Ingredient && allProduction.Length > 0) {
-                gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 6, true, recipeExists);
+                gui.BuildInlineObjectListAndButton(allProduction, addRecipe, new("Add production recipe", comparer, 6, true, recipeExists));
                 numberOfShownRecipes += allProduction.Length;
 
                 if (link == null) {
@@ -895,36 +894,36 @@ goodsHaveNoProduction:;
             if (type <= ProductDropdownType.Ingredient && spentFuelRecipes.Length > 0) {
                 gui.BuildInlineObjectListAndButton(
                     spentFuelRecipes,
-                    DataUtils.AlreadySortedRecipe,
                     (x) => { spentFuel = goods; addRecipe(x); },
-                    "Produce it as a spent fuel",
+                    new("Produce it as a spent fuel",
+                    DataUtils.AlreadySortedRecipe,
                     3,
                     true,
-                    recipeExists);
+                    recipeExists));
                 numberOfShownRecipes += spentFuelRecipes.Length;
             }
 
             if (type >= ProductDropdownType.Product && goods.usages.Length > 0) {
                 gui.BuildInlineObjectListAndButton(
                     goods.usages,
-                    DataUtils.DefaultRecipeOrdering,
                     addRecipe,
-                    "Add consumption recipe",
+                    new("Add consumption recipe",
+                    DataUtils.DefaultRecipeOrdering,
                     6,
                     true,
-                    recipeExists);
+                    recipeExists));
                 numberOfShownRecipes += goods.usages.Length;
             }
 
             if (type >= ProductDropdownType.Product && fuelUseList.Length > 0) {
                 gui.BuildInlineObjectListAndButton(
                     fuelUseList,
-                    DataUtils.AlreadySortedRecipe,
                     (x) => { selectedFuel = goods; addRecipe(x); },
-                    "Add fuel usage",
+                    new("Add fuel usage",
+                    DataUtils.AlreadySortedRecipe,
                     6,
                     true,
-                    recipeExists);
+                    recipeExists));
                 numberOfShownRecipes += fuelUseList.Length;
             }
 
@@ -936,7 +935,7 @@ goodsHaveNoProduction:;
             }
 
             if (type >= ProductDropdownType.Product && allProduction.Length > 0) {
-                gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 1, true, recipeExists);
+                gui.BuildInlineObjectListAndButton(allProduction, addRecipe, new("Add production recipe", comparer, 1, true, recipeExists));
                 numberOfShownRecipes += allProduction.Length;
             }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Date:
     Features:
         - Add pseudo-items representing a recipe's total sushi-inputs and sushi-outputs.
           They can be toggled on/off in the LMB of the recipe.
+        - Add the ability to select qualities for crafters and accumulators.
     Bugfixes:
         - Fixed counts are hidden on disabled recipes, since editing them won't work properly.
         - Accomodate modules as spoilage results.

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,7 @@ Date:
     Features:
         - Add pseudo-items representing a recipe's total sushi-inputs and sushi-outputs.
           They can be toggled on/off in the LMB of the recipe.
-        - Add the ability to select qualities for crafters, accumulators, and modules.
+        - Add the ability to select qualities for crafters, accumulators, modules, and beacons.
     Bugfixes:
         - Fixed counts are hidden on disabled recipes, since editing them won't work properly.
         - Accomodate modules as spoilage results.

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,7 @@ Date:
     Features:
         - Add pseudo-items representing a recipe's total sushi-inputs and sushi-outputs.
           They can be toggled on/off in the LMB of the recipe.
-        - Add the ability to select qualities for crafters and accumulators.
+        - Add the ability to select qualities for crafters, accumulators, and modules.
     Bugfixes:
         - Fixed counts are hidden on disabled recipes, since editing them won't work properly.
         - Accomodate modules as spoilage results.


### PR DESCRIPTION
This allows quality selection for everything except recipes, and should reflect the quality-related values everywhere they are relevant.

This corresponds to tasks "Select quality of crafting entity with new GUI" through "Use quality-dependent stats for modules/beacons" and "UnlockQualityModifier in TechnologyPrototype::effects for milestone analysis" in #311.