### PR TITLE
fix(icons): Use icons that exist in 2.0.33 for science&launches.

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -419,6 +419,13 @@ public class Item : Goods {
         spent = fuelResult;
         return spent != null;
     }
+
+    public override DependencyNode GetDependencies() {
+        if (this == Database.science) {
+            return (Database.technologies.all, DependencyNode.Flags.Source);
+        }
+        return base.GetDependencies();
+    }
 }
 
 public class Module : Item {
@@ -464,20 +471,11 @@ public class Location : FactorioObject {
 public class Special : Goods {
     internal string? virtualSignal { get; set; }
     internal bool power;
-    internal bool isResearch;
     internal bool isVoid;
     public override bool isPower => power;
     public override string type => isPower ? "Power" : "Special";
     public override UnitOfMeasure flowUnitOfMeasure => isVoid ? UnitOfMeasure.None : isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.SpecialGoods;
-    public override DependencyNode GetDependencies() {
-        if (isResearch) {
-            return (Database.technologies.all, DependencyNode.Flags.Source);
-        }
-        else {
-            return base.GetDependencies();
-        }
-    }
 }
 
 [Flags]

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -13,7 +13,7 @@ public static class Database {
     public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
     public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
     public static Goods voidEnergy { get; internal set; } = null!;
-    public static Goods researchUnit { get; internal set; } = null!;
+    public static Goods science { get; internal set; } = null!;
     public static Goods itemInput { get; internal set; } = null!;
     public static Goods itemOutput { get; internal set; } = null!;
     public static Goods electricity { get; internal set; } = null!;

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -129,7 +129,6 @@ public static class SpecialNames {
     public const string RocketLaunch = "launch";
     public const string RocketCraft = "rocket.";
     public const string ReactorRecipe = "reactor";
-    public const string ResearchUnit = "research-unit";
     public const string SpoilRecipe = "spoil";
     public const string PlantRecipe = "plant";
     public const string AsteroidCapture = "asteroid-capture";

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -28,7 +28,7 @@ internal partial class FactorioDataDeserializer {
     private readonly Special heat;
     private readonly Special electricity;
     private readonly Special rocketLaunch;
-    private readonly Special researchUnit;
+    private readonly Item science;
     private readonly Item totalItemOutput;
     private readonly Item totalItemInput;
     private readonly EntityEnergy voidEntityEnergy;
@@ -86,12 +86,12 @@ internal partial class FactorioDataDeserializer {
         rootAccessible.Add(voidEnergy);
 
         rocketLaunch = createSpecialObject(false, SpecialNames.RocketLaunch, "Rocket launch slot",
-            "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/02-rocket.png", "signal-R");
-        researchUnit = createSpecialObject(false, SpecialNames.ResearchUnit, "Research",
-            "This represents one unit of a research task.", "__base__/graphics/icons/compilatron.png", "signal-L");
-        researchUnit.isResearch = true;
-        researchUnit.showInExplorers = false;
-        Analysis.ExcludeFromAnalysis<CostAnalysis>(researchUnit);
+            "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/rocket-static-pod.png", "signal-R");
+
+        science = GetObject<Item>("science");
+        science.showInExplorers = false;
+        Analysis.ExcludeFromAnalysis<CostAnalysis>(science);
+        formerAliases["Special.research-unit"] = science;
 
         generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, "generating");
         generatorProduction.products = [new Product(electricity, 1f)];
@@ -189,7 +189,7 @@ internal partial class FactorioDataDeserializer {
 
         Database.allSciencePacks = [.. sciencePacks];
         Database.voidEnergy = voidEnergy;
-        Database.researchUnit = researchUnit;
+        Database.science = science;
         Database.itemInput = totalItemInput;
         Database.itemOutput = totalItemOutput;
         Database.electricity = electricity;

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -46,7 +46,7 @@ internal partial class FactorioDataDeserializer {
     private void DeserializeTechnology(LuaTable table, ErrorCollector errorCollector) {
         var technology = DeserializeCommon<Technology>(table, "technology");
         LoadTechnologyData(technology, table, errorCollector);
-        technology.products = [new(researchUnit, 1)];
+        technology.products = [new(science, 1)];
     }
 
     private void DeserializeQuality(LuaTable table, ErrorCollector errorCollector) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -969,7 +969,7 @@ goodsHaveNoProduction:;
             #region Recipe selection
             int numberOfShownRecipes = 0;
 
-            if (goods.name == SpecialNames.ResearchUnit) {
+            if (goods == Database.science) {
                 if (gui.BuildButton("Add technology") && gui.CloseDropdown()) {
                     SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology",
                         r => context.AddRecipe(r, DefaultVariantOrdering), checkMark: r => context.recipes.Any(rr => rr.recipe == r));


### PR DESCRIPTION
I checked that the rocket launch slot image also exists in 2.0.32, but I don't have earlier 2.0 versions readily available. If there's interest in supporting both 1.1 and 2.0, I'll need to be more creative about selecting the launch slot image and creating the science/research-unit item.