### PR TITLE
Calculate item weight and display rocket capacity

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -395,6 +395,10 @@ public class Item : Goods {
     /// Gets the time it takes for a base-quality item to spoil, in seconds, or 0 if this item doesn't spoil.
     /// </summary>
     public float baseSpoilTime => getBaseSpoilTime.Value;
+
+    public int weight { get; internal set; }
+    internal float ingredient_to_weight_coefficient = 0.5f;
+
     /// <summary>
     /// Gets the <see cref="Quality"/>-adjusted spoilage time for this item, in seconds, or 0 if this item doesn't spoil.
     /// </summary>

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -40,6 +40,7 @@ public static class Database {
     public static FactorioIdRange<Quality> qualities { get; internal set; } = null!;
     public static FactorioIdRange<Location> locations { get; internal set; } = null!;
     public static int constantCombinatorCapacity { get; internal set; } = 18;
+    public static int rocketCapacity { get; internal set; }
 
     /// <summary>
     /// Returns the set of beacons filtered to only those that can accept at least one module.

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -76,18 +76,18 @@ internal static class DataParserUtils {
         return result;
     }
 
-    public static T Get<T>(this LuaTable table, int key, T def) {
-        _ = Parse(table[key], out var result, def);
+    public static T Get<T>(this LuaTable? table, int key, T def) {
+        _ = Parse(table?[key], out var result, def);
         return result;
     }
 
-    public static T? Get<T>(this LuaTable table, string key) {
-        _ = Parse(table[key], out T? result);
+    public static T? Get<T>(this LuaTable? table, string key) {
+        _ = Parse(table?[key], out T? result);
         return result;
     }
 
-    public static T? Get<T>(this LuaTable table, int key) {
-        _ = Parse(table[key], out T? result);
+    public static T? Get<T>(this LuaTable? table, int key) {
+        _ = Parse(table?[key], out T? result);
         return result;
     }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -578,10 +578,10 @@ internal partial class FactorioDataDeserializer {
             if (mapGen.Get("autoplace_controls", out LuaTable? controls)) {
                 location.placementControls = controls.ObjectElements.Keys.OfType<string>().ToList();
             }
-            if (mapGen.Get<LuaTable>("autoplace_settings")?.Get<LuaTable>("entity")?.Get<LuaTable>("settings") is LuaTable entities) {
+            if (mapGen.Get<LuaTable>("autoplace_settings").Get<LuaTable>("entity").Get<LuaTable>("settings") is LuaTable entities) {
                 location.entitySpawns = entities.ObjectElements.Keys.OfType<string>().ToList();
             }
-            if (mapGen.Get<LuaTable>("autoplace_settings")?.Get<LuaTable>("tile")?.Get<LuaTable>("settings") is LuaTable tiles) {
+            if (mapGen.Get<LuaTable>("autoplace_settings").Get<LuaTable>("tile").Get<LuaTable>("settings") is LuaTable tiles) {
                 foreach (string tile in tiles.ObjectElements.Keys.Cast<string>()) {
                     allObjects.OfType<Tile>().Single(t => t.name == tile).locations.Add(location);
                 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -511,9 +511,13 @@ internal partial class FactorioDataDeserializer {
             if (item.weight != 0) {
                 continue;
             }
+            if (item.stackSize == 0) {
+                continue; // Py's synthetic items sometimes have a stack size of 0.
+            }
+
             Recipe? recipe = allObjects.OfType<Recipe>().FirstOrDefault(r => r.name == item.name);
             // Hidden recipes appear to be ignored by Factorio; a pistol weighs 100g, not the 200kg that would be expected from its stack size.
-            if (recipe?.products.Length > 0 && !recipe.hidden) {
+            if (recipe?.products.Length > 0 && recipe.ingredients.Length > 0 && !recipe.hidden) {
                 float weight = 0;
                 foreach (Ingredient ingredient in recipe.ingredients) {
                     if (ingredient.goods is Item i) {
@@ -543,9 +547,11 @@ internal partial class FactorioDataDeserializer {
                     item.weight = rocketCapacity / (rocketCapacity / item.weight / item.stackSize) / item.stackSize;
                 }
 
-                foreach (Item product in dependencies[item]) {
-                    if (product.weight == 0) {
-                        queue.Enqueue(product);
+                if (dependencies.TryGetValue(item, out List<Item>? products)) {
+                    foreach (Item product in dependencies[item]) {
+                        if (product.weight == 0) {
+                            queue.Enqueue(product);
+                        }
                     }
                 }
             }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -35,6 +35,8 @@ internal partial class FactorioDataDeserializer {
     private readonly EntityEnergy laborEntityEnergy;
     private Entity? character;
     private readonly Version factorioVersion;
+    private int rocketCapacity;
+    private int defaultItemWeight;
 
     private static readonly Version v0_18 = new Version(0, 18);
 
@@ -230,6 +232,8 @@ internal partial class FactorioDataDeserializer {
         Database.allInserters = Database.entities.all.OfType<EntityInserter>().ToArray();
         Database.allAccumulators = Database.entities.all.OfType<EntityAccumulator>().ToArray();
         Database.allContainers = Database.entities.all.OfType<EntityContainer>().ToArray();
+
+        Database.rocketCapacity = rocketCapacity;
     }
 
     private static bool AreInverseRecipes(Recipe packing, Recipe unpacking) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -583,7 +583,7 @@ internal partial class FactorioDataDeserializer {
             }
             if (generation.Get("control", out string? control)) {
                 entity.mapGenerated = true;
-                entity.autoplaceControl = generation?.Get<string>("control");
+                entity.autoplaceControl = generation.Get<string>("control");
             }
         }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -39,7 +39,7 @@ internal partial class FactorioDataDeserializer {
     }
 
     private static void DeserializeFlags(LuaTable table, RecipeOrTechnology recipe) {
-        recipe.hidden = table.Get("hidden", true);
+        recipe.hidden = table.Get("hidden", false);
         recipe.enabled = table.Get("enabled", true);
     }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -447,6 +447,7 @@ doneDrawing:;
 
             using (gui.EnterGroup(contentPadding)) {
                 gui.BuildText("Stack size: " + item.stackSize);
+                gui.BuildText("Rocket capacity: " + DataUtils.FormatAmount(Database.rocketCapacity / item.weight, UnitOfMeasure.None));
             }
         }
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Version: 2.6.0
 Date: January 20th 2025
     Features:
         - Apply productivity, speed, and consumption effects to recipes, and show them in tooltips.
+        - Display rocket capacity in item tooltips.
     Fixes:
         - Building emission/absorption (pollution and spores) are displayed in tooltips again.
         - Fix a parsing error when using the deprecated data.extend API.


### PR DESCRIPTION
This loads or calculates the weight of each item and displays the rocket capacity in the item tooltips. I don't think this completes either #369 or #381, but it loads data needed for them.

The calculations done by Factorio aren't documented, but most of my results match at least one of https://rocketcal.cc/weights.json or Factorio. (I skipped some harder-to-acquire items, such as the spidertron rocket launchers, and all virtual items, such as artillery remotes.)