### PR TITLE
Scroll view for productivity tech levels

### DIFF
--- a/Yafc.UI/ImGui/ImGuiLayout.cs
+++ b/Yafc.UI/ImGui/ImGuiLayout.cs
@@ -267,7 +267,8 @@ public partial class ImGui {
         private readonly ImGui gui;
         private readonly bool initialDrawState;
         private readonly float initialTop;
-        private float maximumBottom;
+        internal float currentTop => gui.state.top;
+        internal float maximumBottom { get; private set; }
 
         internal OverlappingAllocations(ImGui gui, bool alsoDraw) {
             this.gui = gui;

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -229,7 +229,7 @@ public static class ImGuiUtils {
             gui.BuildText(text, TextBlockDisplayStyle.Default(color));
         }
 
-        if (gui.OnClick(gui.lastRect)) {
+        if (gui.enableDrawing && gui.OnClick(gui.lastRect)) {
             newValue = !value;
             return true;
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ Date: November 21st 2024
         - Hide blueprint parameters and the synthetic I and O items from more selection windows.
     Internal changes:
         - Dependency and automation analysis allows more ORs, e.g. "(spawner and capture-ammo) or item-to-place".
+        - Scroll views can appear on tab controls.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.3.1
 Date: November 10th 2024


### PR DESCRIPTION
In https://github.com/shpaass/yafc-ce/pull/334#issuecomment-2442806808 I said I wanted to see a scrolling list for the productivity tech levels, but I didn't realize that scroll views and tab controls didn't get along. They get along now, and the preferences screen won't get too tall with extra prod researches.

The first commit has a fix that should maybe have been its own PR? Trying to change the level of the scrap mining productivity research would toggle dark mode instead. (If you had a lot of milestones, it was steel smelting productivity instead.)