### PR TITLE
More link information

### DIFF
--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -96,6 +96,26 @@ public static partial class DataUtils {
         return (ms.GetMilestoneResult(id) - 1) & ms.lockedMask;
     }
 
+    /// <summary>
+    /// Gets an <see cref="IComparer{T}"/> where the <paramref name="first"/> always comes first.
+    /// </summary>
+    /// <typeparam name="T">The type of objects to compare.</typeparam>
+    /// <param name="first">The object that compares before any other value, including <see langword="null"/>.</param>
+    /// <param name="comparer">The comparer to use when neither of the compared objects is <paramref name="first"/>.</param>
+    /// <returns>An <see cref="IComparer{T}"/> that sorts <paramref name="first"/> before any other value,
+    /// and sorts all other values the same way <paramref name="comparer"/> does.</returns>
+    public static IComparer<T> CustomFirstItemComparer<T>(T first, IComparer<T> comparer) where T : notnull
+        => new CustomFirstComparer<T>(first, comparer);
+
+    private class CustomFirstComparer<T>(T first, IComparer<T> comparer) : IComparer<T> where T : notnull {
+        public int Compare(T? x, T? y) {
+            if (first.Equals(x) && first.Equals(y)) { return 0; }
+            if (first.Equals(x)) { return -1; }
+            if (first.Equals(y)) { return 1; }
+            return comparer.Compare(x, y);
+        }
+    }
+
     public static string dataPath { get; internal set; } = "";
     public static string modsPath { get; internal set; } = "";
 

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -166,9 +166,15 @@ public static class ImmediateWidgets {
         return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj, displayStyle.BackgroundColor, tooltipOptions);
     }
 
