### PR TITLE
fix(#400): Disabled technologies are disabled even if not hidden.

### DIFF
--- a/Yafc.Model/Analysis/DependencyNode.cs
+++ b/Yafc.Model/Analysis/DependencyNode.cs
@@ -29,7 +29,7 @@ public abstract class DependencyNode {
         ItemToPlace = 7,
         TechnologyPrerequisites = 8 | RequireEverything | OneTimeInvestment,
         IngredientVariant = 9,
-        Hidden = 10,
+        Disabled = 10,
         Location = 11 | OneTimeInvestment,
     }
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -112,7 +112,6 @@ public abstract class RecipeOrTechnology : FactorioObject {
     public Goods? mainProduct { get; internal set; }
     public float time { get; internal set; }
     public bool enabled { get; internal set; }
-    public bool hidden { get; internal set; }
     public RecipeFlags flags { get; internal set; }
     public override string type => "Recipe";
 
@@ -184,6 +183,7 @@ public class Recipe : RecipeOrTechnology {
     public Technology[] technologyUnlock { get; internal set; } = [];
     public Dictionary<Technology, float> technologyProductivity { get; internal set; } = [];
     public bool preserveProducts { get; internal set; }
+    public bool hidden { get; internal set; }
 
     public bool HasIngredientVariants() {
         foreach (var ingredient in ingredients) {
@@ -962,8 +962,8 @@ public class Technology : RecipeOrTechnology { // Technology is very similar to 
             nodes.Add(([Database.objectsByTypeName["Mechanics.launch." + triggerItem]], DependencyNode.Flags.Source));
         }
 
-        if (hidden && !enabled) {
-            nodes.Add(([], DependencyNode.Flags.Hidden));
+        if (!enabled) {
+            nodes.Add(([], DependencyNode.Flags.Disabled));
         }
         return nodes;
     }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -38,11 +38,6 @@ internal partial class FactorioDataDeserializer {
         }
     }
 
-    private static void DeserializeFlags(LuaTable table, RecipeOrTechnology recipe) {
-        recipe.hidden = table.Get("hidden", false);
-        recipe.enabled = table.Get("enabled", true);
-    }
-
     private void DeserializeTechnology(LuaTable table, ErrorCollector errorCollector) {
         var technology = DeserializeCommon<Technology>(table, "technology");
         LoadTechnologyData(technology, table, errorCollector);
@@ -130,7 +125,7 @@ internal partial class FactorioDataDeserializer {
             errorCollector.Error($"Could not get requirement(s) to unlock {technology.name}.", ErrorSeverity.AnalysisWarning);
         }
 
-        DeserializeFlags(table, technology);
+        technology.enabled = table.Get("enabled", true);
         technology.time = unit.Get("time", 1f);
         technology.count = unit.Get("count", 1000f);
 
@@ -374,6 +369,7 @@ internal partial class FactorioDataDeserializer {
             recipe.mainProduct = recipe.products[0]?.goods;
         }
 
-        DeserializeFlags(table, recipe);
+        recipe.hidden = table.Get("hidden", false);
+        recipe.enabled = table.Get("enabled", true);
     }
 }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -584,9 +584,9 @@ doneDrawing:;
             BuildRecipe(technology, gui);
         }
 
-        if (technology.hidden && !technology.enabled) {
+        if (!technology.enabled) {
             using (gui.EnterGroup(contentPadding)) {
-                gui.BuildText("This technology is hidden from the list and cannot be researched.", TextBlockDisplayStyle.WrappedText);
+                gui.BuildText("This technology is disabled and cannot be researched.", TextBlockDisplayStyle.WrappedText);
             }
         }
 

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -25,7 +25,7 @@ public class DependencyExplorer : PseudoScreen {
         {DependencyNode.Flags.TechnologyPrerequisites, ("Research", "There are no technology prerequisites")},
         {DependencyNode.Flags.ItemToPlace, ("Item", "This entity cannot be placed")},
         {DependencyNode.Flags.SourceEntity, ("Source", "This recipe requires another entity")},
-        {DependencyNode.Flags.Hidden, ("", "This technology is hidden")},
+        {DependencyNode.Flags.Disabled, ("", "This technology is disabled")},
         {DependencyNode.Flags.Location, ("Location", "There are no locations that spawn this entity")},
     };
 
@@ -77,10 +77,10 @@ public class DependencyExplorer : PseudoScreen {
             else {
                 string text = dependencyType.missingText;
                 if (Database.rootAccessible.Contains(current)) {
-                    text += ", but it is inherently accessible";
+                    text += ", but it is inherently accessible.";
                 }
                 else {
-                    text += ", and it is inaccessible";
+                    text += ", and it is inaccessible.";
                 }
 
                 gui.BuildText(text, TextBlockDisplayStyle.WrappedText);

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date:
     Fixes:
         - When creating launch recipes, obey the rocket capacity, not the item stack size.
         - Improve detection of special (e.g. barrelling, caging) recipes, especially with SA's recycling recipes.
+        - (regression) Py TURDs and other disabled techs were considered enabled if they were not also hidden.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.7.0
 Date: January 27th 2025


### PR DESCRIPTION
This fixes #400 by ignoring (and removing) the hidden field in technologies. It's still needed on recipes for weight calculations, but not for anything else. (Yet, at least. If implemented, #399 will also use the recipe hidden flag.)

A quick check does not reveal any new issues in Space Age or Omni.