### PR TITLE
fix: support long/ulong coming from mod settings

### DIFF
--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -353,6 +353,12 @@ internal partial class LuaContext : IDisposable {
         else if (value is int i) {
             lua_pushnumber(L, i);
         }
+        else if (value is long l) {
+            lua_pushnumber(L, l);
+        }
+        else if (value is ulong ul) {
+            lua_pushnumber(L, ul);
+        }
         else if (value is string s) {
             _ = lua_pushstring(L, s);
         }


### PR DESCRIPTION
This made the cybersyn-combinator mod (and probably others) fail to load