### PR TITLE
Fix missing icons of special recipes

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -164,11 +164,11 @@ internal partial class FactorioDataDeserializer {
         rocketCapacity = raw.Get<LuaTable>("utility-constants").Get<LuaTable>("default").Get("rocket_lift_weight", 1000000);
         defaultItemWeight = raw.Get<LuaTable>("utility-constants").Get<LuaTable>("default").Get("default_item_weight", 100);
         UpdateSplitFluids();
-        var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
         UpdateRecipeIngredientFluids(errorCollector);
+        CalculateMaps(netProduction);
+        var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
         UpdateRecipeCatalysts();
         CalculateItemWeights();
-        CalculateMaps(netProduction);
         ExportBuiltData();
         progress.Report(("Post-processing", "Calculating dependencies"));
         Dependencies.Calculate();


### PR DESCRIPTION
This race condition existed for some time, but with `CalculateItemWeights` added it became a lot likely to happen.