### PR TITLE
fix: Continue loading after encountering undefined recipes.

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -163,7 +163,7 @@ internal partial class FactorioDataDeserializer {
 
         UpdateSplitFluids();
         var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
-        UpdateRecipeIngredientFluids();
+        UpdateRecipeIngredientFluids(errorCollector);
         UpdateRecipeCatalysts();
         CalculateMaps(netProduction);
         ExportBuiltData();

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -68,8 +68,14 @@ internal partial class FactorioDataDeserializer {
         }
     }
 
-    private void UpdateRecipeIngredientFluids() {
+    private void UpdateRecipeIngredientFluids(ErrorCollector errorCollector) {
         foreach (var recipe in allObjects.OfType<Recipe>()) {
+            if (recipe.ingredients == null || recipe.products == null) {
+                errorCollector.Error($"The recipe '{recipe.name}' is not defined in data.raw[\"recipe\"].", ErrorSeverity.Important);
+                recipe.ingredients = [];
+                recipe.products = [];
+                continue;
+            }
             foreach (var ingredient in recipe.ingredients) {
                 if (ingredient.goods is Fluid fluid && fluid.variants != null) {
                     int min = -1, max = fluid.variants.Count - 1;

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Fixes:
         - "Map generated" entities that don't generate in any locations could break automation analysis.
+        - Recipes that are referenced without being defined do not prevent YAFC from loading.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: November 21st 2024


### PR DESCRIPTION
As reported [on Discord](https://discord.com/channels/560199483065892894/1210135763422027837/1312102716352368721), melon is trying to unlock an undefined recipe.

This fills in just enough data so loading can continue, though the recipe ends up with no ingredients, products, or crafters.