### PR TITLE
Fix #255: text too small to be readable on Linux/X with weird screen

### DIFF
--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -70,7 +70,10 @@ public abstract class Window : IDisposable {
         _ = SDL.SDL_GetDisplayDPI(display, out float dpi, out _, out _);
         _ = SDL.SDL_GetDisplayBounds(display, out var rect);
         // 82x60 is the minimum screen size in units, plus some for borders
-        int desiredUnitsToPixels = dpi == 0 ? 13 : MathUtils.Round(dpi / 6.8f);
+        // DPI bellow 96 is more likely to be incorrectly reported value than desired,
+        //     see discussion in https://github.com/shpaass/yafc-ce/issues/255#issuecomment-2508884418
+        //     => we treat is as "unknown" and revert to default 100% scaling
+        int desiredUnitsToPixels = dpi < 96 ? 13 : MathUtils.Round(dpi / 6.8f);
 
         if (desiredUnitsToPixels * 82f >= rect.w) {
             desiredUnitsToPixels = MathUtils.Floor(rect.w / 82f);


### PR DESCRIPTION
If DPI is lower than 96, we just use the default
100% scaling, as the value is more likely to be
driver issue than what the user wants.

See discussion at https://github.com/shpaass/yafc-ce/issues/255#issuecomment-2508884418. Thanks @TheCasualObserver for, well, coming up with the.


I also considered making the check Linux only, as that is where the issue was reported. However, DPI significantly < 96 either should not ever be reported by other OSes, or if it really is correct (IDK, on big old TVs, projectors), the display is still most likely going to be viewed from further away. Pretending like it's normal 96 DPI screen will be better in those cases as well. Nobody will ever want letters made of 6 pixels :grin: (I hope)
