### PR TITLE
fix: Treat recycling recipes as special.

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -175,6 +175,7 @@ public enum FactorioObjectSpecialType {
     Stacking,
     Pressurization,
     Crating,
+    Recycling,
 }
 
 public class Recipe : RecipeOrTechnology {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -9,6 +9,11 @@ internal partial class FactorioDataDeserializer {
         var recipe = DeserializeCommon<Recipe>(table, "recipe");
         LoadRecipeData(recipe, table, errorCollector);
         _ = table.Get("category", out string recipeCategory, "crafting");
+        // "recycling-or-hand-crafting" is Scrap recycling. It's special so it isn't considered a potential source recipe when ctrl+clicking.
+        // It'll still be used as a ctrl+click consumption recipe for scrap.
+        if (recipeCategory is "recycling" or "recycling-or-hand-crafting") {
+            recipe.specialType = FactorioObjectSpecialType.Recycling;
+        }
         recipeCategories.Add(recipeCategory, recipe);
         AllowedEffects allowedEffects = AllowedEffects.None;
         if (table.Get("allow_consumption", true)) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ Date:
         - Recipes that are referenced without being defined do not prevent YAFC from loading.
         - (SA) Tree seeds used by the agricultural tower no longer appear twice in the Dependency Explorer.
         - Milestone analysis got slower in 2.4.0; increase its speed.
+        - (SA) Recycling recipes are now considered special, like barrelling/voiding.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: November 21st 2024


### PR DESCRIPTION
Unlike the other special recipe types, recycling recipes are detected based on the category, not the recipe behavior. I think this is fair since they're generated by the quality mod; they'll likely still be the same categories in all mod packs.