### PR TITLE
Add research-progress item type support

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -566,7 +566,7 @@ internal partial class FactorioDataDeserializer {
                 }
             }
             else if (type == "research-progress" && table.Get("research_item", out string? researchItem)) {
-                return GetObject<Item, Item>(researchItem);
+                return GetObject<Item>(researchItem);
             }
         }
         return null;

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -553,18 +553,22 @@ internal partial class FactorioDataDeserializer {
     }
 
     private Goods? LoadItemOrFluid(LuaTable table, bool useTemperature) {
-        if (table.Get("type", out string? type) && table.Get("name", out string? name)) {
-            if (type == "item") {
-                return GetObject<Item>(table);
-            }
-            else if (type == "fluid") {
-                if (useTemperature && table.Get("temperature", out int temperature)) {
-                    return GetFluidFixedTemp(name, temperature);
+        if (table.Get("type", out string? type)) {
+            if (table.Get("name", out string? name)) {
+                if (type == "item") {
+                    return GetObject<Item>(table);
                 }
-                return GetObject<Fluid>(table);
+                else if (type == "fluid") {
+                    if (useTemperature && table.Get("temperature", out int temperature)) {
+                        return GetFluidFixedTemp(name, temperature);
+                    }
+                    return GetObject<Fluid>(table);
+                }
+            }
+            else if (type == "research-progress" && table.Get("research_item", out string? researchItem)) {
+                return GetObject<Item, Item>(researchItem);
             }
         }
-
         return null;
     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Date:
         - (SA) Tree seeds used by the agricultural tower no longer appear twice in the Dependency Explorer.
         - Milestone analysis got slower in 2.4.0; increase its speed.
         - (SA) Recycling recipes are now considered special, like barrelling/voiding.
+        - Fixed recipe parsing for the ResearchProgressProduct output type.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: November 21st 2024


### PR DESCRIPTION
https://mods.factorio.com/mod/Cerys-Moon-of-Fulgora
the new research-progress type breaks recipe analysis
https://github.com/danielmartin0/Cerys-Moon-of-Fulgora/blob/main/prototypes/recipe/repair.lua#L106 

```
Could not load one of the products for Recipe.cerys-discover-fulgoran-cryogenics, possibly named ''.
   at Yafc.Parser.FactorioDataDeserializer.<>c__DisplayClass87_0.<LoadProduct>b__0(LuaTable table) in ./Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs:line 227
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
   at Yafc.Parser.FactorioDataDeserializer.LoadProductList(LuaTable table, String typeDotName, Boolean allowSimpleSyntax) in ./Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs:line 243
   at Yafc.Parser.FactorioDataDeserializer.LoadRecipeData(Recipe recipe, LuaTable table, ErrorCollector errorCollector) in ./Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs:line 365
   at Yafc.Parser.FactorioDataDeserializer.DeserializeRecipe(LuaTable table, ErrorCollector errorCollector) in ./Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs:line 10
   at Yafc.Parser.FactorioDataDeserializer.DeserializePrototypes(LuaTable data, String type, Action`2 deserializer, IProgress`1 progress, ErrorCollector errorCollector) in ./Yafc.Parser/Data/FactorioDataDeserializer.cs:line 325
   at Yafc.Parser.FactorioDataDeserializer.LoadData(String projectPath, LuaTable data, LuaTable prototypes, Boolean netProduction, IProgress`1 progress, ErrorCollector errorCollector, Boolean renderIcons) in ./Yafc.Parser/Data/FactorioDataDeserializer.cs:line 134
   at Yafc.Parser.FactorioDataSource.Parse(String factorioPath, String modPath, String projectPath, Boolean netProduction, IProgress`1 progress, ErrorCollector errorCollector, String locale, Boolean renderIcons) in ./Yafc.Parser/FactorioDataSource.cs:line 354
   at Yafc.WelcomeScreen.LoadProject() in ./Yafc/Windows/WelcomeScreen.cs:line 396
```

In this fix I added research_item as an item ~~but I think it would also make sense to ignore this recipe and log warning instead if that's preferred.~~

edit: looks like research progress is a new officially supported API, so the fix is correct https://lua-api.factorio.com/latest/concepts/ResearchProgressProduct.html 

yafc loads after the fix.

