### PR TITLE
Fix data.extend parsing

### DIFF
--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -80,7 +80,13 @@ public static partial class FactorioDataSource {
     }
 
     public static byte[] ReadModFile(string modName, string path) {
-        var info = allMods[modName];
+        if (!allMods.TryGetValue(modName, out var info)) {
+            // Treat nonexistent files as empty.
+            // This allows sandbox.lua to load __core__'s definition of data.extend, without breaking the tests (which completely replace data)
+            // Also, this may allow us to tolerate mods that `pcall(require("__other_mod__/something"))` without checking if an appropriate
+            // version of other_mod is loaded. (see https://github.com/ShadowTheAge/yafc/issues/199)
+            return [];
+        }
 
         if (info.zipArchive != null) {
             var entry = info.zipArchive.GetEntry(info.folder + path);

--- a/Yafc/Data/Sandbox.lua
+++ b/Yafc/Data/Sandbox.lua
@@ -19,22 +19,6 @@ for defineType,typeTable in pairs(defines.prototypes) do
 	end
 end	
 
-local function dataAdd(type, name, obj)
-	if not data.raw[type] then data.raw[type] = {} end;
-	data.raw[type][name] = obj;
-	--[[if parentTypes[type] then
-		dataAdd(parentTypes[type], name, obj);
-	end]]
-end
-
-data = {raw = {}, is_demo=false}
-function data:extend(t)
-	for i=1,#t do
-		local prototype = t[i];
-		dataAdd(prototype.type, prototype.name, prototype);
-	end
-end
-
 require("__core__/lualib/dataloader.lua")
 
 local raw_log = _G.raw_log;
@@ -53,9 +37,11 @@ table_size = function(t)
 	end
 	return count
 end
-			
-data.data_crawler = "yafc "..yafc_version;
 
-log(data.data_crawler);
+if data then
+	-- If data isn't set, we couldn't load __core__/lualib/dataloader, which means we're running tests. They replace the entire data table.
+	data.data_crawler = "yafc "..yafc_version;
+	log(data.data_crawler);
+end
 
 size=32;

--- a/Yafc/Data/Sandbox.lua
+++ b/Yafc/Data/Sandbox.lua
@@ -35,15 +35,7 @@ function data:extend(t)
 	end
 end
 
-function data.extend(self, otherdata)
-	if self ~= data and otherdata == nil then
-		otherdata = self
-	end
-	for i=1,#otherdata do
-		local prototype = otherdata[i];
-		dataAdd(prototype.type, prototype.name, prototype);
-	end
-end
+require("__core__/lualib/dataloader.lua")
 
 local raw_log = _G.raw_log;
 _G.raw_log = nil;

--- a/Yafc/Data/Sandbox.lua
+++ b/Yafc/Data/Sandbox.lua
@@ -35,6 +35,16 @@ function data:extend(t)
 	end
 end
 
+function data.extend(self, otherdata)
+	if self ~= data and otherdata == nil then
+		otherdata = self
+	end
+	for i=1,#otherdata do
+		local prototype = otherdata[i];
+		dataAdd(prototype.type, prototype.name, prototype);
+	end
+end
+
 local raw_log = _G.raw_log;
 _G.raw_log = nil;
 function log(s)

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Apply productivity, speed, and consumption effects to recipes, and show them in tooltips.
     Fixes:
         - Building emission/absorption (pollution and spores) are displayed in tooltips again.
+        - Fix a parsing error when using the deprecated data.extend API.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.5.0
 Date: December 30th 2024


### PR DESCRIPTION
This issue specifically affects this popular 2.0 mod and potentially others.
https://mods.factorio.com/mod/planet-picker

in prototypes/items.lua
```lua
data.extend({
  {
    type = "item",
    name = "thermal-vent",
    subgroup = "energy",
    ...
  }
}
```

for some reason the legacy data.extend API usage causes a parsing error.

```
Unhandled exception. Yafc.Parser.LuaException: __*__/pre:32: attempt to get length of local 't' (a nil value)
stack traceback:
        [C]: in function '__len'
        __*__/pre:32: in function 'extend'
        __planet-picker__/prototypes/items.lua:1: in main chunk
        [C]: in function 'require'
        __planet-picker__/data.lua:6: in main chunk
   at Yafc.Parser.LuaContext.Exec(ReadOnlySpan`1 chunk, String mod, String name, Int32 argument) in ./Yafc.Parser/LuaContext.cs:line 538
   at Yafc.Parser.LuaContext.Require(IntPtr lua) in ./Yafc.Parser/LuaContext.cs:line 469
```

It seems the dev plans to continue supporting this usage in a recent patch?
https://github.com/wube/factorio-data/commit/7522d3763e76e09ce1a46cba676dfc2b6d12b127#diff-fbcf7ac713a7edc2c7b4bead4465d751c8740dc4178270053a1397f21ad84fa9R13

I don't really understand how line 32 got in here.
https://github.com/shpaass/yafc-ce/blob/999a3f9aa4c9535c42a5904786c2c996bc566984/Yafc/Data/Sandbox.lua#L32

Adding a custom implementation of data.extend seems to fix the parsing issue.
I'm not exactly sure how this Sandbox system works so if somebody knows please check the fix.

<img width="980" alt="Screenshot 2025-01-06 at 2 00 13 PM" src="https://github.com/user-attachments/assets/3394b217-1232-4772-8f46-8899d24e7405" />





