### PR TITLE
Added remove link button to link summary screen.

### DIFF
--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -48,9 +48,18 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
             _ = gui.BuildFactorioObjectButtonWithText(link.goods, tooltipOptions: DrawParentRecipes(link.owner, "link"));
         }
         scrollArea.Build(gui);
+        if (gui.BuildButton("Remove link", link.owner.links.Contains(link) ? SchemeColor.Primary : SchemeColor.Grey)) {
+            DestroyLink(link);
+            Close();
+        }
         if (gui.BuildButton("Done")) {
             Close();
         }
+    }
+
+    private void DestroyLink(ProductionLink link) {
+        _ = link.owner.RecordUndo().links.Remove(link);
+        Rebuild();
     }
 
     protected override void ReturnPressed() => Close();

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
         - Detect lightning rods/collectors as electricity sources, and estimate the required accumulator count.
+        - Added button to remove link from link summary screen.
     Fixes:
         - When creating launch recipes, obey the rocket capacity, not the item stack size.
         - Improve detection of special (e.g. barrelling, caging) recipes, especially with SA's recycling recipes.


### PR DESCRIPTION
A list of nice-to-have things:
* [x] A changelog 
* [ ] The link from the PR to the issue that it fixes. -> [This was mentioned on discord and created based on that.](https://discord.com/channels/560199483065892894/1210135763422027837/1335116053696479266)
* [x] A description of what testing was done.
I clicked around the link and it even unlinks when you navigate to new links from there.

![afbeelding](https://github.com/user-attachments/assets/46faf453-2a6e-49ab-a2bb-3cfb430258f1)
