### PR TITLE
fix: Voiding and recycling messed up detection of barrelling recipes.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Detect lightning rods/collectors as electricity sources, and estimate the required accumulator count.
     Fixes:
         - When creating launch recipes, obey the rocket capacity, not the item stack size.
+        - Improve detection of special (e.g. barrelling, caging) recipes, especially with SA's recycling recipes.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.7.0
 Date: January 27th 2025


### PR DESCRIPTION
Filled barrels and and barrel-filling recipes were considered normal because filled barrels could be recycled. While this is a valid way to void unwanted fluids, it isn't enough to make them into normal items/recipes.

I expected to see some benefit in Py too, but Yafc's rules say Py's "voiding" recipes are valid sources of Ash.