### PR TITLE
Selection window cleanup

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -490,6 +490,9 @@ public enum AllowedEffects {
 }
 
 public class Tile : FactorioObject {
+    // Tiles participate in accessibility analysis, but only until the pumping recipes get around to reading the locations where their tiles
+    // appear. They often don't have an icon, and don't participate in anything else Yafc cares about, so hide them.
+    public Tile() => showInExplorers = false;
     public Fluid? Fluid { get; internal set; }
 
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Tiles;

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -380,9 +380,8 @@ internal partial class FactorioDataDeserializer {
     }
 
     private void DeserializeItem(LuaTable table, ErrorCollector _1) {
-        string name = table.Get("name", "");
         if (table.Get("type", "") == "module" && table.Get("effect", out LuaTable? moduleEffect)) {
-            Module module = GetObject<Item, Module>(name);
+            Module module = GetObject<Item, Module>(table);
             var effect = ParseEffect(moduleEffect);
             module.moduleSpecification = new ModuleSpecification {
                 category = table.Get("category", ""),
@@ -394,7 +393,7 @@ internal partial class FactorioDataDeserializer {
             };
         }
         else if (table.Get("type", "") == "ammo" && table["ammo_type"] is LuaTable ammo_type) {
-            Ammo ammo = GetObject<Item, Ammo>(name);
+            Ammo ammo = GetObject<Item, Ammo>(table);
             ammo_type.ReadObjectOrArray(readAmmoType);
 
             if (ammo_type["target_filter"] is LuaTable targets) {
@@ -556,13 +555,13 @@ internal partial class FactorioDataDeserializer {
     private Goods? LoadItemOrFluid(LuaTable table, bool useTemperature) {
         if (table.Get("type", out string? type) && table.Get("name", out string? name)) {
             if (type == "item") {
-                return GetObject<Item>(name);
+                return GetObject<Item>(table);
             }
             else if (type == "fluid") {
                 if (useTemperature && table.Get("temperature", out int temperature)) {
                     return GetFluidFixedTemp(name, temperature);
                 }
-                return GetObject<Fluid>(name);
+                return GetObject<Fluid>(table);
             }
         }
 
@@ -599,7 +598,7 @@ internal partial class FactorioDataDeserializer {
             throw new NotSupportedException($"Read a definition of a {prototypeType} that does not have a name.");
         }
 
-        var target = GetObject<T>(name);
+        var target = GetObject<T>(table);
         target.factorioType = table.Get("type", "");
 
         if (table.Get("localised_name", out object? loc)) {  // Keep UK spelling for Factorio/LUA data objects

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -176,14 +176,14 @@ internal partial class FactorioDataDeserializer {
             // case "furnace":
             // case "rocket-silo": // Out of order
             case "accumulator":
-                var accumulator = GetObject<Entity, EntityAccumulator>(name);
+                var accumulator = GetObject<Entity, EntityAccumulator>(table);
 
                 if (table.Get("energy_source", out LuaTable? accumulatorEnergy) && accumulatorEnergy.Get("buffer_capacity", out string? capacity)) {
                     accumulator.baseAccumulatorCapacity = ParseEnergy(capacity);
                 }
                 break;
             case "agricultural-tower":
-                var agriculturalTower = GetObject<Entity, EntityCrafter>(name);
+                var agriculturalTower = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("energy_usage", out usesPower);
                 agriculturalTower.basePower = ParseEnergy(usesPower);
                 float radius = table.Get("radius", 1f);
@@ -194,7 +194,7 @@ internal partial class FactorioDataDeserializer {
             case "assembling-machine":
                 goto case "furnace";
             case "asteroid":
-                Entity asteroid = GetObject<Entity>(name);
+                Entity asteroid = GetObject<Entity>(table);
                 if (table.Get("dying_trigger_effect", out LuaTable? death)) {
                     death.ReadObjectOrArray(trigger => {
                         switch (trigger.Get<string>("type")) {
@@ -207,7 +207,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "asteroid-collector":
-                EntityCrafter collector = GetObject<Entity, EntityCrafter>(name);
+                EntityCrafter collector = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("arm_energy_usage", out usesPower);
                 collector.basePower = ParseEnergy(usesPower) * 60;
                 _ = table.Get("passive_energy_usage", out usesPower);
@@ -216,7 +216,7 @@ internal partial class FactorioDataDeserializer {
                 recipeCrafters.Add(collector, SpecialNames.AsteroidCapture);
                 break;
             case "beacon":
-                var beacon = GetObject<Entity, EntityBeacon>(name);
+                var beacon = GetObject<Entity, EntityBeacon>(table);
                 beacon.baseBeaconEfficiency = table.Get("distribution_effectivity", 0f);
                 beacon.profile = table.Get("profile", out LuaTable? profile) ? profile.ArrayElements<double>().Select(x => (float)x).ToArray() : [1f];
                 _ = table.Get("energy_usage", out usesPower);
@@ -224,7 +224,7 @@ internal partial class FactorioDataDeserializer {
                 beacon.basePower = ParseEnergy(usesPower);
                 break;
             case "boiler":
-                var boiler = GetObject<Entity, EntityCrafter>(name);
+                var boiler = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("energy_consumption", out usesPower);
                 boiler.basePower = ParseEnergy(usesPower);
                 boiler.fluidInputs = 1;
@@ -251,7 +251,7 @@ internal partial class FactorioDataDeserializer {
                 boiler.baseCraftingSpeed = 1f;
                 break;
             case "burner-generator":
-                var generator = GetObject<Entity, EntityCrafter>(name);
+                var generator = GetObject<Entity, EntityCrafter>(table);
 
                 // generator energy input config is strange
                 if (table.Get("max_power_output", out string? maxPowerOutput)) {
@@ -269,7 +269,7 @@ internal partial class FactorioDataDeserializer {
                 recipeCrafters.Add(generator, SpecialNames.GeneratorRecipe);
                 break;
             case "character":
-                var character = GetObject<Entity, EntityCrafter>(name);
+                var character = GetObject<Entity, EntityCrafter>(table);
                 character.itemInputs = 255;
 
                 if (table.Get("mining_categories", out LuaTable? resourceCategories)) {
@@ -300,7 +300,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "container":
-                var container = GetObject<Entity, EntityContainer>(name);
+                var container = GetObject<Entity, EntityContainer>(table);
                 container.inventorySize = table.Get("inventory_size", 0);
 
                 if (factorioType == "logistic-container") {
@@ -312,7 +312,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "electric-energy-interface":
-                var eei = GetObject<Entity, EntityCrafter>(name);
+                var eei = GetObject<Entity, EntityCrafter>(table);
                 eei.energy = voidEntityEnergy;
 
                 if (table.Get("energy_production", out string? interfaceProduction)) {
@@ -323,7 +323,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "furnace":
-                var crafter = GetObject<Entity, EntityCrafter>(name);
+                var crafter = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("energy_usage", out usesPower);
                 ParseModules(table, crafter, AllowedEffects.None);
                 crafter.basePower = ParseEnergy(usesPower);
@@ -380,12 +380,12 @@ internal partial class FactorioDataDeserializer {
             case "generator":
                 goto case "burner-generator";
             case "inserter":
-                var inserter = GetObject<Entity, EntityInserter>(name);
+                var inserter = GetObject<Entity, EntityInserter>(table);
                 inserter.inserterSwingTime = 1f / (table.Get("rotation_speed", 1f) * 60);
                 inserter.isBulkInserter = table.Get("bulk", false);
                 break;
             case "lab":
-                var lab = GetObject<Entity, EntityCrafter>(name);
+                var lab = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("energy_usage", out usesPower);
                 ParseModules(table, lab, AllowedEffects.All ^ AllowedEffects.Quality);
                 lab.basePower = ParseEnergy(usesPower);
@@ -399,7 +399,7 @@ internal partial class FactorioDataDeserializer {
             case "logistic-container":
                 goto case "container";
             case "mining-drill":
-                var drill = GetObject<Entity, EntityCrafter>(name);
+                var drill = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("energy_usage", out usesPower);
                 drill.basePower = ParseEnergy(usesPower);
                 ParseModules(table, drill, AllowedEffects.All);
@@ -418,7 +418,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "offshore-pump":
-                var pump = GetObject<Entity, EntityCrafter>(name);
+                var pump = GetObject<Entity, EntityCrafter>(table);
                 _ = table.Get("energy_usage", out usesPower);
                 pump.basePower = ParseEnergy(usesPower);
                 pump.baseCraftingSpeed = table.Get("pumping_speed", 20f) / 20f;
@@ -443,7 +443,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "projectile":
-                var projectile = GetObject<Entity, EntityProjectile>(name);
+                var projectile = GetObject<Entity, EntityProjectile>(table);
                 if (table["action"] is LuaTable actions) {
                     actions.ReadObjectOrArray(parseAction);
                 }
@@ -465,7 +465,7 @@ internal partial class FactorioDataDeserializer {
                 }
                 break;
             case "reactor":
-                var reactor = GetObject<Entity, EntityReactor>(name);
+                var reactor = GetObject<Entity, EntityReactor>(table);
                 reactor.reactorNeighborBonus = table.Get("neighbour_bonus", 1f); // Keep UK spelling for Factorio/LUA data objects
                 _ = table.Get("consumption", out usesPower);
                 reactor.basePower = ParseEnergy(usesPower);
@@ -475,17 +475,17 @@ internal partial class FactorioDataDeserializer {
             case "rocket-silo":
                 goto case "furnace";
             case "solar-panel":
-                var solarPanel = GetObject<Entity, EntityCrafter>(name);
+                var solarPanel = GetObject<Entity, EntityCrafter>(table);
                 solarPanel.energy = voidEntityEnergy;
                 _ = table.Get("production", out string? powerProduction);
                 recipeCrafters.Add(solarPanel, SpecialNames.GeneratorRecipe);
                 solarPanel.baseCraftingSpeed = ParseEnergy(powerProduction) * 0.7f; // 0.7f is a solar panel ratio on nauvis
                 break;
             case "transport-belt":
-                GetObject<Entity, EntityBelt>(name).beltItemsPerSecond = table.Get("speed", 0f) * 480f;
+                GetObject<Entity, EntityBelt>(table).beltItemsPerSecond = table.Get("speed", 0f) * 480f;
                 break;
             case "unit-spawner":
-                var spawner = GetObject<Entity, EntitySpawner>(name);
+                var spawner = GetObject<Entity, EntitySpawner>(table);
                 spawner.capturedEntityName = table.Get<string>("captured_spawner_entity");
                 break;
         }
@@ -602,11 +602,13 @@ internal partial class FactorioDataDeserializer {
     private void DeserializeAsteroidChunk(LuaTable table, ErrorCollector errorCollector) {
         Entity chunk = DeserializeCommon<Entity>(table, "asteroid-chunk");
         Item asteroid = GetObject<Item>(chunk.name);
-        Recipe recipe = CreateSpecialRecipe(asteroid, SpecialNames.AsteroidCapture, "mining");
-        recipe.time = 1;
-        recipe.ingredients = [];
-        recipe.products = [new Product(asteroid, 1)];
-        recipe.sourceEntity = chunk;
+        if (asteroid.showInExplorers) { // don't create mining recipes for parameter chunks.
+            Recipe recipe = CreateSpecialRecipe(asteroid, SpecialNames.AsteroidCapture, "mining");
+            recipe.time = 1;
+            recipe.ingredients = [];
+            recipe.products = [new Product(asteroid, 1)];
+            recipe.sourceEntity = chunk;
+        }
     }
 
     private float EstimateArgument(LuaTable args, string name, float def = 0) => args.Get(name, out LuaTable? res) ? EstimateNoiseExpression(res) : def;

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -63,7 +63,7 @@ public class MilestonesEditor : PseudoScreen {
                 milestoneList.RebuildContents();
             }
             if (gui.BuildButton("Add milestone")) {
-                SelectMultiObjectPanel.Select(Database.objects.all.Except(Project.current.settings.milestones), "Add new milestone", AddMilestone);
+                SelectMultiObjectPanel.Select(Database.objects.explorable.Except(Project.current.settings.milestones), "Add new milestone", AddMilestone);
             }
         }
     }

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -356,7 +356,7 @@ public class NeverEnoughItemsPanel : PseudoScreen, IComparer<NeverEnoughItemsPan
         }
 
         if (gui.BuildFactorioObjectButtonBackground(gui.lastRect, current, SchemeColor.Grey) == Click.Left) {
-            SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
+            SelectSingleObjectPanel.Select(Database.goods.explorable, "Select item", SetItem);
         }
 
         using (var split = gui.EnterHorizontalSplit(2)) {

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -50,7 +50,7 @@ public class AutoPlannerView : ProjectPageView<AutoPlanner> {
                 }
                 grid.Next();
                 if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-                    SelectSingleObjectPanel.Select(Database.goods.all, "New production goal", x => {
+                    SelectSingleObjectPanel.Select(Database.goods.explorable, "New production goal", x => {
                         goal.Add(new AutoPlannerGoal { amount = 1f, item = x });
                         gui.Rebuild();
                     });

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -259,7 +259,7 @@ goodsHaveNoProduction:;
                         r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
                 }
                 else {
-                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe",
+                    SelectMultiObjectPanel.Select(Database.recipes.explorable, "Select raw recipe",
                         r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
                 }
             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,8 @@ Date:
         - (SA) Locations (except nauvis) are now part of the default milestone list.
         - Milestone overlays can be displayed on inaccessible objects.
         - With 22+ milestones, tooltip headers don't draw them unnecessarily overlapped, and can use multiple lines.
+    Fixes:
+        - Hide blueprint parameters and tiles from the Dependency Explorer and NEIE.
     Internal changes:
         - Dependency and automation analysis allows more ORs, e.g. "(spawner and capture-ammo) or item-to-place".
 ----------------------------------------------------------------------------------------------------------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date:
         - With 22+ milestones, tooltip headers don't draw them unnecessarily overlapped, and can use multiple lines.
     Fixes:
         - Hide blueprint parameters and tiles from the Dependency Explorer and NEIE.
+        - Hide blueprint parameters and the synthetic I and O items from more selection windows.
     Internal changes:
         - Dependency and automation analysis allows more ORs, e.g. "(spawner and capture-ammo) or item-to-place".
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The object selection windows have some things in them that I think are noise and should be removed. Specifically, blueprint parameters and, occasionally, the I and O objects. This hides those objects more often, though I would understand an argument for not hiding them, if someone wants to make that. The recycling recipes for Item.parameter-# are still present, unfortunately, but I think that's a Factorio bug, not a Yafc bug.

![image](https://github.com/user-attachments/assets/a1b15e62-ea07-4c0c-8968-c1a28b0607a6)  ![image](https://github.com/user-attachments/assets/a49489a2-5048-4cda-a3b2-c53770a56f5a)
