### PR TITLE
docs(WelcomeScreen): Explain the loading exception

### DIFF
--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -115,6 +115,8 @@ public partial class ImGui {
         }
     }
 
+    public void BuildWrappedText(string text) => BuildText(text, TextBlockDisplayStyle.WrappedText);
+
     public Vector2 GetTextDimensions(out TextCache? cache, string? text, Font? font = null, bool wrap = false, float maxWidth = float.MaxValue) {
         if (string.IsNullOrEmpty(text)) {
             cache = null;

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -214,13 +214,12 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
     }
 
     private void ProjectErrorMoreInfo(ImGui gui) {
-        void buildWrappedText(string message) => gui.BuildText(message, TextBlockDisplayStyle.WrappedText);
 
-        buildWrappedText("Check that these mods load in Factorio.");
-        buildWrappedText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, " +
+        gui.BuildWrappedText("Check that these mods load in Factorio.");
+        gui.BuildWrappedText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, " +
             "you need to load those in Factorio and then close the game because Factorio saves mod-list.json only when exiting.");
-        buildWrappedText("Check that Factorio loads mods from the same folder as YAFC.");
-        buildWrappedText("If that doesn't help, try removing the mods that have several versions, or are disabled, or don't have the required dependencies.");
+        gui.BuildWrappedText("Check that Factorio loads mods from the same folder as YAFC.");
+        gui.BuildWrappedText("If that doesn't help, try removing the mods that have several versions, or are disabled, or don't have the required dependencies.");
 
         // The whole line is underlined if the allocator is not set to LeftAlign
         gui.allocator = RectAllocator.LeftAlign;
@@ -228,7 +227,7 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
             Ui.VisitLink(AboutScreen.Github);
         }
 
-        buildWrappedText("Please attach a new-game save file to sync mods, versions, and settings.");
+        gui.BuildWrappedText("Please attach a new-game save file to sync mods, versions, and settings.");
     }
 
     private static void DoLanguageList(ImGui gui, Dictionary<string, string> list, bool enabled) {

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -208,24 +208,18 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
     }
 
     private void ProjectErrorMoreInfo(ImGui gui) {
-        gui.allocator = RectAllocator.LeftAlign;
-        gui.BuildText("Check that these mods load in Factorio", TextBlockDisplayStyle.WrappedText);
+        void buildWrappedText(string message) => gui.BuildText(message, TextBlockDisplayStyle.WrappedText);
 
-        string factorioLoadedPassage = "YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, " +
-            "you need to load those in Factorio and then close the game because Factorio writes some files only when exiting";
-        gui.BuildText(factorioLoadedPassage, TextBlockDisplayStyle.WrappedText);
-        gui.BuildText("Check that Factorio loads mods from the same folder as YAFC", TextBlockDisplayStyle.WrappedText);
-
-        string modRemovalPassage = "If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, " +
-            "don't have required dependencies, or (especially) have several versions";
-        gui.BuildText(modRemovalPassage, TextBlockDisplayStyle.WrappedText);
-
+        buildWrappedText("Check that these mods load in Factorio");
+        buildWrappedText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, " +
+            "you need to load those in Factorio and then close the game because Factorio writes some files only when exiting");
+        buildWrappedText("Check that Factorio loads mods from the same folder as YAFC");
+        buildWrappedText("If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, " +
+            "don't have required dependencies, or (especially) have several versions");
         if (gui.BuildLink("If that doesn't help either, create a github issue")) {
             Ui.VisitLink(AboutScreen.Github);
         }
