### PR TITLE
Faster, cleaner milestone analysis

### DIFF
--- a/Yafc.Model/Analysis/Dependencies.cs
+++ b/Yafc.Model/Analysis/Dependencies.cs
@@ -1,33 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace Yafc.Model;
-
-public struct DependencyList(FactorioId[] elements, DependencyList.Flags flags) {
-    [Flags]
-    public enum Flags {
-        RequireEverything = 0x100,
-        OneTimeInvestment = 0x200,
-
-        Ingredient = 1 | RequireEverything,
-        CraftingEntity = 2 | OneTimeInvestment,
-        SourceEntity = 3 | OneTimeInvestment,
-        TechnologyUnlock = 4 | OneTimeInvestment,
-        Source = 5,
-        Fuel = 6,
-        ItemToPlace = 7,
-        TechnologyPrerequisites = 8 | RequireEverything | OneTimeInvestment,
-        IngredientVariant = 9,
-        Hidden = 10,
-        Location = 11 | OneTimeInvestment,
-    }
-
-    public Flags flags = flags;
-    public FactorioId[] elements = elements;
-
-    public DependencyList(IEnumerable<FactorioObject> elements, Flags flags) : this(elements.Select(o => o.id).ToArray(), flags) { }
-}
 
 public static class Dependencies {
     /// <summary>

--- a/Yafc.Model/Analysis/DependencyNode.cs
+++ b/Yafc.Model/Analysis/DependencyNode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Numerics;
 using Yafc.UI;
@@ -14,43 +15,51 @@ namespace Yafc.Model;
 /// This represents one node in a dependency tree, which may be the root node of the tree or the child of another node.
 /// </summary>
 public abstract class DependencyNode {
+    [Flags]
+    public enum Flags {
+        RequireEverything = 0x100,
+        OneTimeInvestment = 0x200,
+
+        Ingredient = 1 | RequireEverything,
+        CraftingEntity = 2 | OneTimeInvestment,
+        SourceEntity = 3 | OneTimeInvestment,
+        TechnologyUnlock = 4 | OneTimeInvestment,
+        Source = 5,
+        Fuel = 6,
+        ItemToPlace = 7,
+        TechnologyPrerequisites = 8 | RequireEverything | OneTimeInvestment,
+        IngredientVariant = 9,
+        Hidden = 10,
+        Location = 11 | OneTimeInvestment,
+    }
+
     private DependencyNode() { } // All derived classes should be nested classes
 
     /// <summary>
-    /// Creates a <see cref="DependencyNode"/> from a <see cref="DependencyList"/>. <paramref name="dependencies"/> contains the require-any/-all
+    /// Creates a <see cref="DependencyNode"/> from a list of dependencies. <paramref name="flags"/> contains the require-any/-all
     /// behavior and information about how the dependencies should be described. (e.g. "Crafter", "Ingredient", etc.)
     /// </summary>
-    public static DependencyNode Create(DependencyList dependencies) => new ListNode(dependencies);
+    public static DependencyNode Create(IEnumerable<FactorioObject> elements, Flags flags) => new ListNode(elements, flags);
 
     /// <summary>
     /// Creates a <see cref="DependencyNode"/> that is satisfied if all of its child nodes are satisfied.
-    /// This matches the old behavior for <see cref="DependencyList"/>[].
-    /// </summary>
-    public static DependencyNode RequireAll(IEnumerable<DependencyList> dependencies) => AndNode.Create(dependencies.Select(Create));
-    /// <summary>
-    /// Creates a <see cref="DependencyNode"/> that is satisfied if all of its child nodes are satisfied.
-    /// This matches the old behavior for <see cref="DependencyList"/>[].
+    /// This matches the old behavior for a legacy DependencyList[].
     /// </summary>
     public static DependencyNode RequireAll(IEnumerable<DependencyNode> dependencies) => AndNode.Create(dependencies);
     /// <summary>
     /// Creates a <see cref="DependencyNode"/> that is satisfied if all of its child nodes are satisfied.
-    /// This matches the old behavior for <see cref="DependencyList"/>[].
+    /// This matches the old behavior for a legacy DependencyList[].
     /// </summary>
     public static DependencyNode RequireAll(params DependencyNode[] dependencies) => AndNode.Create(dependencies);
 
     /// <summary>
     /// Creates a <see cref="DependencyNode"/> that is satisfied if any of its child nodes are satisfied. This behavior was only accessible
-    /// within a single <see cref="DependencyList"/>, by not setting <see cref="DependencyList.Flags.RequireEverything"/>.
-    /// </summary>
-    public static DependencyNode RequireAny(IEnumerable<DependencyList> dependencies) => OrNode.Create(dependencies.Select(Create));
-    /// <summary>
-    /// Creates a <see cref="DependencyNode"/> that is satisfied if any of its child nodes are satisfied. This behavior was only accessible
-    /// within a single <see cref="DependencyList"/>, by not setting <see cref="DependencyList.Flags.RequireEverything"/>.
+    /// within a single legacy DependencyList, by not setting <see cref="Flags.RequireEverything"/>.
     /// </summary>
     public static DependencyNode RequireAny(params DependencyNode[] dependencies) => OrNode.Create(dependencies);
     /// <summary>
     /// Creates a <see cref="DependencyNode"/> that is satisfied if any of its child nodes are satisfied. This behavior was only accessible
-    /// within a single <see cref="DependencyList"/>, by not setting <see cref="DependencyList.Flags.RequireEverything"/>.
+    /// within a single legacy DependencyList, by not setting <see cref="Flags.RequireEverything"/>.
     /// </summary>
     public static DependencyNode RequireAny(IEnumerable<DependencyNode> dependencies) => OrNode.Create(dependencies);
 
@@ -92,8 +101,8 @@ public abstract class DependencyNode {
     /// Instructs this dependency tree to draw itself on the specified <see cref="ImGui"/>.
     /// </summary>
     /// <param name="gui">The drawing destination.</param>
-    /// <param name="builder">A delegate that will draw the passed <see cref="DependencyList"/> onto the passed <see cref="ImGui"/>.</param>
-    public abstract void Draw(ImGui gui, Action<ImGui, DependencyList> builder);
+    /// <param name="builder">A delegate that will draw the passed dependency information onto the passed <see cref="ImGui"/>.</param>
+    public abstract void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder);
 
     /// <summary>
     /// A <see cref="DependencyNode"/> that requires all of its children.
@@ -143,7 +152,7 @@ public abstract class DependencyNode {
         internal override AutomationStatus IsAutomatable(Func<FactorioId, AutomationStatus> isAutomatable, AutomationStatus automationState)
             => dependencies.Min(d => d.IsAutomatable(isAutomatable, automationState));
 
-        public override void Draw(ImGui gui, Action<ImGui, DependencyList> builder) {
+        public override void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder) {
             bool previousChildWasOr = false;
             foreach (DependencyNode dependency in dependencies) {
                 if (dependency is OrNode && previousChildWasOr) {
@@ -198,7 +207,7 @@ public abstract class DependencyNode {
         internal override AutomationStatus IsAutomatable(Func<FactorioId, AutomationStatus> isAutomatable, AutomationStatus automationState)
             => dependencies.Max(d => d.IsAutomatable(isAutomatable, automationState));
 
-        public override void Draw(ImGui gui, Action<ImGui, DependencyList> builder) {
+        public override void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder) {
             Vector2 offset = new(.4f, 0);
             using (gui.EnterGroup(new(1f, 0, 0, 0))) {
                 bool isFirst = true;
@@ -221,37 +230,37 @@ public abstract class DependencyNode {
     /// A <see cref="DependencyNode"/> that matches the behavior of a legacy <see cref="DependencyList"/>.
     /// </summary>
     /// <param name="dependencies">The <see cref="DependencyList"/> whose behavior should be matched by this <see cref="ListNode"/>.</param>
-    private sealed class ListNode(DependencyList dependencies) : DependencyNode {
-        private readonly DependencyList dependencies = dependencies;
+    private sealed class ListNode(IEnumerable<FactorioObject> elements, Flags flags) : DependencyNode {
+        private readonly ReadOnlyCollection<FactorioId> elements = elements.Select(e => e.id).ToList().AsReadOnly();
 
-        internal override IEnumerable<FactorioId> Flatten() => dependencies.elements;
+        internal override IEnumerable<FactorioId> Flatten() => elements;
 
         internal override bool IsAccessible(Func<FactorioId, bool> isAccessible) {
-            if (dependencies.flags.HasFlag(DependencyList.Flags.RequireEverything)) {
-                return dependencies.elements.All(isAccessible);
+            if (flags.HasFlag(Flags.RequireEverything)) {
+                return elements.All(isAccessible);
             }
-            return dependencies.elements.Any(isAccessible);
+            return elements.Any(isAccessible);
         }
 
         internal override Bits AggregateBits(Func<FactorioId, Bits> getBits) {
             Bits bits = new();
-            if (dependencies.flags.HasFlag(DependencyList.Flags.RequireEverything)) {
-                foreach (FactorioId item in dependencies.elements) {
+            if (flags.HasFlag(Flags.RequireEverything)) {
+                foreach (FactorioId item in elements) {
                     bits |= getBits(item);
                 }
                 return bits;
             }
-            else if (dependencies.elements.Length > 0) {
-                return bits | dependencies.elements.Min(getBits);
+            else if (elements.Count > 0) {
+                return bits | elements.Min(getBits);
             }
             return bits;
         }
 
         internal override AutomationStatus IsAutomatable(Func<FactorioId, AutomationStatus> getAutomation, AutomationStatus automationState) {
             // Copied from AutomationAnalysis.cs.
-            if (!dependencies.flags.HasFlags(DependencyList.Flags.OneTimeInvestment)) {
-                if (dependencies.flags.HasFlags(DependencyList.Flags.RequireEverything)) {
-                    foreach (FactorioId element in dependencies.elements) {
+            if (!flags.HasFlags(Flags.OneTimeInvestment)) {
+                if (flags.HasFlags(Flags.RequireEverything)) {
+                    foreach (FactorioId element in elements) {
                         if (getAutomation(element) < automationState) {
                             automationState = getAutomation(element);
                         }
@@ -260,7 +269,7 @@ public abstract class DependencyNode {
                 else {
                     AutomationStatus localHighest = AutomationStatus.NotAutomatable;
 
-                    foreach (FactorioId element in dependencies.elements) {
+                    foreach (FactorioId element in elements) {
                         if (getAutomation(element) > localHighest) {
                             localHighest = getAutomation(element);
                         }
@@ -271,11 +280,11 @@ public abstract class DependencyNode {
                     }
                 }
             }
-            else if (automationState == AutomationStatus.AutomatableNow && dependencies.flags == DependencyList.Flags.CraftingEntity) {
+            else if (automationState == AutomationStatus.AutomatableNow && flags == Flags.CraftingEntity) {
                 // If only character is accessible at current milestones as a crafting entity, don't count the object as currently automatable
                 bool hasMachine = false;
 
-                foreach (FactorioId element in dependencies.elements) {
+                foreach (FactorioId element in elements) {
                     if (element != Database.character?.id && Milestones.Instance.IsAccessibleWithCurrentMilestones(element)) {
                         hasMachine = true;
                         break;
@@ -289,8 +298,9 @@ public abstract class DependencyNode {
             return automationState;
         }
 
-        public override void Draw(ImGui gui, Action<ImGui, DependencyList> builder) => builder(gui, dependencies);
+        public override void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder) => builder(gui, elements, flags);
     }
 
-    public static implicit operator DependencyNode(DependencyList list) => Create(list);
+    public static implicit operator DependencyNode((IEnumerable<FactorioObject> elements, Flags flags) value)
+        => Create(value.elements, value.flags);
 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -402,7 +402,7 @@ internal partial class FactorioDataDeserializer {
                     }
                     if (plantResults.TryGetValue(item, out string? plantResultName)) {
                         item.plantResult = GetObject<Entity>(plantResultName);
-                        entityPlacers.Add(GetObject<Entity>(plantResultName), item);
+                        entityPlacers.Add(GetObject<Entity>(plantResultName), item, true);
                     }
                     if (item.fuelResult != null) {
                         miscSources.Add(item.fuelResult, item);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -561,8 +561,6 @@ internal partial class FactorioDataDeserializer {
         }
 
         if (table.Get("autoplace", out LuaTable? generation)) {
-            entity.mapGenerated = true;
-
             if (generation.Get("probability_expression", out LuaTable? prob)) {
                 float probability = EstimateNoiseExpression(prob);
                 float richness = generation.Get("richness_expression", out LuaTable? rich) ? EstimateNoiseExpression(rich) : probability;
@@ -575,7 +573,10 @@ internal partial class FactorioDataDeserializer {
                 float estimatedAmount = coverage * (richBase + richMultiplier + (richMultiplierDist * EstimationDistanceFromCenter));
                 entity.mapGenDensity = estimatedAmount;
             }
-            entity.autoplaceControl = generation?.Get<string>("control");
+            if (generation.Get("control", out string? control)) {
+                entity.mapGenerated = true;
+                entity.autoplaceControl = generation?.Get<string>("control");
+            }
         }
 
         entity.loot ??= [];

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -14,19 +14,19 @@ public class DependencyExplorer : PseudoScreen {
     private readonly List<FactorioObject> history = [];
     private FactorioObject current;
 
-    private static readonly Dictionary<DependencyList.Flags, (string name, string missingText)> dependencyListTexts = new Dictionary<DependencyList.Flags, (string, string)>()
+    private static readonly Dictionary<DependencyNode.Flags, (string name, string missingText)> dependencyListTexts = new Dictionary<DependencyNode.Flags, (string, string)>()
     {
-        {DependencyList.Flags.Fuel, ("Fuel", "There is no fuel to power this entity")},
-        {DependencyList.Flags.Ingredient, ("Ingredient", "There are no ingredients to this recipe")},
-        {DependencyList.Flags.IngredientVariant, ("Ingredient", "There are no ingredient variants for this recipe")},
-        {DependencyList.Flags.CraftingEntity, ("Crafter", "There are no crafters that can craft this item")},
-        {DependencyList.Flags.Source, ("Source", "This item have no sources")},
-        {DependencyList.Flags.TechnologyUnlock, ("Research", "This recipe is disabled and there are no technologies to unlock it")},
-        {DependencyList.Flags.TechnologyPrerequisites, ("Research", "There are no technology prerequisites")},
-        {DependencyList.Flags.ItemToPlace, ("Item", "This entity cannot be placed")},
-        {DependencyList.Flags.SourceEntity, ("Source", "This recipe requires another entity")},
-        {DependencyList.Flags.Hidden, ("", "This technology is hidden")},
-        {DependencyList.Flags.Location, ("Location", "There are no locations that spawn this entity")},
+        {DependencyNode.Flags.Fuel, ("Fuel", "There is no fuel to power this entity")},
+        {DependencyNode.Flags.Ingredient, ("Ingredient", "There are no ingredients to this recipe")},
+        {DependencyNode.Flags.IngredientVariant, ("Ingredient", "There are no ingredient variants for this recipe")},
+        {DependencyNode.Flags.CraftingEntity, ("Crafter", "There are no crafters that can craft this item")},
+        {DependencyNode.Flags.Source, ("Source", "This item have no sources")},
+        {DependencyNode.Flags.TechnologyUnlock, ("Research", "This recipe is disabled and there are no technologies to unlock it")},
+        {DependencyNode.Flags.TechnologyPrerequisites, ("Research", "There are no technology prerequisites")},
+        {DependencyNode.Flags.ItemToPlace, ("Item", "This entity cannot be placed")},
+        {DependencyNode.Flags.SourceEntity, ("Source", "This recipe requires another entity")},
+        {DependencyNode.Flags.Hidden, ("", "This technology is hidden")},
+        {DependencyNode.Flags.Location, ("Location", "There are no locations that spawn this entity")},
     };
 
     public DependencyExplorer(FactorioObject current) : base(60f) {
@@ -52,17 +52,17 @@ public class DependencyExplorer : PseudoScreen {
     private void DrawDependencies(ImGui gui) {
         gui.spacing = 0f;
 
-        Dependencies.dependencyList[current].Draw(gui, (gui, data) => {
-            if (!dependencyListTexts.TryGetValue(data.flags, out var dependencyType)) {
-                dependencyType = (data.flags.ToString(), "Missing " + data.flags);
+        Dependencies.dependencyList[current].Draw(gui, (gui, elements, flags) => {
+            if (!dependencyListTexts.TryGetValue(flags, out var dependencyType)) {
+                dependencyType = (flags.ToString(), "Missing " + flags);
             }
 
-            if (data.elements.Length > 0) {
+            if (elements.Count > 0) {
                 gui.AllocateSpacing(0.5f);
-                if (data.elements.Length == 1) {
+                if (elements.Count == 1) {
                     gui.BuildText("Require this " + dependencyType.name + ":");
                 }
-                else if (data.flags.HasFlags(DependencyList.Flags.RequireEverything)) {
+                else if (flags.HasFlags(DependencyNode.Flags.RequireEverything)) {
                     gui.BuildText("Require ALL of these " + dependencyType.name + "s:");
                 }
                 else {
@@ -70,7 +70,7 @@ public class DependencyExplorer : PseudoScreen {
                 }
 
                 gui.AllocateSpacing(0.5f);
-                foreach (var id in data.elements.OrderByDescending(x => CostAnalysis.Instance.flow[x])) {
+                foreach (var id in elements.OrderByDescending(x => CostAnalysis.Instance.flow[x])) {
                     DrawFactorioObject(gui, id);
                 }
             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Date:
         - "Map generated" entities that don't generate in any locations could break automation analysis.
         - Recipes that are referenced without being defined do not prevent YAFC from loading.
         - (SA) Tree seeds used by the agricultural tower no longer appear twice in the Dependency Explorer.
+        - Milestone analysis got slower in 2.4.0; increase its speed.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: November 21st 2024

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date:
     Fixes:
         - "Map generated" entities that don't generate in any locations could break automation analysis.
         - Recipes that are referenced without being defined do not prevent YAFC from loading.
+        - (SA) Tree seeds used by the agricultural tower no longer appear twice in the Dependency Explorer.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: November 21st 2024


### PR DESCRIPTION
2.4.0 has a significant speed regression in the milestone analysis; this cleans up the milestone analysis code and partially restores the speed.

The primary user-visible change is the speed improvement, but this does make minor changes to pY and SA analysis (see 1e75d3a7 message). It also improves handling of stupid Entity sources (d34bce1), if there are any mods that abuse how entities come into existence.