### PR TITLE
Space age biter captivity

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -423,6 +423,7 @@ public class Entity : FactorioObject {
         : basePower;
     public EntityEnergy energy { get; internal set; } = null!; // TODO: Prove that this is always properly initialized. (Do we need an EntityWithEnergy type?)
     public Item[] itemsToPlace { get; internal set; } = null!; // null-forgiving: This is initialized in CalculateMaps.
+    internal FactorioObject[] miscSources { get; set; } = [];
     public int size { get; internal set; }
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Entities;
     public override string type => "Entity";
@@ -436,7 +437,7 @@ public class Entity : FactorioObject {
             return;
         }
 
-        collector.Add(itemsToPlace, DependencyList.Flags.ItemToPlace);
+        collector.Add([.. itemsToPlace, .. miscSources], DependencyList.Flags.ItemToPlace);
     }
 }
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -326,7 +326,7 @@ public class Item : Goods {
     /// </summary>
     /// <remarks>This forces modules to be loaded before other items, since deserialization otherwise creates Item objects for all spoil results.
     /// It does not protect against modules that spoil into other modules, but one hopes people won't do that.</remarks>
-    internal static string[] ExplicitPrototypeLoadOrder { get; } = ["module"];
+    internal static string[] ExplicitPrototypeLoadOrder { get; } = ["ammo", "module"];
 
     public Item? fuelResult { get; internal set; }
     public int stackSize { get; internal set; }
@@ -345,6 +345,11 @@ public class Item : Goods {
 
 public class Module : Item {
     public ModuleSpecification moduleSpecification { get; internal set; } = null!; // null-forgiving: Initialized by DeserializeItem.
+}
+
+internal class Ammo : Item {
+    internal HashSet<string> projectileNames { get; } = [];
+    internal HashSet<string>? targetFilter { get; set; }
 }
 
 public class Fluid : Goods {
@@ -486,6 +491,10 @@ public class EntityCrafter : EntityWithModules {
     }
     public float CraftingSpeed(Quality quality) => factorioType is "agricultural-tower" or "electric-energy-interface" ? baseCraftingSpeed : quality.ApplyStandardBonus(baseCraftingSpeed);
     public EffectReceiver effectReceiver { get; internal set; } = null!;
+}
+
+internal class EntityProjectile : Entity {
+    internal HashSet<string> placeEntities { get; } = [];
 }
 
 public sealed class Quality : FactorioObject {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -497,6 +497,10 @@ internal class EntityProjectile : Entity {
     internal HashSet<string> placeEntities { get; } = [];
 }
 
+internal class EntitySpawner : Entity {
+    internal string? capturedEntityName { get; set; }
+}
+
 public sealed class Quality : FactorioObject {
     public static Quality Normal { get; internal set; } = null!;
     /// <summary>

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -87,6 +87,8 @@ public enum RecipeFlags {
     ScaleProductionWithPower = 1 << 3,
     /// <summary>Set when the technology has a research trigger to craft an item</summary>
     HasResearchTriggerCraft = 1 << 4,
+    /// <summary>Set when the technology has a research trigger to capture a spawner</summary>
+    HasResearchTriggerCaptureEntity = 1 << 8,
 }
 
 public abstract class RecipeOrTechnology : FactorioObject {
@@ -690,6 +692,16 @@ public class Technology : RecipeOrTechnology { // Technology is very similar to 
     public Dictionary<Recipe, float> changeRecipeProductivity { get; internal set; } = [];
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Technologies;
     public override string type => "Technology";
+    /// <summary>
+    /// If the technology has a trigger that requires entities, they are stored here.
+    /// </summary>
+    /// <remarks>Lazy-loaded so the database can load and correctly type (eg EntityCrafter, EntitySpawner, etc.) the entities without having to do another pass.</remarks>
+    public IReadOnlyList<Entity> triggerEntities => getTriggerEntities.Value;
+
+    /// <summary>
+    /// Sets the value used to construct <see cref="triggerEntities"/>.
+    /// </summary>
+    internal Lazy<IReadOnlyList<Entity>> getTriggerEntities { get; set; } = new Lazy<IReadOnlyList<Entity>>(() => []);
 
     public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
         base.GetDependencies(collector, temp);

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -86,6 +86,23 @@ internal static class DataParserUtils {
     }
 
     public static IEnumerable<T> ArrayElements<T>(this LuaTable? table) => table?.ArrayElements.OfType<T>() ?? [];
+
+    /// <summary>
+    /// Reads a <see cref="LuaTable"/> that has the format "Thing or array[Thing]", and calls <paramref name="action"/> for each Thing in the array,
+    /// or for the passed Thing, as appropriate.
+    /// </summary>
+    /// <param name="table">A <see cref="LuaTable"/> that might be either an object or an array of objects.</param>
+    /// <param name="action">The action to perform on each object in <paramref name="table"/>.</param>
+    public static void ReadObjectOrArray(this LuaTable table, Action<LuaTable> action) {
+        if (table.ArrayElements.Count > 0) {
+            foreach (LuaTable entry in table.ArrayElements.OfType<LuaTable>()) {
+                action(entry);
+            }
+        }
+        else {
+            action(table);
+        }
+    }
 }
 
 public static class SpecialNames {

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -145,6 +145,8 @@ internal partial class FactorioDataDeserializer {
             DeserializePrototypes(raw, (string)prototypeName, DeserializeEntity, progress, errorCollector);
         }
 
+        ParseCaptureEffects();
+
         ParseModYafcHandles(data["script_enabled"] as LuaTable);
         progress.Report(("Post-processing", "Computing maps"));
         // Deterministically sort all objects

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -469,6 +469,10 @@ internal partial class FactorioDataDeserializer {
                 }
 
                 break;
+            case "unit-spawner":
+                var spawner = GetObject<Entity, EntitySpawner>(name);
+                spawner.capturedEntityName = table.Get<string>("captured_spawner_entity");
+                break;
         }
 
         var entity = DeserializeCommon<Entity>(table, "entity");

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -446,6 +446,29 @@ internal partial class FactorioDataDeserializer {
                 }
 
                 break;
+            case "projectile":
+                var projectile = GetObject<Entity, EntityProjectile>(name);
+                if (table["action"] is LuaTable actions) {
+                    actions.ReadObjectOrArray(parseAction);
+                }
+
+                void parseAction(LuaTable action) {
+                    if (action.Get<string>("type") == "direct" && action["action_delivery"] is LuaTable delivery) {
+                        delivery.ReadObjectOrArray(parseDelivery);
+                    }
+                }
+                void parseDelivery(LuaTable delivery) {
+                    if (delivery.Get<string>("type") == "instant" && delivery["target_effects"] is LuaTable effects) {
+                        effects.ReadObjectOrArray(parseEffect);
+                    }
+                }
+                void parseEffect(LuaTable effect) {
+                    if (effect.Get<string>("type") == "create-entity" && effect.Get("entity_name", out string? createdEntity)) {
+                        projectile.placeEntities.Add(createdEntity);
+                    }
+                }
+
+                break;
         }
 
         var entity = DeserializeCommon<Entity>(table, "entity");

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -286,6 +286,18 @@ internal partial class FactorioDataDeserializer {
                 technology.flags = RecipeFlags.HasResearchTriggerCraft;
 
                 break;
+            case "capture-spawner":
+                technology.flags = RecipeFlags.HasResearchTriggerCaptureEntity;
+                if (researchTriggerTable.Get<string>("entity") is string entity) {
+                    technology.getTriggerEntities = new(() => [((Entity)Database.objectsByTypeName["Entity." + entity])]);
+                }
+                else {
+                    technology.getTriggerEntities = new(static () =>
+                        Database.entities.all.OfType<EntitySpawner>()
+                        .Where(e => e.capturedEntityName != null)
+                        .ToList());
+                }
+                break;
             default:
                 errorCollector.Error($"Research trigger of {technology.typeDotName} has an unsupported type {type}", ErrorSeverity.MinorDataLoss);
                 break;

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -498,8 +498,10 @@ public class ObjectTooltip : Tooltip {
     }
 
     private static void BuildTechnology(Technology technology, ImGui gui) {
-        bool isResearchTriggerCraft = (technology.flags & RecipeFlags.HasResearchTriggerCraft) == RecipeFlags.HasResearchTriggerCraft;
-        if (!isResearchTriggerCraft) {
+        bool isResearchTriggerCraft = technology.flags.HasFlag(RecipeFlags.HasResearchTriggerCraft);
+        bool isResearchTriggerCapture = technology.flags.HasFlag(RecipeFlags.HasResearchTriggerCaptureEntity);
+
+        if (!isResearchTriggerCraft && !isResearchTriggerCapture) {
             BuildRecipe(technology, gui);
         }
 
@@ -522,6 +524,22 @@ public class ObjectTooltip : Tooltip {
                 using var grid = gui.EnterInlineGrid(3f);
                 grid.Next();
                 _ = gui.BuildFactorioObjectWithAmount(technology.ingredients[0].goods, technology.ingredients[0].amount, ButtonDisplayStyle.ProductionTableUnscaled);
+            }
+        }
+        else if (isResearchTriggerCapture) {
+            BuildSubHeader(gui, "Entity capture required");
+            using (gui.EnterGroup(contentPadding)) {
+                if (technology.triggerEntities.Count == 1) {
+                    gui.BuildText("Capture:");
+                    gui.BuildFactorioObjectButtonWithText(technology.triggerEntities[0]);
+
+                }
+                else {
+                    gui.BuildText("Capture one of:");
+                    foreach (var entity in technology.triggerEntities) {
+                        gui.BuildFactorioObjectButtonWithText(entity);
+                    }
+                }
             }
         }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
         - (SA) Process accessiblilty of captured spawners, which also fixes biter eggs and subsequent Gleba recipes.
+        - (SA) Add support for the capture-spawner technology trigger.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.2.0
 Date: November 6th 2024

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Features:
+        - (SA) Process accessiblilty of captured spawners, which also fixes biter eggs and subsequent Gleba recipes.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.2.0
 Date: November 6th 2024
     Features:


### PR DESCRIPTION
Closes #315; this treats ammo items that produce capture bots as placement items for the captured spawners, and reads the CaptureSpawnerTechnologyTrigger to display its information in the tooltips.

I ended up not reading CaptureRobotPrototype at all; it doesn't contain interesting information about what the capture robot does. The interesting information is the chain of triggers from an ammo item to a projectile entity to a capture bot entity, and also the (non-trigger) chain from the ammo item to the valid targets to the capture result.

I briefly considered trying to tie accessibility of captured spawners to both capture rockets and spawners, but (1) the dependency analyzer doesn't support "... or (A and B)" tests and (2) biter and spitter spawners are always accessible anyway.