### PR TITLE
Space age spoilage

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -329,6 +329,12 @@ public abstract class Goods : FactorioObject {
 }
 
 public class Item : Goods {
+    public Item() {
+        getSpoilResult = new(() => getSpoilRecipe()?.products[0].goods);
+        getBaseSpoilTime = new(() => getSpoilRecipe()?.time ?? 0);
+        Recipe? getSpoilRecipe() => Database.recipes.all.OfType<Mechanics>().SingleOrDefault(r => r.name == "spoil." + name);
+    }
+
     /// <summary>
     /// The prototypes in this array will be loaded in order, before any other prototypes.
     /// This should correspond to the prototypes for subclasses of item, with more derived classes listed before their base classes.
@@ -347,6 +353,29 @@ public class Item : Goods {
     public override string type => "Item";
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Items;
     public override UnitOfMeasure flowUnitOfMeasure => UnitOfMeasure.ItemPerSecond;
+    /// <summary>
+    /// Gets the result when this item spoils, or <see langword="null"/> if this item doesn't spoil.
+    /// </summary>
+    public FactorioObject? spoilResult => getSpoilResult.Value;
+    /// <summary>
+    /// Gets the time it takes for a base-quality item to spoil, in seconds, or 0 if this item doesn't spoil.
+    /// </summary>
+    public float baseSpoilTime => getBaseSpoilTime.Value;
+    /// <summary>
+    /// Gets the <see cref="Quality"/>-adjusted spoilage time for this item, in seconds, or 0 if this item doesn't spoil.
+    /// </summary>
+    public float GetSpoilTime(Quality quality) => quality.ApplyStandardBonus(baseSpoilTime);
+
+    /// <summary>
+    /// The lazy store for getting the spoilage result. By default it searches for and reads a $"Mechanics.spoil.{name}" recipe,
+    /// but it can be overridden for items that spoil into Entities.
+    /// </summary>
+    internal Lazy<FactorioObject?> getSpoilResult;
+    /// <summary>
+    /// The lazy store for getting the normal-quality spoilage time. By default it searches for and reads a $"Mechanics.spoil.{name}" recipe,
+    /// but it can be overridden for items that spoil into Entities.
+    /// </summary>
+    internal Lazy<float> getBaseSpoilTime;
 
     public override bool HasSpentFuel([NotNullWhen(true)] out Item? spent) {
         spent = fuelResult;

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -170,6 +170,8 @@ public class Recipe : RecipeOrTechnology {
     public string[]? allowedModuleCategories { get; internal set; }
     public Technology[] technologyUnlock { get; internal set; } = [];
     public Dictionary<Technology, float> technologyProductivity { get; internal set; } = [];
+    public bool preserveProducts { get; internal set; }
+
     public bool HasIngredientVariants() {
         foreach (var ingredient in ingredients) {
             if (ingredient.variants != null) {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -248,6 +248,11 @@ public class Product : IFactorioObjectWrapper {
     internal readonly float amountMax;
     internal readonly float probability;
     public readonly float amount; // This is average amount including probability and range
+    /// <summary>
+    /// Gets or sets the fixed freshness of this product: 0 if the recipe has result_is_always_fresh, or percent_spoiled from the
+    /// ItemProductPrototype, or <see langword="null"/> if neither of those values are set.
+    /// </summary>
+    public float? percentSpoiled { get; internal set; }
     internal float productivityAmount { get; private set; }
 
     public void SetCatalyst(float catalyst) {
@@ -283,7 +288,10 @@ public class Product : IFactorioObjectWrapper {
         amount = productivityAmount = probability * (min + max) / 2;
     }
 
-    public bool IsSimple => amountMin == amountMax && probability == 1f;
+    /// <summary>
+    /// Gets <see langword="true"/> if this product is one item with 100% probability and default spoilage behavior.
+    /// </summary>
+    public bool IsSimple => amountMin == amountMax && amount == 1 && probability == 1 && percentSpoiled == null;
 
     FactorioObject IFactorioObjectWrapper.target => goods;
 
@@ -300,6 +308,16 @@ public class Product : IFactorioObjectWrapper {
             }
             if (probability != 1f) {
                 text = DataUtils.FormatAmount(probability, UnitOfMeasure.Percent) + " " + text;
+            }
+            else if (amountMin == 1 && amountMax == 1) {
+                text = "1x " + text;
+            }
+
+            if (percentSpoiled == 0) {
+                text += ", always fresh";
+            }
+            else if (percentSpoiled != null) {
+                text += ", " + DataUtils.FormatAmount(percentSpoiled.Value, UnitOfMeasure.Percent) + " spoiled";
             }
 
             return text;

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -487,6 +487,23 @@ public class Entity : FactorioObject {
     public int size { get; internal set; }
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Entities;
     public override string type => "Entity";
+    /// <summary>
+    /// Gets the result when this entity spoils (possibly <see langword="null"/>, if the entity burns out with no replacement),
+    /// or <see langword="null"/> if this entity doesn't spoil.
+    /// </summary>
+    public Entity? spoilResult => getSpoilResult?.Value;
+    /// <summary>
+    /// Gets the time it takes for a base-quality entity to spoil, in seconds, or 0 if this entity doesn't spoil.
+    /// </summary>
+    public float baseSpoilTime { get; internal set; }
+    /// <summary>
+    /// Gets the <see cref="Quality"/>-adjusted spoilage time for this entity, in seconds, or 0 if this entity doesn't spoil.
+    /// </summary>
+    public float GetSpoilTime(Quality quality) => quality.ApplyStandardBonus(baseSpoilTime);
+    /// <summary>
+    /// The lazy store for getting the spoilage result, if this entity spoils.
+    /// </summary>
+    internal Lazy<Entity?>? getSpoilResult;
 
     public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
         if (energy != null) {

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -449,15 +449,15 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
                         handledFuel = true;
                     }
 
-                    yield return (product.goods, amount, links.products[i++]);
+                    yield return (product.goods, amount, links.products[i++], product.percentSpoiled);
                 }
                 else {
-                    yield return (null, 0, null);
+                    yield return (null, 0, null, null);
                 }
             }
 
             if (!handledFuel) {
-                yield return hierarchyEnabled ? (spentFuel, fuelUsagePerSecond, links.spentFuel) : (null, 0, null);
+                yield return hierarchyEnabled ? (spentFuel, fuelUsagePerSecond, links.spentFuel, null) : (null, 0, null, null);
             }
         }
     }
@@ -745,7 +745,9 @@ public record RecipeRowIngredient(Goods? Goods, float Amount, ProductionLink? Li
         => new(value.Goods, value.Amount, value.Link, value.Variants);
 }
 
-public record RecipeRowProduct(Goods? Goods, float Amount, ProductionLink? Link) {
-    public static implicit operator (Goods? Goods, float Amount, ProductionLink? Link)(RecipeRowProduct value) => (value.Goods, value.Amount, value.Link);
-    public static implicit operator RecipeRowProduct((Goods? Goods, float Amount, ProductionLink? Link) value) => new(value.Goods, value.Amount, value.Link);
+public record RecipeRowProduct(Goods? Goods, float Amount, ProductionLink? Link, float? PercentSpoiled) {
+    public static implicit operator (Goods? Goods, float Amount, ProductionLink? Link, float? PercentSpoiled)(RecipeRowProduct value)
+        => (value.Goods, value.Amount, value.Link, value.PercentSpoiled);
+    public static implicit operator RecipeRowProduct((Goods? Goods, float Amount, ProductionLink? Link, float? PercentSpoiled) value)
+        => new(value.Goods, value.Amount, value.Link, value.PercentSpoiled);
 }

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -225,6 +225,8 @@ public class ProjectSettings(Project project) : ModelObject<Project>(project) {
     public int reactorSizeX { get; set; } = 2;
     public int reactorSizeY { get; set; } = 2;
     public float PollutionCostModifier { get; set; } = 0;
+    public float spoilingRate { get; set; } = 1;
+
     public event Action<bool>? changed;
     protected internal override void ThisChanged(bool visualOnly) => changed?.Invoke(visualOnly);
 

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -7,27 +7,33 @@ namespace Yafc.Parser;
 
 internal static class DataParserUtils {
     private static class ConvertersFromLua<T> {
-        public static Func<object, T, T>? convert;
+        public static Converter? convert;
+
+        [return: NotNullIfNotNull(nameof(@default))]
+        public delegate T Converter(object value, T @default);
     }
 
     static DataParserUtils() {
         ConvertersFromLua<int>.convert = (o, def) => o is long l ? (int)l : o is double d ? (int)d : o is string s && int.TryParse(s, out int res) ? res : def;
+        ConvertersFromLua<int?>.convert = (o, def) => o is long l ? (int)l : o is double d ? (int)d : o is string s && int.TryParse(s, out int res) ? res : def;
         ConvertersFromLua<float>.convert = (o, def) => o is long l ? l : o is double d ? (float)d : o is string s && float.TryParse(s, out float res) ? res : def;
-        ConvertersFromLua<bool>.convert = delegate (object src, bool def) {
+        ConvertersFromLua<float?>.convert = (o, def) => o is long l ? l : o is double d ? (float)d : o is string s && float.TryParse(s, out float res) ? res : def;
+        ConvertersFromLua<bool>.convert = (o, def) => ConvertersFromLua<bool?>.convert!(o, def).Value;
+        ConvertersFromLua<bool?>.convert = (o, def) => {
 
-            if (src is bool b) {
+            if (o is bool b) {
                 return b;
             }
 
-            if (src == null) {
+            if (o == null) {
                 return def;
             }
 
-            if (src.Equals("true")) {
+            if (o.Equals("true")) {
                 return true;
             }
 
-            if (src.Equals("false")) {
+            if (o.Equals("false")) {
                 return false;
             }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -168,7 +168,7 @@ internal partial class FactorioDataDeserializer {
         }
     }
 
-    private Func<LuaTable, Product> LoadProduct(string typeDotName, int multiplier = 1) => table => {
+    private Func<LuaTable, Product> LoadProduct(string typeDotName, int multiplier = 1, float? percentSpoiled = null) => table => {
         Goods? goods = LoadItemOrFluid(table, true);
 
         float min, max, catalyst;
@@ -183,6 +183,8 @@ internal partial class FactorioDataDeserializer {
             else {
                 throw new NotSupportedException($"Could not load amount for one of the products for {typeDotName}, possibly named '{table.Get("name", "")}'.");
             }
+
+            percentSpoiled ??= table.Get<float?>("percent_spoiled");
 
             float extraCountFraction = table.Get("extra_count_fraction", 0f);
             min += extraCountFraction;
@@ -207,7 +209,7 @@ internal partial class FactorioDataDeserializer {
             throw new NotSupportedException($"Could not load one of the products for {typeDotName}, possibly named '{table.Get("name", "")}'.");
         }
 
-        Product product = new Product(goods, min * multiplier, max * multiplier, table.Get("probability", 1f));
+        Product product = new Product(goods, min * multiplier, max * multiplier, table.Get("probability", 1f)) { percentSpoiled = percentSpoiled };
 
         if (catalyst > 0f) {
             product.SetCatalyst(catalyst);
@@ -217,12 +219,14 @@ internal partial class FactorioDataDeserializer {
     };
 
     private Product[] LoadProductList(LuaTable table, string typeDotName, bool allowSimpleSyntax) {
+        float? percentSpoiled = table.Get("result_is_always_fresh", false) ? 0 : null;
+
         if (table.Get("results", out LuaTable? resultList)) {
-            return resultList.ArrayElements<LuaTable>().Select(LoadProduct(typeDotName)).Where(x => x.amount != 0).ToArray();
+            return resultList.ArrayElements<LuaTable>().Select(LoadProduct(typeDotName, percentSpoiled: percentSpoiled)).Where(x => x.amount != 0).ToArray();
         }
 
         if (allowSimpleSyntax && table.Get("result", out string? name)) {
-            return [(new Product(GetObject<Item>(name), 1))];
+            return [(new Product(GetObject<Item>(name), 1) { percentSpoiled = percentSpoiled })];
         }
 
         return [];

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -336,6 +336,7 @@ internal partial class FactorioDataDeserializer {
         recipe.products = LoadProductList(table, recipe.typeDotName, allowSimpleSyntax: false);
 
         recipe.time = table.Get("energy_required", 0.5f);
+        recipe.preserveProducts = table.Get("preserve_products_in_machine_output", false);
 
         if (table.Get("main_product", out string? mainProductName) && mainProductName != "") {
             recipe.mainProduct = recipe.products.FirstOrDefault(x => x.goods.name == mainProductName)?.goods;

--- a/Yafc/Utils/ObjectDisplayStyles.cs
+++ b/Yafc/Utils/ObjectDisplayStyles.cs
@@ -8,7 +8,8 @@ namespace Yafc.UI;
 /// <param name="Size">The icon size. The production tables use size 3.</param>
 /// <param name="MilestoneDisplay">The <see cref="Yafc.MilestoneDisplay"/> option to use when drawing the icon.</param>
 /// <param name="UseScaleSetting">Whether or not to obey the <see cref="Model.ProjectPreferences.iconScale"/> setting.</param>
-public record IconDisplayStyle(float Size, MilestoneDisplay MilestoneDisplay, bool UseScaleSetting) {
+/// <param name="AlwaysAccessible">If <see langword="true"/>, this icon will always be drawn as if the <see cref="FactorioObject"/> is accessible.</param>
+public record IconDisplayStyle(float Size, MilestoneDisplay MilestoneDisplay, bool UseScaleSetting, bool AlwaysAccessible = false) {
     /// <summary>
     /// Gets the default icon style: Size 2, <see cref="MilestoneDisplay.Normal"/>, and not scaled.
     /// </summary>

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -96,7 +96,7 @@ public static class ImmediateWidgets {
 
             gui.DrawIcon(qualityRect, quality.icon, SchemeColor.Source);
         }
-        if (gui.isBuilding && obj.target is Item { baseSpoilTime: > 0 }) {
+        if (gui.isBuilding && obj.target is Item { baseSpoilTime: > 0 } or Entity { baseSpoilTime: > 0 }) {
             Vector2 size = new Vector2(displayStyle.Size / 2.5f);
             Rect spoilableRect = new Rect(gui.lastRect.TopLeft, size);
 

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -68,7 +68,7 @@ public static class ImmediateWidgets {
             return;
         }
 
-        SchemeColor color = obj.target.IsAccessible() ? SchemeColor.Source : SchemeColor.SourceFaint;
+        SchemeColor color = (obj.target.IsAccessible() || displayStyle.AlwaysAccessible) ? SchemeColor.Source : SchemeColor.SourceFaint;
         if (displayStyle.UseScaleSetting) {
             Rect rect = gui.AllocateRect(displayStyle.Size, displayStyle.Size, RectAlignment.Middle);
             gui.DrawIcon(rect.Expand(displayStyle.Size * (Project.current.preferences.iconScale - 1) / 2), obj.target.icon, color);
@@ -95,6 +95,12 @@ public static class ImmediateWidgets {
             Rect qualityRect = new Rect(gui.lastRect.BottomLeft - delta, size);
 
             gui.DrawIcon(qualityRect, quality.icon, SchemeColor.Source);
+        }
+        if (gui.isBuilding && obj.target is Item { baseSpoilTime: > 0 }) {
+            Vector2 size = new Vector2(displayStyle.Size / 2.5f);
+            Rect spoilableRect = new Rect(gui.lastRect.TopLeft, size);
+
+            gui.DrawIcon(spoilableRect, Icon.Time, SchemeColor.PureForeground);
         }
     }
 
@@ -163,7 +169,7 @@ public static class ImmediateWidgets {
         using (gui.EnterRow()) {
             gui.BuildFactorioObjectIcon(obj, iconDisplayStyle);
             var color = gui.textColor;
-            if (obj != null && !obj.target.IsAccessible()) {
+            if (obj != null && !obj.target.IsAccessible() && !iconDisplayStyle.AlwaysAccessible) {
                 color += 1;
             }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -339,6 +339,7 @@ public class ObjectTooltip : Tooltip {
                 float spoilTime = perishable.GetSpoilTime(quality) / Project.current.settings.spoilingRate;
                 gui.BuildText($"After {DataUtils.FormatTime(spoilTime)}, spoils into");
                 gui.BuildFactorioObjectButtonWithText(spoiled, iconDisplayStyle: IconDisplayStyle.Default with { AlwaysAccessible = true });
+                tooltipOptions.ExtraSpoilInformation?.Invoke(gui);
             }
         }
 
@@ -441,7 +442,7 @@ public class ObjectTooltip : Tooltip {
             }
         }
 
-        if (recipe.products.Length > 0 && !(recipe.products.Length == 1 && recipe.products[0].IsSimple && recipe.products[0].goods is Item && recipe.products[0].amount == 1f)) {
+        if (recipe.products.Length > 0 && !(recipe.products.Length == 1 && recipe.products[0].IsSimple && recipe.products[0].goods is Item)) {
             BuildSubHeader(gui, "Products");
             using (gui.EnterGroup(contentPadding)) {
                 foreach (var product in recipe.products) {
@@ -634,9 +635,13 @@ public struct ObjectTooltipOptions {
     /// </summary>
     public HintLocations HintLocations { get; set; }
     /// <summary>
-    /// Gets or sets a value that, if not null, will be called after drawing the tooltip header.
+    /// Gets or sets a value that, if not <see langword="null"/>, will be called after drawing the tooltip header.
     /// </summary>
     public DrawBelowHeader? DrawBelowHeader { get; set; }
+    /// <summary>
+    /// Gets or sets a value that, if not <see langword="null"/>, will be called after drawing the spoilage information.
+    /// </summary>
+    public GuiBuilder ExtraSpoilInformation { get; set; }
 
     // Reduce boilerplate by permitting unambiguous and relatively obvious implicit conversions.
     public static implicit operator ObjectTooltipOptions(HintLocations hintLocations) => new() { HintLocations = hintLocations };

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -333,6 +333,15 @@ public class ObjectTooltip : Tooltip {
             }
         }
 
+        if (goods is Item { spoilResult: FactorioObject spoiled } perishable) {
+            BuildSubHeader(gui, "Perishable");
+            using (gui.EnterGroup(contentPadding)) {
+                float spoilTime = perishable.GetSpoilTime(quality);
+                gui.BuildText($"After {DataUtils.FormatTime(spoilTime)}, spoils into");
+                gui.BuildFactorioObjectButtonWithText(spoiled, iconDisplayStyle: IconDisplayStyle.Default with { AlwaysAccessible = true });
+            }
+        }
+
         if (goods.fuelFor.Length > 0) {
             if (goods.fuelValue > 0f) {
                 BuildSubHeader(gui, "Fuel value " + DataUtils.FormatAmount(goods.fuelValue, UnitOfMeasure.Megajoule) + " used for:");
@@ -588,7 +597,8 @@ public class ObjectTooltip : Tooltip {
             ("Crafting speed:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
             ("Accumulator capacity:", '+' + DataUtils.FormatAmount(quality.AccumulatorCapacityBonus, UnitOfMeasure.Percent)),
             ("Module effects:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent) + '*'),
-            ("Beacon transmission efficiency:", '+' + DataUtils.FormatAmount(quality.BeaconTransmissionBonus, UnitOfMeasure.None))
+            ("Beacon transmission efficiency:", '+' + DataUtils.FormatAmount(quality.BeaconTransmissionBonus, UnitOfMeasure.None)),
+            ("Time before spoiling:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
         ];
 
         float rightWidth = text.Max(t => gui.GetTextDimensions(out _, t.right).X);

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -117,10 +117,10 @@ public class ObjectTooltip : Tooltip {
         }
     }
 
-    private static void BuildItem(ImGui gui, IFactorioObjectWrapper item) {
+    private static void BuildItem(ImGui gui, IFactorioObjectWrapper item, string? extraText = null) {
         using (gui.EnterRow()) {
             gui.BuildFactorioObjectIcon(item.target);
-            gui.BuildText(item.text, TextBlockDisplayStyle.WrappedText);
+            gui.BuildText(item.text + extraText, TextBlockDisplayStyle.WrappedText);
         }
     }
 
@@ -445,8 +445,9 @@ public class ObjectTooltip : Tooltip {
         if (recipe.products.Length > 0 && !(recipe.products.Length == 1 && recipe.products[0].IsSimple && recipe.products[0].goods is Item)) {
             BuildSubHeader(gui, "Products");
             using (gui.EnterGroup(contentPadding)) {
+                string? extraText = recipe is Recipe { preserveProducts: true } ? ", preserved until removed from the machine" : null;
                 foreach (var product in recipe.products) {
-                    BuildItem(gui, product);
+                    BuildItem(gui, product, extraText);
                 }
             }
         }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -192,7 +192,7 @@ public class ObjectTooltip : Tooltip {
         {EntityEnergyType.SolidFuel, "Solid fuel energy usage: "},
     };
 
-    private static void BuildEntity(Entity entity, Quality quality, ImGui gui) {
+    private void BuildEntity(Entity entity, Quality quality, ImGui gui) {
         if (entity.loot.Length > 0) {
             BuildSubHeader(gui, "Loot");
             using (gui.EnterGroup(contentPadding)) {
@@ -237,6 +237,21 @@ public class ObjectTooltip : Tooltip {
                 using (gui.EnterGroup(contentPadding)) {
                     BuildIconRow(gui, crafter.inputs, 2);
                 }
+            }
+        }
+
+        float spoilTime = entity.GetSpoilTime(quality); // The spoiling rate setting does not apply to entities.
+        if (spoilTime != 0f) {
+            BuildSubHeader(gui, "Perishable");
+            using (gui.EnterGroup(contentPadding)) {
+                if (entity.spoilResult != null) {
+                    gui.BuildText($"After {DataUtils.FormatTime(spoilTime)} of no production, spoils into");
+                    gui.BuildFactorioObjectButtonWithText(new ObjectWithQuality<Entity>(entity.spoilResult, quality), iconDisplayStyle: IconDisplayStyle.Default with { AlwaysAccessible = true });
+                }
+                else {
+                    gui.BuildText($"Expires after {DataUtils.FormatTime(spoilTime)} of no production");
+                }
+                tooltipOptions.ExtraSpoilInformation?.Invoke(gui);
             }
         }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -336,7 +336,7 @@ public class ObjectTooltip : Tooltip {
         if (goods is Item { spoilResult: FactorioObject spoiled } perishable) {
             BuildSubHeader(gui, "Perishable");
             using (gui.EnterGroup(contentPadding)) {
-                float spoilTime = perishable.GetSpoilTime(quality);
+                float spoilTime = perishable.GetSpoilTime(quality) / Project.current.settings.spoilingRate;
                 gui.BuildText($"After {DataUtils.FormatTime(spoilTime)}, spoils into");
                 gui.BuildFactorioObjectButtonWithText(spoiled, iconDisplayStyle: IconDisplayStyle.Default with { AlwaysAccessible = true });
             }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -157,6 +157,15 @@ public class PreferencesScreen : PseudoScreen {
             }
         }
 
+        using (gui.EnterRowWithHelpIcon("Set this to match the spoiling rate you selected when starting your game. 10% is slow spoiling, and 1000% (1k%) is fast spoiling.")) {
+            gui.BuildText("Spoiling rate:", topOffset: 0.5f);
+            DisplayAmount amount = new(settings.spoilingRate, UnitOfMeasure.Percent);
+            if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.DefaultTextInput)) {
+                settings.RecordUndo().spoilingRate = Math.Clamp(amount.Value, .1f, 10);
+                gui.Rebuild();
+            }
+        }
+
         gui.AllocateSpacing();
 
         if (gui.BuildCheckBox("Dark mode", Preferences.Instance.darkMode, out bool newValue)) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -586,7 +586,13 @@ goodsHaveNoProduction:;
             else {
                 foreach (var (goods, amount, link, percentSpoiled) in recipe.Products) {
                     grid.Next();
-                    if (percentSpoiled == null) {
+                    if (recipe.recipe is Recipe { preserveProducts: true }) {
+                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, new() {
+                            HintLocations = HintLocations.OnConsumingRecipes,
+                            ExtraSpoilInformation = gui => gui.BuildText("This recipe output does not start spoiling until removed from the machine.", TextBlockDisplayStyle.WrappedText)
+                        });
+                    }
+                    else if (percentSpoiled == null) {
                         view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
                     }
                     else if (percentSpoiled == 0) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -584,9 +584,21 @@ goodsHaveNoProduction:;
                 view.BuildTableProducts(gui, recipe.subgroup, recipe.owner, ref grid, false);
             }
             else {
-                foreach (var (goods, amount, link) in recipe.Products) {
+                foreach (var (goods, amount, link, percentSpoiled) in recipe.Products) {
                     grid.Next();
-                    view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
+                    if (percentSpoiled == null) {
+                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
+                    }
+                    else if (percentSpoiled == 0) {
+                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot,
+                            new() { HintLocations = HintLocations.OnConsumingRecipes, ExtraSpoilInformation = gui => gui.BuildText("This recipe output is always fresh.") });
+                    }
+                    else {
+                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, new() {
+                            HintLocations = HintLocations.OnConsumingRecipes,
+                            ExtraSpoilInformation = gui => gui.BuildText($"This recipe output is {DataUtils.FormatAmount(percentSpoiled.Value, UnitOfMeasure.Percent)} spoiled.")
+                        });
+                    }
                 }
                 if (recipe.fixedProduct == Database.itemOutput || recipe.showTotalIO) {
                     grid.Next();

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,11 +18,12 @@
 Version:
 Date:
     Features:
-        - (SA) Process accessiblilty of captured spawners, which also fixes biter eggs and subsequent Gleba recipes.
+        - (SA) Process accessibilty of captured spawners, which also fixes biter eggs and subsequent Gleba recipes.
         - (SA) Add support for the capture-spawner technology trigger.
         - Add the remaining research triggers and the mining-with-fluid research effect to the dependency/milestone
           analysis.
         - Explain what to do if Yafc fails to load a mod.
+        - (SA) Add spoiling time and result to item tooltips. Add a clock overlay to icons for perishable items.
     Internal changes:
         - Using the LuaContext after it is freed now produces a better error.
 ----------------------------------------------------------------------------------------------------------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,7 +23,7 @@ Date:
         - Add the remaining research triggers and the mining-with-fluid research effect to the dependency/milestone
           analysis.
         - Explain what to do if Yafc fails to load a mod.
-        - (SA) Add spoiling time and result to item tooltips. Add a clock overlay to icons for perishable items.
+        - (SA) Add spoiling time and result to tooltips. Add a clock overlay to icons for perishable items/entities.
     Internal changes:
         - Using the LuaContext after it is freed now produces a better error.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This loads and displays all the spoiling information from #313, except "Mark spoil result items in GUI", which I don't think is necessary; and "Support spoilable science packs", which can be accomplished for now by setting the table to have (excess) desired output.

Perishable items and entities get a clock overlay on their icon, and a new "Perishable" section in their tooltip. If they are recipe outputs they may also get a "This recipe output ..." string.
![image](https://github.com/user-attachments/assets/12d49fcc-aba5-47c3-a171-fbf9162aa4b9)

Recipes that have non-default spoil behavior describe that behavior in their tooltip.
![image](https://github.com/user-attachments/assets/bf2ae9cd-cd40-4108-854d-9586678a1060)