### PR TITLE
Add a self-contained Windows release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ VERSION=$(grep -oPm1 "(?<=<AssemblyVersion>)[^<]+" Yafc/Yafc.csproj)
 echo "Building YAFC version $VERSION..."
 
 dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows
+dotnet publish Yafc/Yafc.csproj -r win-x64 --self-contained -c Release -o Build/Windows-self-contained
 dotnet publish Yafc/Yafc.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
 dotnet publish Yafc/Yafc.csproj -r osx-arm64 --self-contained false -c Release -o Build/OSX-arm64
 dotnet publish Yafc/Yafc.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
@@ -21,5 +22,6 @@ tar czf Yafc-CE-Linux-$VERSION.tar.gz Linux
 tar czf Yafc-CE-OSX-intel-$VERSION.tar.gz OSX
 tar czf Yafc-CE-OSX-arm64-$VERSION.tar.gz OSX-arm64
 zip -r Yafc-CE-Windows-$VERSION.zip Windows
+zip -r Yafc-CE-Windows-self-contained-$VERSION.zip Windows-self-contained
 popd
 

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,9 @@ echo "Building YAFC version $VERSION..."
 
 dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows
 dotnet publish Yafc/Yafc.csproj -r win-x64 --self-contained -c Release -o Build/Windows-self-contained
-dotnet publish Yafc/Yafc.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
-dotnet publish Yafc/Yafc.csproj -r osx-arm64 --self-contained false -c Release -o Build/OSX-arm64
-dotnet publish Yafc/Yafc.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
+dotnet publish Yafc/Yafc.csproj -r osx-x64 -c Release -o Build/OSX
+dotnet publish Yafc/Yafc.csproj -r osx-arm64 -c Release -o Build/OSX-arm64
+dotnet publish Yafc/Yafc.csproj -r linux-x64 -c Release -o Build/Linux
 
 echo "The libraries of this release were scanned on Virustotal, but we could not reproduce the checksums." > Build/OSX-arm64/_WARNING.TXT
 echo "If you want to help with the checksums, please navigate to https://github.com/shpaass/yafc-ce/issues/274" >> Build/OSX-arm64/_WARNING.TXT


### PR DESCRIPTION
Adds a self-contained Windows deliverable.
Also removes `--self-contained false` from other deliverables because it is so by default. More info on that in the commit message.

Testing done: Made a build before and after the refactor. The sizes of artifacts were the same.

Closes #359