### PR TITLE
Hovering over desired product shows duplicate recipe

### DIFF
--- a/Yafc.Model/Analysis/DependencyNode.cs
+++ b/Yafc.Model/Analysis/DependencyNode.cs
@@ -241,7 +241,7 @@ public abstract class DependencyNode {
     /// </summary>
     /// <param name="dependencies">The <see cref="DependencyList"/> whose behavior should be matched by this <see cref="ListNode"/>.</param>
     private sealed class ListNode(IEnumerable<FactorioObject> elements, Flags flags) : DependencyNode {
-        private readonly ReadOnlyCollection<FactorioId> elements = elements.Select(e => e.id).ToList().AsReadOnly();
+        private readonly ReadOnlyCollection<FactorioId> elements = elements.Select(e => e.id).Distinct().ToList().AsReadOnly();
 
         internal override IEnumerable<FactorioId> Flatten() => elements;
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -478,7 +478,7 @@ internal partial class FactorioDataDeserializer {
                     break;
                 case Goods goods:
                     goods.usages = itemUsages.GetArray(goods);
-                    goods.production = itemProduction.GetArray(goods);
+                    goods.production = itemProduction.GetArray(goods).Distinct().ToArray();
                     goods.miscSources = miscSources.GetArray(goods);
 
                     if (o is Item item) {


### PR DESCRIPTION
This fixes #403. It also fixes a similar issue in the net production calculations, where recipes with repeated outputs (such as Vrauk MK02) could be treated as consumption recipes instead production recipes.