### PR TITLE
fix: Restore pollution info in building tooltips.

### DIFF
--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -125,7 +125,9 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
             float minPower = 1000f;
 
             foreach (var crafter in recipe.crafters) {
-                minEmissions = MathF.Min(crafter.energy.emissions, minEmissions);
+                foreach ((_, float e) in crafter.energy.emissions) {
+                    minEmissions = MathF.Min(e, minEmissions);
+                }
 
                 if (crafter.energy.type == EntityEnergyType.Heat) {
                     break;

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -931,7 +931,7 @@ public class EntityEnergy {
     public EntityEnergyType type { get; internal set; }
     public TemperatureRange workingTemperature { get; internal set; }
     public TemperatureRange acceptedTemperature { get; internal set; } = TemperatureRange.Any;
-    public float emissions { get; internal set; }
+    public IReadOnlyList<(string, float)> emissions { get; internal set; } = [];
     public float drain { get; internal set; }
     public float baseFuelConsumptionLimit { get; internal set; } = float.PositiveInfinity;
     public float FuelConsumptionLimit(Quality quality) => quality.ApplyStandardBonus(baseFuelConsumptionLimit);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Yafc.Model;
@@ -78,7 +79,14 @@ internal partial class FactorioDataDeserializer {
 
         EntityEnergy energy = new EntityEnergy();
         entity.energy = energy;
-        energy.emissions = energySource.Get("emissions_per_minute", 0f);
+        LuaTable? table = energySource.Get<LuaTable>("emissions_per_minute");
+        List<(string, float)> emissions = [];
+        foreach (var (key, value) in table?.ObjectElements ?? []) {
+            if (key is string k && value is double v) {
+                emissions.Add((k, (float)v));
+            }
+        }
+        energy.emissions = emissions.AsReadOnly();
         energy.effectivity = energySource.Get("effectivity", 1f);
 
         switch (type) {

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -291,17 +291,22 @@ doneDrawing:;
                     BuildIconRow(gui, entity.energy.fuels, 2);
                 }
 
-                if (entity.energy.emissions != 0f) {
-                    TextBlockDisplayStyle emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.BackgroundText);
-                    if (entity.energy.emissions < 0f) {
-                        emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Green);
-                        gui.BuildText("This building absorbs pollution", emissionStyle);
+                foreach ((string name, float amount) in entity.energy.emissions) {
+                    if (amount != 0f) {
+                        TextBlockDisplayStyle emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.BackgroundText);
+                        if (amount < 0f) {
+                            emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Green);
+                            gui.BuildText("This building absorbs " + name, emissionStyle);
+                            gui.BuildText($"Absorption: {DataUtils.FormatAmount(-amount, UnitOfMeasure.None)} {name} per minute", emissionStyle);
+                        }
+                        else {
+                            if (amount >= 20f) {
+                                emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Error);
+                                gui.BuildText("This building contributes to global warning!", emissionStyle);
+                            }
+                            gui.BuildText($"Emission: {DataUtils.FormatAmount(amount, UnitOfMeasure.None)} {name} per minute", emissionStyle);
+                        }
                     }
-                    else if (entity.energy.emissions >= 20f) {
-                        emissionStyle = TextBlockDisplayStyle.Default(SchemeColor.Error);
-                        gui.BuildText("This building contributes to global warning!", emissionStyle);
-                    }
-                    gui.BuildText("Emissions: " + DataUtils.FormatAmount(entity.energy.emissions, UnitOfMeasure.None), emissionStyle);
                 }
             }
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Fixes:
+        - Building emission/absorption (pollution and spores) are displayed in tooltips again.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.5.0
 Date: December 30th 2024
     Features:


### PR DESCRIPTION
2.0 changed the format of emission info, which prevented us from loading that information. This loads that information again and distinguishes between the various types (pollution and spores in vanilla/SA) of emissions.