-
-        string gameSavePassage = "For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.";
-        gui.BuildText(gameSavePassage, TextBlockDisplayStyle.WrappedText);
+        buildWrappedText("For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.");
     }
 
     private static void DoLanguageList(ImGui gui, Dictionary<string, string> list, bool enabled) {

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -116,10 +116,16 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
         }
         else if (errorMessage != null) {
             errorScroll.Build(gui);
+            bool thereIsAModToDisable = (errorMod != null);
+
             using (gui.EnterRow()) {
-                string explanation = "YAFC was unable to load the project. You can disable the problematic mod once by clicking on 'Disable & reload' button, or you can disable it " +
-                                     "permanently for YAFC by copying the mod-folder, disabling the mod in the copy by editing mod-list.json, and pointing YAFC to the copy.";
-                gui.BuildText(explanation, TextBlockDisplayStyle.WrappedText);
+                if (thereIsAModToDisable) {
+                    gui.BuildWrappedText("YAFC was unable to load the project. You can disable the problematic mod once by clicking on 'Disable & reload' button, or you can disable it " +
+                                         "permanently for YAFC by copying the mod-folder, disabling the mod in the copy by editing mod-list.json, and pointing YAFC to the copy.");
+                }
+                else {
+                    gui.BuildWrappedText("YAFC cannot proceed because it was unable to load the project.");
+                }
             }
 
             using (gui.EnterRow()) {
@@ -132,8 +138,8 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
                 if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
                     _ = SDL.SDL_SetClipboardText(errorMessage);
                 }
-                if (errorMod != null && gui.BuildButton("Disable & reload").WithTooltip(gui, "Disable this mod until you close YAFC or change the mod folder.")) {
-                    FactorioDataSource.DisableMod(errorMod);
+                if (thereIsAModToDisable && gui.BuildButton("Disable & reload").WithTooltip(gui, "Disable this mod until you close YAFC or change the mod folder.")) {
+                    FactorioDataSource.DisableMod(errorMod!);
                     errorMessage = null;
                     LoadProject();
                 }

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -215,9 +215,13 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
             "you need to load those in Factorio and then close the game because Factorio writes some files only when exiting.");
         buildWrappedText("Check that Factorio loads mods from the same folder as YAFC.");
         buildWrappedText("If that doesn't help, try removing the mods that have several versions, or are disabled, or don't have the required dependencies.");
+
+        // The whole line is underlined if the allocator is not set to LeftAlign
+        gui.allocator = RectAllocator.LeftAlign;
         if (gui.BuildLink("If all else fails, then create an issue on GitHub")) {
             Ui.VisitLink(AboutScreen.Github);
         }
+
         buildWrappedText("Please attach a new-game save file to sync mods, versions, and settings.");
     }
 

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -210,16 +210,15 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
     private void ProjectErrorMoreInfo(ImGui gui) {
         void buildWrappedText(string message) => gui.BuildText(message, TextBlockDisplayStyle.WrappedText);
 
-        buildWrappedText("Check that these mods load in Factorio");
+        buildWrappedText("Check that these mods load in Factorio.");
         buildWrappedText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, " +
-            "you need to load those in Factorio and then close the game because Factorio writes some files only when exiting");
-        buildWrappedText("Check that Factorio loads mods from the same folder as YAFC");
-        buildWrappedText("If that doesn't help, try removing all the mods that are present but aren't loaded because they are disabled, " +
-            "don't have required dependencies, or (especially) have several versions");
-        if (gui.BuildLink("If that doesn't help either, create a github issue")) {
+            "you need to load those in Factorio and then close the game because Factorio writes some files only when exiting.");
+        buildWrappedText("Check that Factorio loads mods from the same folder as YAFC.");
+        buildWrappedText("If that doesn't help, try removing the mods that have several versions, or are disabled, or don't have the required dependencies.");
+        if (gui.BuildLink("If all else fails, then create an issue on GitHub")) {
             Ui.VisitLink(AboutScreen.Github);
         }
-        buildWrappedText("For these types of errors simple mod list will not be enough. You need to attach a 'New game' save game for syncing mods, mod versions and mod settings.");
+        buildWrappedText("Please attach a new-game save file to sync mods, versions, and settings.");
     }
 
     private static void DoLanguageList(ImGui gui, Dictionary<string, string> list, bool enabled) {

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -218,7 +218,7 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
 
         buildWrappedText("Check that these mods load in Factorio.");
         buildWrappedText("YAFC only supports loading mods that were loaded in Factorio before. If you add or remove mods or change startup settings, " +
-            "you need to load those in Factorio and then close the game because Factorio writes some files only when exiting.");
+            "you need to load those in Factorio and then close the game because Factorio saves mod-list.json only when exiting.");
         buildWrappedText("Check that Factorio loads mods from the same folder as YAFC.");
         buildWrappedText("If that doesn't help, try removing the mods that have several versions, or are disabled, or don't have the required dependencies.");
 

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -117,11 +117,17 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
         else if (errorMessage != null) {
             errorScroll.Build(gui);
             using (gui.EnterRow()) {
-                gui.BuildText("This error is critical. Unable to load project.");
+                string explanation = "YAFC was unable to load the project. You can disable the problematic mod once by clicking on 'Disable & reload' button, or you can disable it " +
+                                     "permanently for YAFC by copying the mod-folder, disabling the mod in the copy by editing mod-list.json, and pointing YAFC to the copy.";
+                gui.BuildText(explanation, TextBlockDisplayStyle.WrappedText);
+            }
+
+            using (gui.EnterRow()) {
                 if (gui.BuildLink("More info")) {
                     ShowDropDown(gui, gui.lastRect, ProjectErrorMoreInfo, new Padding(0.5f), 30f);
                 }
             }
+
             using (gui.EnterRow()) {
                 if (gui.BuildButton("Copy to clipboard", SchemeColor.Grey)) {
                     _ = SDL.SDL_SetClipboardText(errorMessage);

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date:
         - (SA) Add support for the capture-spawner technology trigger.
         - Add the remaining research triggers and the mining-with-fluid research effect to the dependency/milestone
           analysis.
+        - Explain what to do if Yafc fails to load a mod.
     Internal changes:
         - Using the LuaContext after it is freed now produces a better error.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
People were asking what to do when the mod fails to load, so I explained it some more in this change.
The reasonings behind the changes are explained in the commit messages. 

The change that _might_ break the popup is the removal of `gui.allocator = RectAllocator.LeftAlign;` in https://github.com/shpaass/yafc-ce/commit/02170b9e414f8714dd13b3bb8778c5aed858abd7.  
I tested the resulting popup, so it's unlikely that it would break as the error-window size is constant, from what I understand.

This PR closes #342.