### PR TITLE
Fix pyhard spoilage loading error

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -315,6 +315,16 @@ public abstract class Goods : FactorioObject {
 }
 
 public class Item : Goods {
+    /// <summary>
+    /// The prototypes in this array will be loaded in order, before any other prototypes.
+    /// This should correspond to the prototypes for subclasses of item, with more derived classes listed before their base classes.
+    /// e.g. If ItemWithHealth and ModuleWithHealth C# classes were added, all prototypes for both classes must be listed here.
+    /// Ignoring style restrictions, the prototypes could be listed in any order, provided all ModuleWithHealth prototype(s) are listed before "module".
+    /// </summary>
+    /// <remarks>This forces modules to be loaded before other items, since deserialization otherwise creates Item objects for all spoil results.
+    /// It does not protect against modules that spoil into other modules, but one hopes people won't do that.</remarks>
+    internal static string[] ExplicitPrototypeLoadOrder { get; } = ["module"];
+
     public Item? fuelResult { get; internal set; }
     public int stackSize { get; internal set; }
     public Entity? placeResult { get; internal set; }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -117,7 +117,11 @@ internal partial class FactorioDataDeserializer {
         raw = (LuaTable?)data["raw"] ?? throw new ArgumentException("Could not load data.raw from data argument", nameof(data));
         LuaTable itemPrototypes = (LuaTable?)prototypes?["item"] ?? throw new ArgumentException("Could not load prototypes.item from data argument", nameof(prototypes));
 
-        foreach (object prototypeName in itemPrototypes.ObjectElements.Keys) {
+        foreach (object prototypeName in Item.ExplicitPrototypeLoadOrder.Intersect(itemPrototypes.ObjectElements.Keys)) {
+            DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress, errorCollector);
+        }
+
+        foreach (object prototypeName in itemPrototypes.ObjectElements.Keys.Except(Item.ExplicitPrototypeLoadOrder)) {
             DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress, errorCollector);
         }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date:
           They can be toggled on/off in the LMB of the recipe.
     Bugfixes:
         - Fixed counts are hidden on disabled recipes, since editing them won't work properly.
+        - Accomodate modules as spoilage results.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.1.0
 Date: October 29th 2024


### PR DESCRIPTION
Pyhard added spoiling recipes where the spoil result is a module. This was not expected and caused loading errors (https://github.com/shpaass/yafc-ce/issues/313#issuecomment-2454222964). I fixed it by forcibly loading modules before anything else.
