### PR TITLE
Fix #291: Changed dropdown icon to Icon.Menu for clarity and consistency.

### DIFF
--- a/Yafc/Widgets/DataGrid.cs
+++ b/Yafc/Widgets/DataGrid.cs
@@ -67,7 +67,7 @@ public abstract class TextDataColumn<TData>(string header, float initialWidth, f
             var rect = gui.statePosition;
             Rect menuRect = new Rect(rect.Right - 1.7f, rect.Y, 1.5f, 1.5f);
             if (gui.isBuilding) {
-                gui.DrawIcon(menuRect, Icon.DropDown, SchemeColor.BackgroundText);
+                gui.DrawIcon(menuRect, Icon.Menu, SchemeColor.BackgroundText);
             }
 
             if (gui.BuildButton(menuRect, SchemeColor.None, SchemeColor.Grey)) {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -250,7 +250,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             }
 
             gui.allocator = RectAllocator.RightRow;
-            if (gui.BuildButton(Icon.DropDown, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, "List and search all pages (Ctrl+Shift+" +
+            if (gui.BuildButton(Icon.Menu, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, "List and search all pages (Ctrl+Shift+" +
                 ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_F) + ")") || showSearchAll) {
                 showSearchAll = false;
                 updatePageList();

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
         - Apply productivity, speed, and consumption effects to recipes, and show them in tooltips.
+        - Updated the dropdown icon for better clarity.
     Fixes:
         - Building emission/absorption (pollution and spores) are displayed in tooltips again.
         - Fix a parsing error when using the deprecated data.extend API.


### PR DESCRIPTION
Fix #291 by changing to the `Icon.Menu`.

Changed in two places:

1. On the top bar of the page:
![image](https://github.com/user-attachments/assets/769499a9-d182-4a73-baf9-7b4ec636ac98)
2. On the top-right dropdown:
![image](https://github.com/user-attachments/assets/0a1b81aa-1b99-4c18-8b93-56ca47024e51)
