### PR TITLE
Lightning collectors

### DIFF
--- a/Docs/Fulgora lightning model.md
+++ b/Docs/Fulgora lightning model.md
@@ -1,0 +1,26 @@
+This is the math used to calculate `requiredChargeMw` (called "_cap_" here) in `BuildAccumulatorView`.
+The first two equations are the starting point, and the remainder are solving for _cap_.
+
+_chargeTime_ is per lightning strike.
+_eff_ is the efficiency of the lightning attractor.
+
+$$chargeTime=\frac{1000MJ\times eff}{drain+cap+load}$$
+$$cap\times chargeTime\times numStrikes-load\times(stormTime-chargeTime\times numStrikes)=reqMj$$
+$$\frac{cap\times 1000MJ\times eff\times numStrikes}{drain+cap+load}-load\times\left(stormTime-\frac{1000MJ\times eff\times numStrikes}{drain+cap+load}\right)=reqMj$$
+$$\frac{cap\times 1000MJ\times eff\times numStrikes}{drain+cap+load}-load\times stormTime+\left(\frac{load\times 1000MJ\times eff\times numStrikes}{drain+cap+load}\right)=reqMj$$
+$$\frac{cap\times 1000MJ\times eff\times numStrikes-load\times stormTime\times(drain+cap+load)+load\times 1000MJ\times eff\times numStrikes}{drain+cap+load}=reqMj$$
+$$cap\times 1000MJ\times eff\times numStrikes-load\times stormTime\times(drain+cap+load)+load\times 1000MJ\times eff\times numStrikes\\
+=reqMj\times(drain+cap+load)$$
+$$cap\times 1000MJ\times eff\times numStrikes-load\times stormTime\times drain-load\times stormTime\times cap\\
+-\ load\times stormTime\times load+load\times 1000MJ\times eff\times numStrikes\\
+=reqMj\times drain+reqMj\times cap+reqMj\times load$$
+$$cap\times 1000MJ\times eff\times numStrikes-load\times stormTime\times cap-reqMj\times cap\\
+\begin{aligned}
+=\ &reqMj\times drain+reqMj\times load+load\times stormTime\times drain\\
+&+load\times stormTime\times load-load\times 1000MJ\times eff\times numStrikes
+\end{aligned}$$
+$$\begin{aligned}
+cap\times(&1000MJ\times eff\times numStrikes-load\times stormTime-reqMj)\\
+&=reqMj\times drain+load\times(reqMj+stormTime\times drain+stormTime\times load-1000MJ\times eff\times numStrikes)
+\end{aligned}$$
+$$cap=\frac{reqMj\times drain+load\times(reqMj+stormTime\times(drain+load)-1000MJ\times eff\times numStrikes)}{1000MJ\times eff\times numStrikes-load\times stormTime-reqMj}$$

