### PR TITLE
fix(#381): Rocket launch recipes use rocket capacity, not stack size.

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -340,6 +340,9 @@ public class Product : IFactorioObjectWrapper {
         }
     }
     float IFactorioObjectWrapper.amount => amount;
+
+    public static Product operator *(Product product, int factor) =>
+        new(product.goods, product.amountMin * factor, product.amountMax * factor, product.probability);
 }
 
 // Abstract base for anything that can be produced or consumed by recipes (etc)
@@ -669,6 +672,9 @@ public class EntityCrafter : EntityWithModules {
     public Goods[]? inputs { get; internal set; }
     public RecipeOrTechnology[] recipes { get; internal set; } = null!; // null-forgiving: Set in the first step of CalculateMaps
     private float _craftingSpeed = 1;
+    // For rocket silos, the number of inventory slots. Launch recipes are limited by both weight and available slots.
+    internal int rocketInventorySize;
+
     public virtual float baseCraftingSpeed {
         // The speed of a lab is baseSpeed * (1 + researchSpeedBonus) * Math.Min(0.2, 1 + moduleAndBeaconSpeedBonus)
         get => _craftingSpeed * (1 + (factorioType == "lab" ? Project.current.settings.researchSpeedBonus : 0));

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -400,6 +400,8 @@ internal partial class FactorioDataDeserializer {
                                 }
                             }
                         }
+
+                        crafter.rocketInventorySize = rocketInventorySize;
                     }
                 }
                 break;

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,8 @@ Version:
 Date:
     Features:
         - Detect lightning rods/collectors as electricity sources, and estimate the required accumulator count.
+    Fixes:
+        - When creating launch recipes, obey the rocket capacity, not the item stack size.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.7.0
 Date: January 27th 2025


### PR DESCRIPTION
Py launch recipes now consume 5 items, instead of 1, and scale up their output accordingly.

The satellite and space platform launch recipes are still correct. Fish launch goes to 300 in SA instead of 100 in vanilla, but that's both a rarely-modeled recipe and a justifiable result.