### PR TITLE
Auto saving

### DIFF
--- a/Yafc.Model.Tests/LuaDependentTestHelper.cs
+++ b/Yafc.Model.Tests/LuaDependentTestHelper.cs
@@ -82,7 +82,7 @@ internal static class LuaDependentTestHelper {
             }
             context.Exec(bytes, "*", "");
 
-            project = new FactorioDataDeserializer(new(1, 1)).LoadData(null, context.data, (LuaTable)context.defines["prototypes"]!, false, helper, new(), false);
+            project = new FactorioDataDeserializer(new(1, 1)).LoadData(null, context.data, (LuaTable)context.defines["prototypes"]!, false, helper, new(), false, false);
         }
 
         DataUtils.SetupForProject(project);

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -107,10 +107,11 @@ internal partial class FactorioDataDeserializer {
     /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
     /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
     /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
+    /// <param name="useLatestSave">If <see langword="true"/>, Yafc will try to find the most recent autosave.</param>
     /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties
     /// in <see cref="Database"/>.</returns>
     public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, bool netProduction,
-        IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
+        IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons, bool useLatestSave) {
 
         progress.Report(("Loading", "Loading items"));
         raw = (LuaTable?)data["raw"] ?? throw new ArgumentException("Could not load data.raw from data argument", nameof(data));
@@ -173,7 +174,7 @@ internal partial class FactorioDataDeserializer {
         Dependencies.Calculate();
         TechnologyLoopsFinder.FindTechnologyLoops();
         progress.Report(("Post-processing", "Creating project"));
-        Project project = Project.ReadFromFile(projectPath, errorCollector);
+        Project project = Project.ReadFromFile(projectPath, errorCollector, useLatestSave);
         Analysis.ProcessAnalyses(progress, project, errorCollector);
         progress.Report(("Rendering icons", ""));
         iconRenderedProgress = progress;

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -166,12 +166,13 @@ public static partial class FactorioDataSource {
     /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
     /// <param name="locale">One of the languages supported by Factorio. Typically just the two-letter language code, e.g. en,
     /// but occasionally also includes the region code, e.g. pt-PT.</param>
+    /// <param name="useLatestSave">If <see langword="true"/>, Yafc will try to find the most recent autosave.</param>
     /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
     /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>.
     /// Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
     /// <exception cref="NotSupportedException">Thrown if a mod enabled in mod-list.json could not be found in <paramref name="modPath"/>.</exception>
     public static Project Parse(string factorioPath, string modPath, string projectPath, bool netProduction,
-        IProgress<(string MajorState, string MinorState)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
+        IProgress<(string MajorState, string MinorState)> progress, ErrorCollector errorCollector, string locale, bool useLatestSave, bool renderIcons = true) {
 
         LuaContext? dataContext = null;
 
@@ -357,7 +358,7 @@ public static partial class FactorioDataSource {
             _ = dataContext.Exec(postProcess, "*", "post");
 
             FactorioDataDeserializer deserializer = new FactorioDataDeserializer(factorioVersion ?? defaultFactorioVersion);
-            var project = deserializer.LoadData(projectPath, dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
+            var project = deserializer.LoadData(projectPath, dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons, useLatestSave);
             logger.Information("Completed!");
             progress.Report(("Completed!", ""));
 

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -38,6 +38,8 @@ public abstract class Window : IDisposable {
     public virtual bool preventQuit => false;
     internal Window(Padding padding) => rootGui = new ImGui(Build, padding);
 
+    public event OnFocusLost? onFocusLost;
+
     internal void Create() {
         if (surface is null) {
             throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Create)}.");
@@ -179,7 +181,8 @@ public abstract class Window : IDisposable {
         }
     }
 
-    public virtual void FocusLost() { }
+    public virtual void FocusLost() => onFocusLost?.Invoke();
+
     public virtual void Minimized() { }
 
     public void SetNextRepaint(long nextRepaintTime) {
@@ -263,3 +266,5 @@ public abstract class Window : IDisposable {
         GC.SuppressFinalize(this);
     }
 }
+
+public delegate void OnFocusLost();

--- a/Yafc/Utils/Preferences.cs
+++ b/Yafc/Utils/Preferences.cs
@@ -12,8 +12,6 @@ public class Preferences {
     public static readonly string appDataFolder;
     private static readonly string fileName;
 
-    public static readonly string autosaveFilename;
-
     static Preferences() {
         appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
@@ -24,7 +22,6 @@ public class Preferences {
             _ = Directory.CreateDirectory(appDataFolder);
         }
 
-        autosaveFilename = Path.Combine(appDataFolder, "autosave2.yafc");
         fileName = Path.Combine(appDataFolder, "yafc2.config");
         if (File.Exists(fileName)) {
             try {
@@ -73,6 +70,16 @@ public class Preferences {
     /// An opaque integer that the shopping list uses to store its display options. See the ShoppingListScreen properties that read and write this value.
     /// </summary>
     public int shoppingDisplayState { get; set; } = 3;
+
+    /// <summary>
+    /// When enabled autosave every time the window loses focus.
+    /// </summary>
+    public bool autosaveEnabled { get; set; } = true;
+
+    /// <summary>
+    /// When enabled a newer autosave will always get priority above the manual saved file when loading the project.
+    /// </summary>
+    public bool useMostRecentSave { get; set; } = true;
 
     public void AddProject(string dataPath, string modsPath, string projectPath, bool netProduction) {
         recentProjects = [.. recentProjects.Where(x => string.Compare(projectPath, x.path, StringComparison.InvariantCultureIgnoreCase) != 0)

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -60,6 +60,12 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         Create("Yet Another Factorio Calculator CE v" + YafcLib.version.ToString(3), display, Preferences.Instance.initialMainScreenWidth,
             Preferences.Instance.initialMainScreenHeight, Preferences.Instance.maximizeMainScreen);
         SetProject(project);
+
+        onFocusLost += () => {
+            if (Preferences.Instance.autosaveEnabled) {
+                project.PerformAutoSave();
+            }
+        };
     }
 
     [MemberNotNull(nameof(project))]
@@ -667,7 +673,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
 
         ErrorCollector errors = new ErrorCollector();
         try {
-            Project project = Project.ReadFromFile(path, errors);
+            Project project = Project.ReadFromFile(path, errors, Preferences.Instance.useMostRecentSave);
             Analysis.ProcessAnalyses(this, project, errors);
             SetProject(project);
         }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -208,6 +208,10 @@ public class PreferencesScreen : PseudoScreen {
             Preferences.Instance.Save();
             RenderingUtils.SetColorScheme(newValue);
         }
+
+        if (gui.BuildCheckBox("Enable autosave (Saves when the window loses focus)", Preferences.Instance.autosaveEnabled, out newValue)) {
+            Preferences.Instance.autosaveEnabled = newValue;
+        }
     }
 
     protected override void ReturnPressed() => Close();

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -34,6 +34,7 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
     private string? errorMessage;
     private string? tip;
     private readonly string[] tips;
+    private bool useMostRecentSave = true;
 
     private static readonly Dictionary<string, string> languageMapping = new Dictionary<string, string>()
     {
@@ -168,6 +169,14 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
                 }
 
                 gui.BuildText("In-game objects language:");
+            }
+
+            using (gui.EnterRowWithHelpIcon("""When enabled it will try to find a more recent autosave. Disable if you want to load your manual save only.""", false)) {
+                if (gui.BuildCheckBox("Load most recent (auto-)save", Preferences.Instance.useMostRecentSave,
+                        out useMostRecentSave)) {
+                    Preferences.Instance.useMostRecentSave = useMostRecentSave;
+                    Preferences.Instance.Save();
+                }
             }
 
             using (gui.EnterRowWithHelpIcon("""
@@ -393,7 +402,7 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
             await Ui.ExitMainThread();
 
             ErrorCollector collector = new ErrorCollector();
-            var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, netProduction, this, collector, Preferences.Instance.language);
+            var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, netProduction, this, collector, Preferences.Instance.language, Preferences.Instance.useMostRecentSave);
 
             await Ui.EnterMainThread();
             logger.Information("Opening main screen");

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
         - Open the preferences or milestones when you click on the icon for the reactor or quality warning messages.
+        - Implemented Auto Save.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.10.0
 Date: March 5th 2025


### PR DESCRIPTION
This is a continuation of the discussion in the draft PR [here](https://github.com/shpaass/yafc-ce/pull/41)
This fixes issue [22](https://github.com/shpaass/yafc-ce/issues/22)

How it works:
- There is a new setting to enable/disable autosaves (it is enabled by default) 
![afbeelding](https://github.com/user-attachments/assets/f460dc18-6c0e-4059-88f2-adcbd28bfb43)
- When the focus on the YAFC window is lost an autosave is made (only when there anything got changed)
- It uses a rolling window of 5 saves to keep a small history.

When loading a project there is a new setting:
![afbeelding](https://github.com/user-attachments/assets/0169c866-901c-491a-86e2-989bef65d16a)
When disabled it will just load the save you selected (whether it is your main save or an autosave doesn't matter), when it is enabled it will try to find the most recent save you have.
![afbeelding](https://github.com/user-attachments/assets/cc7e9f92-36c4-4557-8a4f-7d1d49f23cd5)
In the case above autosave-1.yafc would be loaded eventhough the user selected "project-yafc".

When manually saving you will always save the 'main' file (project.yafc in the above case), this because autosaves get overwritten real fast, so when you would open an auto-save and forget to change the save path you would quickly lose that manual save.

There is one 'edge' case in which the user manually changes the filename of the autosave, but this wont break anything.

Let me know what you guys think, if everyone agrees that this is a solid solution then I will add some tests.
