### PR TITLE
Link summary related

### DIFF
--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -205,7 +205,7 @@ match:
     /// </summary>
     /// <param name="skip">Filter out all these recipes and do not step into their childeren.</param>
     public IEnumerable<RecipeRow> GetAllRecipes(ProductionTable? skip = null) => this == skip ? [] : recipes
-        .SelectMany<RecipeRow, RecipeRow>(row => [row, ..row?.subgroup?.GetAllRecipes(skip) ?? []]);
+        .SelectMany<RecipeRow, RecipeRow>(row => [row, .. row?.subgroup?.GetAllRecipes(skip) ?? []]);
 
     private static void AddFlow(RecipeRow recipe, Dictionary<IObjectWithQuality<Goods>, (double prod, double cons)> summer) {
         foreach (var product in recipe.Products) {

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -203,21 +203,9 @@ match:
     /// <summary>
     /// Get all <see cref="RecipeRow"/>s contained in this <see cref="ProductionTable"/>, in a depth-first ordering. (The same as in the UI when all nested tables are expanded.)
     /// </summary>
-    public IEnumerable<RecipeRow> GetAllRecipes() {
-        return flatten(recipes);
-
-        static IEnumerable<RecipeRow> flatten(IEnumerable<RecipeRow> rows) {
-            foreach (var row in rows) {
-                yield return row;
-
-                if (row.subgroup is not null) {
-                    foreach (var row2 in flatten(row.subgroup.GetAllRecipes())) {
-                        yield return row2;
-                    }
-                }
-            }
-        }
-    }
+    /// <param name="skip">Filter out all these recipes and do not step into their childeren.</param>
+    public IEnumerable<RecipeRow> GetAllRecipes(ProductionTable? skip = null) => this == skip ? [] : recipes
+        .SelectMany<RecipeRow, RecipeRow>(row => [row, ..row?.subgroup?.GetAllRecipes(skip) ?? []]);
 
     private static void AddFlow(RecipeRow recipe, Dictionary<IObjectWithQuality<Goods>, (double prod, double cons)> summer) {
         foreach (var product in recipe.Products) {

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -81,20 +81,21 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
                 table.Add((row, localFlow));
             }
             var color = 1;
+            gui.spacing = 0.75f;
             if (childLinks.Values.Any(e => e.Any())) {
-                gui.BuildText("Child links: ", Font.subheader);
+                gui.BuildText("Child links: ", Font.productionTableHeader);
                 foreach (var relTable in childLinks.Values) {
                     BuildFlow(gui, relTable, relTable.Sum(e => Math.Abs(e.flow)), false, color++);
                 }
             }
             if (parentLinks.Values.Any(e => e.Any())) {
-                gui.BuildText("Parent links: ", Font.subheader);
+                gui.BuildText("Parent links: ", Font.productionTableHeader);
                 foreach (var relTable in parentLinks.Values) {
                     BuildFlow(gui, relTable, relTable.Sum(e => Math.Abs(e.flow)), false, color++);
                 }
             }
             if (otherLinks.Values.Any(e => e.Any())) {
-                gui.BuildText("Unrelated links: ", Font.subheader);
+                gui.BuildText("Unrelated links: ", Font.productionTableHeader);
                 foreach (var relTable in otherLinks.Values) {
                     BuildFlow(gui, relTable, relTable.Sum(e => Math.Abs(e.flow)), false, color++);
                 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Features:
+        - Add related recipes to the Link Summary screen.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.8.1
 Date: February 20th 2025
     Fixes:


### PR DESCRIPTION
A list of nice-to-have things:
* [x] A changelog 
* [ ] The link from the PR to the issue that it fixes. -> Not a direct fix, but this is work towards better link visualization to aid #409, #414
* [x] A description of what testing was done.
I clicked around on the new unrelated links and you navigate to new links from there.

As a followup to #408 this is an implementation of #414 (Only the visualization part):

![afbeelding](https://github.com/user-attachments/assets/bef76af3-ded1-4f2c-b290-dca8d76346f2)

As seen above, the link summary now not only display the currently selected link, but also recipes from other links covering the same recipe. It also tells you where in the recipe tree those links are, parent means they're in the same branch but higher up, child means the same but lower, unrelated is any other recipe.

There are a few more unimplemented ideas in #414 to add buttons to manipulate the other recipes, those can be tackled later.

![afbeelding](https://github.com/user-attachments/assets/2a2b592b-b68a-4b8a-b26e-667113464c79)