--- a/Yafc.Model/Model/QualityExtensions.cs
+++ b/Yafc.Model/Model/QualityExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Yafc.Model;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Yafc.Model;
 
 public static class QualityExtensions {
     public static float GetCraftingSpeed(this IObjectWithQuality<EntityCrafter> crafter) => crafter.target.CraftingSpeed(crafter.quality);
@@ -6,4 +8,28 @@ public static class QualityExtensions {
     public static float GetPower(this IObjectWithQuality<Entity> entity) => entity.target.Power(entity.quality);
 
     public static float GetBeaconEfficiency(this IObjectWithQuality<EntityBeacon> beacon) => beacon.target.BeaconEfficiency(beacon.quality);
+
+    public static float GetAttractorEfficiency(this IObjectWithQuality<EntityAttractor> attractor)
+        => attractor.target.Efficiency(attractor.quality);
+
+    public static float StormPotentialPerTick(this IObjectWithQuality<EntityAttractor> attractor)
+        => attractor.target.StormPotentialPerTick(attractor.quality);
+
+    /// <summary>
+    /// If possible, converts an <see cref="IObjectWithQuality{T}"/> into one with a different generic parameter.
+    /// </summary>
+    /// <typeparam name="T">The desired type parameter for the output <see cref="IObjectWithQuality{T}"/>.</typeparam>
+    /// <param name="obj">The input <see cref="IObjectWithQuality{T}"/> to be converted.</param>
+    /// <param name="result">If <c><paramref name="obj"/>?.target is <typeparamref name="T"/></c>, an <see cref="IObjectWithQuality{T}"/> with
+    /// the same target and quality as <paramref name="obj"/>. Otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the conversion was successful, or <see langword="false"/> if it was not.</returns>
+    public static bool Is<T>(this IObjectWithQuality<FactorioObject>? obj, [NotNullWhen(true)] out IObjectWithQuality<T>? result) where T : FactorioObject {
+        if (obj is null or IObjectWithQuality<T>) {
+            result = obj as IObjectWithQuality<T>;
+            return result is not null;
+        }
+        // Use the conversion because it permits a null target. The constructor does not.
+        result = (ObjectWithQuality<T>?)(obj.target as T, obj.quality);
+        return result is not null;
+    }
 }

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -11,6 +11,7 @@ public enum WarningFlags {
     ReactorsNeighborsFromPrefs = 1 << 1,
     FuelUsageInputLimited = 1 << 2,
     AsteroidCollectionNotModelled = 1 << 3,
+    AssumesFulgoraAndModel = 1 << 4,
 
     // Static errors
     EntityNotSpecified = 1 << 8,
@@ -149,6 +150,9 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
 
             if (entity.target.factorioType == "solar-panel") {
                 warningFlags |= WarningFlags.AssumesNauvisSolarRatio;
+            }
+            else if (entity.target.factorioType == "lightning-attractor") {
+                warningFlags |= WarningFlags.AssumesFulgoraAndModel;
             }
             else if (entity.target.factorioType == "asteroid-collector") {
                 warningFlags |= WarningFlags.AsteroidCollectionNotModelled;

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -333,7 +333,7 @@ doneDrawing:;
                 miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.AccumulatorCapacity(quality), UnitOfMeasure.Megajoule);
                 break;
             case EntityCrafter solarPanel:
-                if (solarPanel.baseCraftingSpeed > 0f && entity.factorioType == "solar-panel") {
+                if (solarPanel.baseCraftingSpeed > 0f && entity.factorioType is "solar-panel" or "lightning-attractor") {
                     miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.CraftingSpeed(quality), UnitOfMeasure.Megawatt);
                 }
 
@@ -671,6 +671,7 @@ doneDrawing:;
             ("Module effects:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent) + '*'),
             ("Beacon transmission efficiency:", '+' + DataUtils.FormatAmount(quality.BeaconTransmissionBonus, UnitOfMeasure.None)),
             ("Time before spoiling:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
+            ("Lightning attractor range & efficiency:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
         ];
 
         float rightWidth = text.Max(t => gui.GetTextDimensions(out _, t.right).X);

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -332,17 +332,25 @@ doneDrawing:;
             case EntityAccumulator accumulator:
                 miscText = "Accumulator charge: " + DataUtils.FormatAmount(accumulator.AccumulatorCapacity(quality), UnitOfMeasure.Megajoule);
                 break;
-            case EntityCrafter solarPanel:
-                if (solarPanel.baseCraftingSpeed > 0f && entity.factorioType is "solar-panel" or "lightning-attractor") {
-                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.CraftingSpeed(quality), UnitOfMeasure.Megawatt);
+            case EntityAttractor attractor:
+                if (attractor.baseCraftingSpeed > 0f) {
+                    miscText = "Power production (average usable): " + DataUtils.FormatAmount(attractor.CraftingSpeed(quality), UnitOfMeasure.Megawatt);
+                    miscText += $"\n    Build in a {attractor.ConstructionGrid(quality)}-tile square grid";
+                    miscText += "\nProtection range: " + DataUtils.FormatAmount(attractor.Range(quality), UnitOfMeasure.None);
+                    miscText += "\nCollection efficiency: " + DataUtils.FormatAmount(attractor.Efficiency(quality), UnitOfMeasure.Percent);
                 }
 
+                break;
+            case EntityCrafter solarPanel:
+                if (solarPanel.baseCraftingSpeed > 0f && entity.factorioType == "solar-panel") {
+                    miscText = "Power production (average): " + DataUtils.FormatAmount(solarPanel.CraftingSpeed(quality), UnitOfMeasure.Megawatt);
+                }
                 break;
         }
 
         if (miscText != null) {
             using (gui.EnterGroup(contentPadding)) {
-                gui.BuildText(miscText);
+                gui.BuildText(miscText, TextBlockDisplayStyle.WrappedText);
             }
         }
     }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1467,6 +1467,7 @@ goodsHaveNoProduction:;
         {WarningFlags.ExceedsBuiltCount, "This recipe requires more buildings than are currently built."},
         {WarningFlags.AsteroidCollectionNotModelled, "The speed of asteroid collectors depends heavily on location and travel speed. " +
             "It also depends on the distance between adjacent collectors. These dependencies are not modeled. Expect widely varied performance."},
+        {WarningFlags.AssumesFulgoraAndModel, "Energy production values assume Fulgoran storms and attractors in a square grid." },
     };
 
     private static readonly (Icon icon, SchemeColor color)[] tagIcons = [

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -365,17 +365,63 @@ goodsHaveNoProduction:;
                 view.BuildGoodsIcon(gui, fuel, fuelLink, fuelAmount, ProductDropdownType.Fuel, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes);
             }
             else {
-                if (recipe.recipe == Database.electricityGeneration && recipe.entity.target.factorioType == "solar-panel") {
-                    BuildSolarPanelAccumulatorView(gui, recipe);
+                if (recipe.recipe == Database.electricityGeneration && recipe.entity.target.factorioType is "solar-panel" or "lightning-attractor") {
+                    BuildAccumulatorView(gui, recipe);
                 }
             }
         }
 
-        private static void BuildSolarPanelAccumulatorView(ImGui gui, RecipeRow recipe) {
+        private static void BuildAccumulatorView(ImGui gui, RecipeRow recipe) {
             var accumulator = recipe.GetVariant(Database.allAccumulators);
             Quality accumulatorQuality = recipe.GetVariant(Database.qualities.all.OrderBy(q => q.level).ToArray());
-            float requiredMj = recipe.entity?.GetCraftingSpeed() * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
-            float requiredAccumulators = requiredMj / accumulator.AccumulatorCapacity(accumulatorQuality);
+            float requiredAccumulators = 0;
+            if (recipe.entity?.target.factorioType == "solar-panel") {
+                float requiredMj = recipe.entity?.GetCraftingSpeed() * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
+                requiredAccumulators = requiredMj / accumulator.AccumulatorCapacity(accumulatorQuality);
+            }
+            else if (recipe.entity.Is(out IObjectWithQuality<EntityAttractor>? attractor)) {
+                // Model the storm as rising from 0% to 100% over 30 seconds, staying at 100% for 24 seconds, and decaying over 30 seconds.
+                // I adjusted these until the right answers came out of my Excel model.
+                // TODO(multi-planet): Adjust these numbers based on day length.
+                const int stormRiseTicks = 30 * 60, stormPlateauTicks = 24 * 60, stormFallTicks = 30 * 60;
+                const int stormTotalTicks = stormRiseTicks + stormPlateauTicks + stormFallTicks;
+
+                // Don't try to model the storm with less than 1 attractor (6 lightning strikes for a normal rod)
+                float stormMjPerTick = attractor.StormPotentialPerTick() * (recipe.buildingCount < 1 ? 1 : recipe.buildingCount);
+                // TODO(multi-planet): Use the appropriate LightningPrototype::energy instead of hardcoding the 1000 of Fulgoran lightning.
+                // Tick numbers will be wrong if the first and last strike don't happen in the rise and fall periods. This is okay because
+                // a single normal rod has the first strike at 23 seconds, and the _second_ at 32.
+                float totalStormEnergy = stormMjPerTick * 3 * 60 * 60 /*TODO(multi-planet): ticks per day*/ * 0.3f;
+                float lostStormEnergy = totalStormEnergy % 1000;
+                float firstStrikeTick = (MathF.Sqrt(1 + 8 * 1000 * stormRiseTicks / stormMjPerTick) + 1) / 2;
+                float lastStrikeTick = stormTotalTicks - (MathF.Sqrt(1 + 8 * lostStormEnergy * stormFallTicks / stormMjPerTick) + 1) / 2;
+                int strikeCount = (int)(totalStormEnergy / 1000);
+
+                float requiredPower = attractor.GetCraftingSpeed() * recipe.buildingCount;
+
+                // Two different conditions need to be tested here. The first test is for capacity when discharging: the accumulators must have
+                // a capacity of requiredPower * timeBetween(lastStrikeDischarged, firstStrike + 1 day)
+                // As simplifying assumptions for this calculation, (1) the accumulators are fully charged when the last strike hits, and
+                // (2) the attractor's internal buffer is empty when the last strike hits.
+                // If incorrect, these cause errors in opposite directions.
+                float lastStrikeDrainedTick = lastStrikeTick + 1000 * attractor.GetAttractorEfficiency() / (requiredPower + attractor.target.drain) * 60;
+                float requiredTicks = 3 * 60 * 60 /*TODO(multi-planet): ticks per day*/ - lastStrikeDrainedTick + firstStrikeTick;
+                float requiredMj = requiredPower * requiredTicks / 60;
+
+                // The second test is for capacity when charging: The accumulators must draw at least requiredMj out of the attractors.
+                // Solve: chargeTimePerStrike = 1000MJ * effectiveness / (150MW + chargePower + requiredPower)
+                // And: chargePower * chargeTimePerStrike * #strikes - requiredPower * nonStrikeStormTime = requiredMj
+                // Not fun (see Fulgora lightning model.md), but the result is:
+                float stormLengthSeconds = (lastStrikeDrainedTick - firstStrikeTick) / 60;
+                float stormEnergy = 1000 * attractor.GetAttractorEfficiency() * strikeCount;
+                float numerator = requiredMj * attractor.target.drain + requiredPower * (requiredMj + stormLengthSeconds * (attractor.target.drain + requiredPower) - stormEnergy);
+                float denominator = stormEnergy - requiredPower * stormLengthSeconds - requiredMj;
+                float requiredChargeMw = numerator / denominator;
+
+                requiredAccumulators = Math.Max(requiredMj / accumulator.AccumulatorCapacity(accumulatorQuality),
+                    requiredChargeMw / accumulator.Power(accumulatorQuality));
+            }
+
             ObjectWithQuality<Entity> accumulatorWithQuality = new(accumulator, accumulatorQuality);
             if (gui.BuildFactorioObjectWithAmount(accumulatorWithQuality, requiredAccumulators, ButtonDisplayStyle.ProductionTableUnscaled) == Click.Left) {
                 ShowAccumulatorDropdown(gui, recipe, accumulator, accumulatorQuality);
@@ -1467,7 +1513,8 @@ goodsHaveNoProduction:;
         {WarningFlags.ExceedsBuiltCount, "This recipe requires more buildings than are currently built."},
         {WarningFlags.AsteroidCollectionNotModelled, "The speed of asteroid collectors depends heavily on location and travel speed. " +
             "It also depends on the distance between adjacent collectors. These dependencies are not modeled. Expect widely varied performance."},
-        {WarningFlags.AssumesFulgoraAndModel, "Energy production values assume Fulgoran storms and attractors in a square grid." },
+        {WarningFlags.AssumesFulgoraAndModel, "Energy production values assume Fulgoran storms and attractors in a square grid.\n" +
+            "The accumulator estimate tries to store 10% of the energy captured by the attractors."},
     };
 
     private static readonly (Icon icon, SchemeColor color)[] tagIcons = [

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Features:
+        - Detect lightning rods/collectors as electricity sources, and estimate the required accumulator count.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.7.0
 Date: January 27th 2025
     Features:

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -6,6 +6,7 @@ dylib
 Factorio
 Floodfill
 foreach
+Fulgoran
 imgui
 Kovarex
 liblua


### PR DESCRIPTION
This adds lightning collectors as electricity sources (when paired with accumulators), covering tasks 1 and 3 of #319. Discord discussion of #390 was leaning toward a square grid. There didn't seem to be strong opinions on how effective the accumulators should be, so I picked 10%. Both of these could be configured, but I chose not to do that for now.

I also chose to hardcode Fulgoran storm properties (#319, task 2), but left todos behind for where they would need to be changed.