-    public static Click BuildFactorioObjectButtonWithText(this ImGui gui, IFactorioObjectWrapper? obj, string? extraText = null, IconDisplayStyle? iconDisplayStyle = null) {
+    public static Click BuildFactorioObjectButtonWithText(this ImGui gui, IFactorioObjectWrapper? obj, string? extraText = null,
+        IconDisplayStyle? iconDisplayStyle = null, float indent = 0f, ObjectTooltipOptions tooltipOptions = default) {
+
         iconDisplayStyle ??= IconDisplayStyle.Default;
         using (gui.EnterRow()) {
+            if (indent > 0) {
+                // Relying on EnterRow using a default spacing of 0.5.
+                gui.AllocateRect(indent - 0.5f, 0);
+            }
             gui.BuildFactorioObjectIcon(obj, iconDisplayStyle);
             var color = gui.textColor;
             if (obj != null && !obj.target.IsAccessible() && !iconDisplayStyle.AlwaysAccessible) {
@@ -188,7 +194,7 @@ public static class ImmediateWidgets {
             gui.BuildText(obj == null ? "None" : obj.target.locName, TextBlockDisplayStyle.WrappedText with { Color = color });
         }
 
-        return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj);
+        return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj, tooltipOptions: tooltipOptions);
     }
 
     internal static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, [NotNullWhen(true)] out T? selected, ObjectSelectOptions<T> options) where T : FactorioObject {

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -1,29 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using SDL2;
 using Yafc.Model;
 using Yafc.UI;
 
 namespace Yafc;
 
 public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow row, float flow)> {
-    private readonly ProductionLink link;
-    private readonly List<(RecipeRow row, float flow)> input = [];
-    private readonly List<(RecipeRow row, float flow)> output = [];
+    private readonly Stack<ProductionLink> links = new();
+
+    private ProductionLink link;
+    private List<(RecipeRow row, float flow)> input;
+    private List<(RecipeRow row, float flow)> output;
     private float totalInput, totalOutput;
     private readonly ScrollArea scrollArea;
 
     private ProductionLinkSummaryScreen(ProductionLink link) {
         scrollArea = new ScrollArea(30, BuildScrollArea);
-        this.link = link;
         CalculateFlow(link);
     }
 
     private void BuildScrollArea(ImGui gui) {
         gui.BuildText("Production: " + DataUtils.FormatAmount(totalInput, link.goods.flowUnitOfMeasure), Font.subheader);
-        BuildFlow(gui, input, totalInput);
+        BuildFlow(gui, input, totalInput, false);
         gui.spacing = 0.5f;
         gui.BuildText("Consumption: " + DataUtils.FormatAmount(totalOutput, link.goods.flowUnitOfMeasure), Font.subheader);
-        BuildFlow(gui, output, totalOutput);
+        BuildFlow(gui, output, totalOutput, true);
         if (link.amount != 0) {
             gui.spacing = 0.5f;
             gui.BuildText((link.amount > 0 ? "Requested production: " : "Requested consumption: ") + DataUtils.FormatAmount(MathF.Abs(link.amount),
@@ -47,16 +51,57 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
 
     protected override void ReturnPressed() => Close();
 
-    private void BuildFlow(ImGui gui, List<(RecipeRow row, float flow)> list, float total) {
+    private void BuildFlow(ImGui gui, List<(RecipeRow row, float flow)> list, float total, bool isLinkOutput) {
         gui.spacing = 0f;
         foreach (var (row, flow) in list) {
             string amount = DataUtils.FormatAmount(flow, link.goods.flowUnitOfMeasure);
-            _ = gui.BuildFactorioObjectButtonWithText(row.recipe, amount, tooltipOptions: DrawParentRecipes(row.owner, "recipe"));
+            if (gui.BuildFactorioObjectButtonWithText(row.recipe, amount, tooltipOptions: DrawParentRecipes(row.owner, "recipe")) == Click.Left) {
+                // Find the corresponding links associated with the clicked recipe,
+                IEnumerable<Goods> goods = isLinkOutput ? row.recipe.products.Select(p => p.goods) : row.recipe.ingredients.Select(i => i.goods);
+                Dictionary<Goods, ProductionLink> links = goods
+                    .Select(goods => { row.FindLink(goods, out ProductionLink? link); return (goods, link: link!); })
+                    .Where(x => x.link != null)
+                    .ToDictionary(x => x.goods, x => x.link);
+                links.Remove(link.goods); // except the current one, only applicable for recipes like kovarex that have catalysts.
+
+                // Jump to the only link, or offer a selection of links to inspect next.
+                if (links.Count == 1) {
+                    changeLinkView(links.First().Value);
+                }
+                else {
+                    gui.ShowDropDown(drawLinks);
+                }
+
+                void drawLinks(ImGui gui) {
+                    if (links.Count == 0) {
+                        string text = isLinkOutput ? "This recipe has no linked products." : "This recipe has no linked ingredients";
+                        gui.BuildText(text, TextBlockDisplayStyle.ErrorText);
+                    }
+                    else {
+                        IComparer<Goods> comparer = DataUtils.DefaultOrdering;
+                        if (isLinkOutput && row.recipe.mainProduct is Goods mainProduct) {
+                            comparer = DataUtils.CustomFirstItemComparer(mainProduct, comparer);
+                        }
+
+                        string header = isLinkOutput ? "Select product link to inspect" : "Select ingredient link to inspect";
+                        ObjectSelectOptions<Goods> options = new(header, comparer, int.MaxValue);
+                        if (gui.BuildInlineObjectList(links.Keys, out Goods? selected, options) && gui.CloseDropdown()) {
+                            changeLinkView(links[selected]);
+                        }
+                    }
+                }
+            }
+
             if (gui.isBuilding) {
                 var lastRect = gui.lastRect;
                 lastRect.Width *= (flow / total);
                 gui.DrawRectangle(lastRect, SchemeColor.Primary);
             }
+        }
+
+        void changeLinkView(ProductionLink newLink) {
+            links.Push(link);
+            CalculateFlow(newLink);
         }
     }
 
@@ -87,9 +132,19 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
         }
     };
 
+    public override bool KeyDown(SDL.SDL_Keysym key) {
+        if (key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_BACKSPACE or SDL.SDL_Scancode.SDL_SCANCODE_KP_BACKSPACE && links.Count > 0) {
+            CalculateFlow(links.Pop());
+            return true;
+        }
+        return base.KeyDown(key);
+    }
+
+    [MemberNotNull(nameof(link), nameof(input), nameof(output))]
     private void CalculateFlow(ProductionLink link) {
-        totalInput = 0;
-        totalOutput = 0;
+        // changeLinkView calls this while iterating over one of these lists. We must create new lists rather than editing the existing ones.
+        List<(RecipeRow row, float flow)> input = [], output = [];
+        totalInput = totalOutput = 0;
         foreach (var recipe in link.capturedRecipes) {
             float production = recipe.GetProductionForRow(link.goods);
             float consumption = recipe.GetConsumptionForRow(link.goods);
@@ -106,6 +161,11 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
         }
         input.Sort(this);
         output.Sort(this);
+
+        this.input = input;
+        this.output = output;
+        this.link = link;
+
         Rebuild();
         scrollArea.RebuildContents();
     }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -43,6 +43,10 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
 
     public override void Build(ImGui gui) {
         BuildHeader(gui, "Link summary");
+        using (gui.EnterRow()) {
+            gui.BuildText("Exploring link for: ", topOffset: 0.5f);
+            _ = gui.BuildFactorioObjectButtonWithText(link.goods, tooltipOptions: DrawParentRecipes(link.owner, "link"));
+        }
         scrollArea.Build(gui);
         if (gui.BuildButton("Done")) {
             Close();

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Date:
     Features:
         - Added Ctrl+Shift+F to search all pages.
         - In the Link Summary panel tooltip, add information on where (in the table) each recipe can be found.
+        - In the Link Summary panel, allow clicking on a recipe to inspect that recipe's links.
     Fixes:
         - "Map generated" entities that don't generate in any locations could break automation analysis.
         - Recipes that are referenced without being defined do not prevent YAFC from loading.

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
         - Added Ctrl+Shift+F to search all pages.
+        - In the Link Summary panel tooltip, add information on where (in the table) each recipe can be found.
     Fixes:
         - "Map generated" entities that don't generate in any locations could break automation analysis.
         - Recipes that are referenced without being defined do not prevent YAFC from loading.


### PR DESCRIPTION
I often want to know more than the link summary screen shows me by default, so I've added extra information in the tooltips, and the ability to click rows to jump to related links.
![Untitled](https://github.com/user-attachments/assets/70627636-3a22-4a3b-9b01-65912ff3b238)
