### PR TITLE
Quality recipes

### DIFF
--- a/Docs/CodeStyle.md
+++ b/Docs/CodeStyle.md
@@ -75,3 +75,22 @@ Most of the operators like `.` `+` `&&` go to the next line.
 The notable operators that stay on the same line are `=>`, `=> {`, and `,`.
 
 The wrapping of arguments in constructors and method-definitions is up to you.
+
+# Quality Implementation
+Despite several attempts, the implementation of quality levels is unpleasantly twisted.
+Here are some guidelines to keep handling of quality levels from causing additional problems:
+* **Serialization**
+  * All serialized values (public properties of `ModelObject`s and `[Serializable]` classes) must be a suitable concrete type.
+  (That is, `ObjectWithQuality<T>`, not `IObjectWithQuality<T>`)
+* **Equality**
+  * Where `==` operators are expected/used, prefer the concrete type.
+  The `==` operator will silently revert to reference equality if both sides of are the interface type.
+  * On the other hand, the `==` operator will fail to compile if the two sides are distinct concrete types.
+  Use `.As<type>()` to convert one side to the interface type.
+  * Types that call `Object.Equals`, such as `Dictionary` and `HashSet`, will behave correctly on both the interface and concrete types.
+  The interface type may be more convenient for things like dictionary keys or hashset values.
+* **Conversion**
+  * There is a conversion from `(T?, Quality)` to `ObjectWithQuality<T>?`, where a null input will return a null result.
+  If the input is definitely not null, use the constructor instead.
+  C# prohibits conversions to or from interface types.
+  * The interface types are covariant; an `IObjectWithQuality<Item>` may be used as an `IObjectWithQuality<Goods>` in the same way that an `Item` may be used as a `Goods`.

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -14,7 +14,7 @@ public class ProductionTableContentTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         table.modules.beacon = new(Database.allBeacons.Single(), Quality.Normal);
@@ -31,7 +31,7 @@ public class ProductionTableContentTests {
                 row.entity = new(crafter, Quality.Normal);
 
                 foreach (Goods fuel in crafter.energy.fuels) {
-                    row.fuel = fuel;
+                    row.fuel = (fuel, Quality.Normal);
 
                     foreach (Module module in Database.allModules.Concat([null])) {
                         ModuleTemplateBuilder builder = new();
@@ -58,7 +58,7 @@ public class ProductionTableContentTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         List<Module> modules = [.. Database.allModules.Where(m => !m.name.Contains("productivity"))];
@@ -73,7 +73,7 @@ public class ProductionTableContentTests {
                 row.entity = new(crafter, Quality.Normal);
 
                 foreach (Goods fuel in crafter.energy.fuels) {
-                    row.fuel = fuel;
+                    row.fuel = (fuel, Quality.Normal);
 
                     foreach (Module module in modules) {
                         for (int beaconCount = 0; beaconCount < 13; beaconCount++) {
@@ -117,7 +117,7 @@ public class ProductionTableContentTests {
 
         // Ensure that the fuel consumption remains constant, except when the entity and fuel change simultaneously.
         row.fixedFuel = true;
-        (Goods oldFuel, float fuelAmount, _, _) = row.FuelInformation;
+        ((Goods oldFuel, _), float fuelAmount, _, _) = row.FuelInformation;
         testCombinations(row, table, testFuel(row, table));
         row.fixedFuel = false;
 
@@ -149,7 +149,7 @@ public class ProductionTableContentTests {
                 row.fixedBuildings = 1;
                 row.fixedFuel = true;
                 table.Solve((ProjectPage)table.owner).Wait();
-                (oldFuel, fuelAmount, _, _) = row.FuelInformation;
+                ((oldFuel, _), fuelAmount, _, _) = row.FuelInformation;
                 assertCalls++;
             }
         };

--- a/Yafc.Model.Tests/Model/ProductionTableTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.cs
@@ -30,7 +30,7 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
 
         ErrorCollector collector = new();
         using MemoryStream stream = new();
@@ -48,7 +48,7 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
         row.subgroup = new ProductionTable(row);
 
@@ -68,10 +68,10 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
         row.subgroup = new ProductionTable(row);
-        row.subgroup.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        row.subgroup.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
 
         ErrorCollector collector = new();
         using MemoryStream stream = new();
@@ -121,7 +121,7 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
         row.subgroup = new ProductionTable(row);
 

--- a/Yafc.Model.Tests/Model/RecipeParametersTests.cs
+++ b/Yafc.Model.Tests/Model/RecipeParametersTests.cs
@@ -14,8 +14,8 @@ public class RecipeParametersTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "boiler.boiler.steam"), DataUtils.DeterministicComparer);
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "boiler.heat-exchanger.steam"), DataUtils.DeterministicComparer);
+        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "boiler.boiler.steam"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "boiler.heat-exchanger.steam"), Quality.Normal), DataUtils.DeterministicComparer);
 
         List<Fluid> water = Database.fluidVariants["Fluid.water"];
 
@@ -30,8 +30,8 @@ public class RecipeParametersTests {
                 // boiler has changed in 2.0 and doesn't work yet
                 continue;
             }
-            boiler.ChangeVariant(boiler.Ingredients.Single().Goods, water[i]);
-            heatExchanger.ChangeVariant(boiler.Ingredients.Single().Goods, water[i]);
+            boiler.ChangeVariant(boiler.Ingredients.Single().Goods.target, water[i]);
+            heatExchanger.ChangeVariant(boiler.Ingredients.Single().Goods.target, water[i]);
 
             await table.Solve((ProjectPage)table.owner);
 

--- a/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
+++ b/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
@@ -12,16 +12,16 @@ public class SelectableVariantsTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "generator.electricity"), DataUtils.DeterministicComparer);
+        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "generator.electricity"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         // Solve is not necessary in this test, but I'm calling it in case we decide to hide the fuel on disabled recipes.
         await table.Solve((ProjectPage)table.owner);
-        Assert.Equal("steam@165", row.FuelInformation.Goods.name);
+        Assert.Equal("steam@165", row.FuelInformation.Goods.target.name);
 
-        row.fuel = row.FuelInformation.Variants[1];
+        row.fuel = row.FuelInformation.Variants[1].With(Quality.Normal);
         await table.Solve((ProjectPage)table.owner);
-        Assert.Equal("steam@500", row.FuelInformation.Goods.name);
+        Assert.Equal("steam@500", row.FuelInformation.Goods.target.name);
     }
 
     [Fact]
@@ -31,16 +31,16 @@ public class SelectableVariantsTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "generator.electricity"), DataUtils.DeterministicComparer);
+        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "generator.electricity"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         // Solve is not necessary in this test, but I'm calling it in case we decide to hide the fuel on disabled recipes.
         await table.Solve((ProjectPage)table.owner);
-        Assert.Equal("steam@500", row.FuelInformation.Goods.name);
+        Assert.Equal("steam@500", row.FuelInformation.Goods.target.name);
 
-        row.fuel = row.FuelInformation.Variants[0];
+        row.fuel = row.FuelInformation.Variants[0].With(Quality.Normal);
         await table.Solve((ProjectPage)table.owner);
-        Assert.Equal("steam@165", row.FuelInformation.Goods.name);
+        Assert.Equal("steam@165", row.FuelInformation.Goods.target.name);
     }
 
     [Fact]
@@ -49,16 +49,16 @@ public class SelectableVariantsTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(Database.recipes.all.Single(r => r.name == "steam_void"), DataUtils.DeterministicComparer);
+        table.AddRecipe((Database.recipes.all.Single(r => r.name == "steam_void"), Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         // Solve is necessary here: Disabled recipes have null ingredients (and products), and Solve is the call that updates hierarchyEnabled.
         await table.Solve((ProjectPage)table.owner);
-        Assert.Equal("steam@165", row.Ingredients.Single().Goods.name);
+        Assert.Equal("steam@165", row.Ingredients.Single().Goods.target.name);
 
-        row.ChangeVariant(row.Ingredients.Single().Goods, row.Ingredients.Single().Variants[1]);
+        row.ChangeVariant(row.Ingredients.Single().Goods.target, row.Ingredients.Single().Variants[1]);
         await table.Solve((ProjectPage)table.owner);
-        Assert.Equal("steam@500", row.Ingredients.Single().Goods.name);
+        Assert.Equal("steam@500", row.Ingredients.Single().Goods.target.name);
     }
 
     // No corresponding CanSelectVariantIngredientWithFavorites: Favorites control fuel selection, but not ingredient selection.

--- a/Yafc.Model/Analysis/AutomationAnalysis.cs
+++ b/Yafc.Model/Analysis/AutomationAnalysis.cs
@@ -20,7 +20,7 @@ public class AutomationAnalysis : Analysis {
     public override void Compute(Project project, ErrorCollector warnings) {
         Stopwatch time = Stopwatch.StartNew();
         var state = Database.objects.CreateMapping<AutomationStatus>();
-        state[Database.voidEnergy] = AutomationStatus.AutomatableNow;
+        state[Database.voidEnergy.target] = AutomationStatus.AutomatableNow;
         Queue<FactorioId> processingQueue = new Queue<FactorioId>(Database.objects.count);
         int unknowns = 0;
 
@@ -77,7 +77,7 @@ public class AutomationAnalysis : Analysis {
                 }
             }
         }
-        state[Database.voidEnergy] = AutomationStatus.NotAutomatable;
+        state[Database.voidEnergy.target] = AutomationStatus.NotAutomatable;
 
         logger.Information("Automation analysis (first pass) finished in {ElapsedTime}ms. Unknowns left: {unknownsRemaining}", time.ElapsedMilliseconds, unknowns);
         if (unknowns > 0) {

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -180,7 +180,7 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
             float sizeUsage = CostPerSecond * recipe.time * size;
             float logisticsCost = (sizeUsage * (1f + (CostPerIngredientPerSize * recipe.ingredients.Length) + (CostPerProductPerSize * recipe.products.Length))) + (CostPerMj * minPower);
 
-            if (singleUsedFuel == Database.electricity || singleUsedFuel == Database.voidEnergy || singleUsedFuel == Database.heat) {
+            if (singleUsedFuel == Database.electricity.target || singleUsedFuel == Database.voidEnergy.target || singleUsedFuel == Database.heat.target) {
                 singleUsedFuel = null;
             }
 

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -77,19 +77,21 @@ public class BlueprintIcon {
 public class BlueprintSignal {
     public string? name { get; set; }
     public string? type { get; set; }
+    public string? quality { get; set; }
 
-    public void Set(Goods goods) {
-        if (goods is Special sp) {
+    public void Set(IObjectWithQuality<Goods> goods) {
+        if (goods.target is Special sp) {
             type = "virtual";
             name = sp.virtualSignal;
         }
-        else if (goods is Fluid fluid) {
+        else if (goods.target is Fluid fluid) {
             type = "fluid";
             name = fluid.originalName;
         }
         else {
             type = "item";
-            name = goods.name;
+            name = goods.target.name;
+            quality = goods.quality.name;
         }
     }
 }
@@ -102,6 +104,7 @@ public class BlueprintEntity {
     public BlueprintPosition position { get; set; } = new BlueprintPosition();
     public int direction { get; set; }
     public string? recipe { get; set; }
+    public string? recipe_quality { get; set; }
     [JsonPropertyName("control_behavior")] public BlueprintControlBehavior? controlBehavior { get; set; }
     public BlueprintConnection? connections { get; set; }
     [JsonPropertyName("request_filters")] public List<BlueprintRequestFilter> requestFilters { get; } = [];
@@ -130,6 +133,7 @@ public class BlueprintEntity {
 [Serializable]
 public class BlueprintRequestFilter {
     public string? name { get; set; }
+    public string? quality { get; set; }
     public int index { get; set; }
     public int count { get; set; }
 }

--- a/Yafc.Model/Blueprints/BlueprintUtilities.cs
+++ b/Yafc.Model/Blueprints/BlueprintUtilities.cs
@@ -16,7 +16,7 @@ public static class BlueprintUtilities {
         return result;
     }
 
-    public static string ExportConstantCombinators(string name, IReadOnlyList<(Goods item, int amount)> goods, bool copyToClipboard = true) {
+    public static string ExportConstantCombinators(string name, IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods, bool copyToClipboard = true) {
         int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
         int offset = -combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
@@ -49,7 +49,7 @@ public static class BlueprintUtilities {
         return ExportBlueprint(blueprint, copyToClipboard);
     }
 
-    public static string ExportRequesterChests(string name, IReadOnlyList<(Item item, int amount)> goods, EntityContainer chest, bool copyToClipboard = true) {
+    public static string ExportRequesterChests(string name, IReadOnlyList<(IObjectWithQuality<Item> item, int amount)> goods, EntityContainer chest, bool copyToClipboard = true) {
         if (chest.logisticSlotsCount <= 0) {
             throw new NotSupportedException("Chest does not have logistic slots");
         }
@@ -65,7 +65,7 @@ public static class BlueprintUtilities {
 
             for (int j = 0; j < chest.logisticSlotsCount; j++) {
                 var (item, amount) = goods[index++];
-                BlueprintRequestFilter filter = new BlueprintRequestFilter { index = j + 1, count = amount, name = item.name };
+                BlueprintRequestFilter filter = new BlueprintRequestFilter { index = j + 1, count = amount, name = item.target.name, quality = item.quality.name };
                 entity.requestFilters.Add(filter);
 
                 if (index >= goods.Count) {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -866,12 +866,12 @@ public sealed class ObjectWithQuality<T>(T target, Quality quality) : IObjectWit
     public bool Equals(IObjectWithQuality<FactorioObject>? other) => other is not null && target == other.target && quality == other.quality;
     public override int GetHashCode() => HashCode.Combine(target, quality);
 
-    public static bool operator ==(ObjectWithQuality<T>? left, ObjectWithQuality<T>? right) => left == (IObjectWithQuality<T>?)right;
-    public static bool operator ==(ObjectWithQuality<T>? left, IObjectWithQuality<T>? right) => (left is null && right is null) || (left is not null && left.Equals(right));
-    public static bool operator ==(IObjectWithQuality<T>? left, ObjectWithQuality<T>? right) => right == left;
+    public static bool operator ==(ObjectWithQuality<T>? left, ObjectWithQuality<T>? right) => left == (IObjectWithQuality<FactorioObject>?)right;
+    public static bool operator ==(ObjectWithQuality<T>? left, IObjectWithQuality<FactorioObject>? right) => (left is null && right is null) || (left is not null && left.Equals(right));
+    public static bool operator ==(IObjectWithQuality<FactorioObject>? left, ObjectWithQuality<T>? right) => right == left;
     public static bool operator !=(ObjectWithQuality<T>? left, ObjectWithQuality<T>? right) => !(left == right);
-    public static bool operator !=(ObjectWithQuality<T>? left, IObjectWithQuality<T>? right) => !(left == right);
-    public static bool operator !=(IObjectWithQuality<T>? left, ObjectWithQuality<T>? right) => !(left == right);
+    public static bool operator !=(ObjectWithQuality<T>? left, IObjectWithQuality<FactorioObject>? right) => !(left == right);
+    public static bool operator !=(IObjectWithQuality<FactorioObject>? left, ObjectWithQuality<T>? right) => !(left == right);
 }
 
 public class Effect {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -163,7 +163,6 @@ public abstract class RecipeOrTechnology : FactorioObject {
         return true;
     }
 
-    public bool CanAcceptModule(ObjectWithQuality<Module> module) => CanAcceptModule(module.target);
     public virtual bool CanAcceptModule(Module _) => true;
 }
 
@@ -424,7 +423,7 @@ public class Item : Goods {
     }
 
     public override DependencyNode GetDependencies() {
-        if (this == Database.science) {
+        if (this == Database.science.target) {
             return (Database.technologies.all, DependencyNode.Flags.Source);
         }
         return base.GetDependencies();
@@ -803,14 +802,6 @@ public interface IObjectWithQuality<out T> : IFactorioObjectWrapper where T : Fa
     Quality quality { get; }
 }
 
-public static class ObjectWithQualityExtensions {
-    // This method cannot be declared on the interface.
-    public static void Deconstruct<T>(this IObjectWithQuality<T> value, out T obj, out Quality quality) where T : FactorioObject {
-        obj = value.target;
-        quality = value.quality;
-    }
-}
-
 /// <summary>
 /// Represents a <see cref="FactorioObject"/> with an attached <see cref="Quality"/> modifier.
 /// </summary>
@@ -830,7 +821,8 @@ public sealed class ObjectWithQuality<T>(T target, Quality quality) : IObjectWit
         Fluid or Location or Mechanics { source: Entity } or Quality or Special or Technology or Tile => Quality.Normal,
         Recipe r when r.ingredients.All(i => i.goods is Fluid) => Quality.Normal,
         // Everything else supports quality (except science):
-        _ => target == Database.science ? Quality.Normal : quality
+        // null-checking: Database.science is null when constructing the object that is stored in Database.science.
+        _ => target == Database.science?.target ? Quality.Normal : quality
     };
 
     /// <summary>

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -823,7 +823,15 @@ public sealed class ObjectWithQuality<T>(T target, Quality quality) : IObjectWit
     /// <inheritdoc/>
     public T target { get; } = target ?? throw new ArgumentNullException(nameof(target));
     /// <inheritdoc/>
-    public Quality quality { get; } = quality ?? throw new ArgumentNullException(nameof(quality));
+    public Quality quality { get; } = CheckQuality(target, quality ?? throw new ArgumentNullException(nameof(quality)));
+
+    private static Quality CheckQuality(T target, Quality quality) => target switch {
+        // Things that don't support quality:
+        Fluid or Location or Mechanics { source: Entity } or Quality or Special or Technology or Tile => Quality.Normal,
+        Recipe r when r.ingredients.All(i => i.goods is Fluid) => Quality.Normal,
+        // Everything else supports quality (except science):
+        _ => target == Database.science ? Quality.Normal : quality
+    };
 
     /// <summary>
     /// Creates a new <see cref="ObjectWithQuality{T}"/> with the current <see cref="target"/> and the specified <see cref="Quality"/>.

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -785,6 +785,7 @@ public sealed class Quality : FactorioObject {
     public float AccumulatorCapacityBonus => level;
     public float BeaconTransmissionBonus => .2f * level;
     public float BeaconConsumptionFactor { get; internal set; }
+    public float UpgradeChance { get; internal set; }
 }
 
 /// <summary>

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -785,6 +785,11 @@ public sealed class Quality : FactorioObject {
     public float BeaconTransmissionBonus => .2f * level;
     public float BeaconConsumptionFactor { get; internal set; }
     public float UpgradeChance { get; internal set; }
+
+    public static bool operator <(Quality left, Quality right) => left.level < right.level;
+    public static bool operator >(Quality left, Quality right) => left.level > right.level;
+    public static bool operator <=(Quality left, Quality right) => left.level <= right.level;
+    public static bool operator >=(Quality left, Quality right) => left.level >= right.level;
 }
 
 /// <summary>

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -383,7 +383,7 @@ public static partial class DataUtils {
         float amount = 0f;
 
         foreach (var i in row.recipe.target.ingredients) {
-            if (i.ContainsVariant(ingredient.target)) {
+            if (i.goods.With(row.recipe.quality) == ingredient || (ingredient.quality == Quality.Normal && i.ContainsVariant(ingredient.target))) {
                 amount += i.amount * (float)row.recipesPerSecond;
             }
         }

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -357,12 +357,12 @@ public static partial class DataUtils {
         return amount;
     }
 
-    public static float GetProductionForRow(this RecipeRow row, Goods product) {
+    public static float GetProductionForRow(this RecipeRow row, IObjectWithQuality<Goods> product) {
         float amount = 0f;
 
-        foreach (var p in row.recipe.products) {
-            if (p.goods == product) {
-                amount += p.GetAmountForRow(row);
+        foreach (var p in row.Products) {
+            if (p.Goods == product) {
+                amount += p.Amount;
             }
         }
         return amount;
@@ -379,11 +379,11 @@ public static partial class DataUtils {
         return amount;
     }
 
-    public static float GetConsumptionForRow(this RecipeRow row, Goods ingredient) {
+    public static float GetConsumptionForRow(this RecipeRow row, IObjectWithQuality<Goods> ingredient) {
         float amount = 0f;
 
-        foreach (var i in row.recipe.ingredients) {
-            if (i.ContainsVariant(ingredient)) {
+        foreach (var i in row.recipe.target.ingredients) {
+            if (i.ContainsVariant(ingredient.target)) {
                 amount += i.amount * (float)row.recipesPerSecond;
             }
         }
@@ -736,6 +736,7 @@ public static partial class DataUtils {
         return str;
     }
 
+    public static bool Match(this IObjectWithQuality<FactorioObject>? obj, SearchQuery query) => (obj?.target).Match(query);
     public static bool Match(this FactorioObject? obj, SearchQuery query) {
         if (query.empty) {
             return true;

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -12,13 +12,13 @@ public static class Database {
     public static Item[] allSciencePacks { get; internal set; } = null!;
     public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
     public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
-    public static Goods voidEnergy { get; internal set; } = null!;
-    public static Goods science { get; internal set; } = null!;
-    public static Goods itemInput { get; internal set; } = null!;
-    public static Goods itemOutput { get; internal set; } = null!;
-    public static Goods electricity { get; internal set; } = null!;
-    public static Recipe electricityGeneration { get; internal set; } = null!;
-    public static Goods heat { get; internal set; } = null!;
+    public static ObjectWithQuality<Goods> voidEnergy { get; internal set; } = null!;
+    public static ObjectWithQuality<Item> science { get; internal set; } = null!;
+    public static ObjectWithQuality<Goods> itemInput { get; internal set; } = null!;
+    public static ObjectWithQuality<Goods> itemOutput { get; internal set; } = null!;
+    public static ObjectWithQuality<Special> electricity { get; internal set; } = null!;
+    public static ObjectWithQuality<Recipe> electricityGeneration { get; internal set; } = null!;
+    public static ObjectWithQuality<Special> heat { get; internal set; } = null!;
     public static Entity? character { get; internal set; }
     public static EntityCrafter[] allCrafters { get; internal set; } = null!;
     public static Module[] allModules { get; internal set; } = null!;

--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -127,9 +127,9 @@ public class ModuleFillerParameters : ModelObject<ModelObject> {
 
         Quality quality = Quality.MaxAccessible;
 
-        RecipeOrTechnology recipe = row.recipe;
+        ObjectWithQuality<RecipeOrTechnology> recipe = row.recipe;
 
-        if (autoFillPayback > 0 && (fillMiners || !recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity))) {
+        if (autoFillPayback > 0 && (fillMiners || !recipe.target.flags.HasFlags(RecipeFlags.UsesMiningProductivity))) {
             /*
                 Auto Fill Calculation
                 The goal is to find the best module to fill the building with, based on the economy (cost per second) of the configuration.
@@ -152,9 +152,9 @@ public class ModuleFillerParameters : ModelObject<ModelObject> {
             */
 
 
-            float productivityEconomy = recipe.Cost() / partialParams.recipeTime;
+            float productivityEconomy = recipe.target.Cost() / partialParams.recipeTime;
             float speedEconomy = Math.Max(0.0001f, entity.Cost()) / autoFillPayback;
-            float effectivityEconomy = partialParams.fuelUsagePerSecondPerBuilding * row.fuel?.Cost() ?? 0f;
+            float effectivityEconomy = partialParams.fuelUsagePerSecondPerBuilding * row.fuel?.target.Cost() ?? 0f;
 
             if (effectivityEconomy < 0f) {
                 effectivityEconomy = 0f;
@@ -164,7 +164,7 @@ public class ModuleFillerParameters : ModelObject<ModelObject> {
             ObjectWithQuality<Module>? usedModule = null;
 
             foreach (var module in Database.allModules) {
-                if (module.IsAccessibleWithCurrentMilestones() && entity.CanAcceptModule(module.moduleSpecification) && recipe.CanAcceptModule(module)) {
+                if (module.IsAccessibleWithCurrentMilestones() && entity.CanAcceptModule(module.moduleSpecification) && recipe.target.CanAcceptModule(module)) {
                     float economy = module.moduleSpecification.Productivity(quality) * productivityEconomy
                                   + module.moduleSpecification.Speed(quality) * speedEconomy
                                   - module.moduleSpecification.Consumption(quality) * effectivityEconomy;
@@ -194,7 +194,7 @@ public class ModuleFillerParameters : ModelObject<ModelObject> {
     }
 
     internal void GetModulesInfo((float recipeTime, float fuelUsagePerSecondPerBuilding) partialParams, RecipeRow row, EntityCrafter entity, ref ModuleEffects effects, ref UsedModule used) {
-        AutoFillBeacons(row.recipe, entity, ref effects, ref used);
+        AutoFillBeacons(row.recipe.target, entity, ref effects, ref used);
         AutoFillModules(partialParams, row, entity, ref effects, ref used);
     }
 

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -359,25 +359,25 @@ match:
             var recipeVar = vars[i];
             var links = recipe.links;
 
-            for (int j = 0; j < recipe.recipe.target.products.Length; j++) {
-                var product = recipe.recipe.target.products[j];
-
-                if (product.amount <= 0f) {
+            foreach (var product in recipe.ProductsForSolver) {
+                if (product.Amount <= 0f) {
                     continue;
                 }
 
-                if (recipe.FindLink(new ObjectWithQuality<Goods>(product.goods, recipe.recipe.quality), out var link)) {
+                int j = Array.FindIndex(recipe.recipe.target.products, p => p.goods == product.Goods!.target);
+
+                if (recipe.FindLink(product.Goods!, out var link)) {
                     link.flags |= ProductionLink.Flags.HasProduction;
-                    float added = product.GetAmountPerRecipe(recipe.parameters.productivity);
+                    float added = product.Amount;
                     AddLinkCoefficient(constraints[link.solverIndex], recipeVar, link, recipe, added);
-                    float cost = product.goods.Cost();
+                    float cost = product.Goods!.target.Cost();
 
                     if (cost > 0f) {
                         objCoefficients[i] += added * cost;
                     }
                 }
 
-                links.products[j] = link;
+                links.products[j, product.Goods!.quality] = link;
             }
 
             for (int j = 0; j < recipe.recipe.target.ingredients.Length; j++) {
@@ -414,8 +414,6 @@ match:
                     }
                 }
             }
-
-            recipe.links = links;
         }
 
         foreach (var link in allLinks) {

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -11,8 +11,11 @@ public struct ModuleEffects {
     public float speed;
     public float productivity;
     public float consumption;
+    public float quality;
+
     public readonly float speedMod => MathF.Max(1f + speed, 0.2f);
     public readonly float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
+    public readonly float qualityMod => MathF.Max(quality, 0);
     public void AddModules(ObjectWithQuality<Module> module, float count, AllowedEffects allowedEffects) {
         ModuleSpecification spec = module.target.moduleSpecification;
         Quality quality = module.quality;
@@ -27,6 +30,10 @@ public struct ModuleEffects {
         if (allowedEffects.HasFlags(AllowedEffects.Consumption)) {
             consumption += spec.Consumption(quality) * count;
         }
+
+        if (allowedEffects.HasFlags(AllowedEffects.Quality)) {
+            this.quality += spec.Consumption(quality) * count;
+        }
     }
 
     public void AddModules(ObjectWithQuality<Module> module, float count) {
@@ -39,6 +46,7 @@ public struct ModuleEffects {
         }
 
         consumption += spec.Consumption(quality) * count;
+        this.quality += spec.Quality(quality) * count;
     }
 
     public readonly int GetModuleSoftLimit(ObjectWithQuality<Module> module, int hardLimit) {

--- a/Yafc.Model/Model/QualityExtensions.cs
+++ b/Yafc.Model/Model/QualityExtensions.cs
@@ -3,6 +3,12 @@
 namespace Yafc.Model;
 
 public static class QualityExtensions {
+    // This method cannot be declared on the interface.
+    public static void Deconstruct<T>(this IObjectWithQuality<T> value, out T obj, out Quality quality) where T : FactorioObject {
+        obj = value.target;
+        quality = value.quality;
+    }
+
     public static float GetCraftingSpeed(this IObjectWithQuality<EntityCrafter> crafter) => crafter.target.CraftingSpeed(crafter.quality);
 
     public static float GetPower(this IObjectWithQuality<Entity> entity) => entity.target.Power(entity.quality);
@@ -15,6 +21,26 @@ public static class QualityExtensions {
     public static float StormPotentialPerTick(this IObjectWithQuality<EntityAttractor> attractor)
         => attractor.target.StormPotentialPerTick(attractor.quality);
 
+    public static bool IsSourceResource(this IObjectWithQuality<Goods>? goods) => (goods?.target).IsSourceResource();
+    /// <summary>
+    /// Gets the string <c>target.name + "@" + quality.name</c>.
+    /// </summary>
+    public static string QualityName(this IObjectWithQuality<FactorioObject> obj) => obj.target.name + "@" + obj.quality.name;
+
+    public static IObjectWithQuality<Goods>? mainProduct(this IObjectWithQuality<RecipeOrTechnology> recipe) =>
+        (ObjectWithQuality<Goods>?)(recipe.target.mainProduct, recipe.quality);
+
+    public static bool CanAcceptModule(this IObjectWithQuality<RecipeOrTechnology> recipe, Module module) =>
+        recipe.target.CanAcceptModule(module);
+    public static bool CanAcceptModule(this IObjectWithQuality<RecipeOrTechnology> recipe, IObjectWithQuality<Module> module) =>
+        recipe.target.CanAcceptModule(module.target);
+
+    public static IObjectWithQuality<Item>? FuelResult(this IObjectWithQuality<Goods>? goods) =>
+        (goods?.target as Item)?.fuelResult.With(goods!.quality); // null-forgiving: With is not called if goods is null.
+
+    [return: NotNullIfNotNull(nameof(obj))]
+    public static ObjectWithQuality<T>? With<T>(this T? obj, Quality quality) where T : FactorioObject => (obj, quality);
+
     /// <summary>
     /// If possible, converts an <see cref="IObjectWithQuality{T}"/> into one with a different generic parameter.
     /// </summary>
@@ -24,12 +50,31 @@ public static class QualityExtensions {
     /// the same target and quality as <paramref name="obj"/>. Otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if the conversion was successful, or <see langword="false"/> if it was not.</returns>
     public static bool Is<T>(this IObjectWithQuality<FactorioObject>? obj, [NotNullWhen(true)] out IObjectWithQuality<T>? result) where T : FactorioObject {
+        result = obj.As<T>();
+        return result is not null;
+    }
+
+    /// <summary>
+    /// Tests whether an <see cref="IObjectWithQuality{T}"/> can be converted to one with a different generic parameter.
+    /// </summary>
+    /// <typeparam name="T">The desired type parameter for the <see cref="IObjectWithQuality{T}"/> conversion to be tested.</typeparam>
+    /// <param name="obj">The input <see cref="IObjectWithQuality{T}"/> to be converted.</param>
+    /// <returns><see langword="true"/> if the conversion is possible, or <see langword="false"/> if it was not.</returns>
+    public static bool Is<T>(this IObjectWithQuality<FactorioObject>? obj) where T : FactorioObject => obj?.target is T;
+
+    /// <summary>
+    /// If possible, converts an <see cref="IObjectWithQuality{T}"/> into one with a different generic parameter.
+    /// </summary>
+    /// <typeparam name="T">The desired type parameter for the output <see cref="IObjectWithQuality{T}"/>.</typeparam>
+    /// <param name="obj">The input <see cref="IObjectWithQuality{T}"/> to be converted.</param>
+    /// <param name="result">If <c><paramref name="obj"/>?.target is <typeparamref name="T"/></c>, an <see cref="IObjectWithQuality{T}"/> with
+    /// the same target and quality as <paramref name="obj"/>. Otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the conversion was successful, or <see langword="false"/> if it was not.</returns>
+    public static IObjectWithQuality<T>? As<T>(this IObjectWithQuality<FactorioObject>? obj) where T : FactorioObject {
         if (obj is null or IObjectWithQuality<T>) {
-            result = obj as IObjectWithQuality<T>;
-            return result is not null;
+            return obj as IObjectWithQuality<T>;
         }
         // Use the conversion because it permits a null target. The constructor does not.
-        result = (ObjectWithQuality<T>?)(obj.target as T, obj.quality);
-        return result is not null;
+        return (ObjectWithQuality<T>?)(obj.target as T, obj.quality);
     }
 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -29,8 +29,8 @@ internal partial class FactorioDataDeserializer {
     private readonly Special electricity;
     private readonly Special rocketLaunch;
     private readonly Item science;
-    private readonly Item totalItemOutput;
-    private readonly Item totalItemInput;
+    private readonly Special totalItemOutput;
+    private readonly Special totalItemInput;
     private readonly EntityEnergy voidEntityEnergy;
     private readonly EntityEnergy laborEntityEnergy;
     private Entity? character;
@@ -43,7 +43,7 @@ internal partial class FactorioDataDeserializer {
     public FactorioDataDeserializer(Version factorioVersion) {
         this.factorioVersion = factorioVersion;
 
-        Special createSpecialObject(bool isPower, string name, string locName, string locDescr, string icon, string signal) {
+        Special createSpecialObject(bool isPower, bool isUsable, string name, string locName, string locDescr, string icon, string? signal) {
             var obj = GetObject<Special>(name);
             obj.virtualSignal = signal;
             obj.factorioType = "special";
@@ -53,39 +53,25 @@ internal partial class FactorioDataDeserializer {
             obj.power = isPower;
             if (isPower) {
                 obj.fuelValue = 1f;
+                fuels.Add(name, obj);
             }
-
+            obj.isLinkable = isUsable;
+            obj.showInExplorers = isUsable;
+            if (!isUsable) {
+                rootAccessible.Add(obj);
+            }
             return obj;
         }
 
-        Item createSpecialItem(string name, string locName, string locDescr, string icon) {
-            Item obj = GetObject<Item>(name);
-            obj.factorioType = "special";
-            obj.locName = locName;
-            obj.locDescr = locDescr;
-            obj.iconSpec = [new FactorioIconPart(icon)];
-            obj.isLinkable = false;
-            obj.showInExplorers = false;
-            rootAccessible.Add(obj);
-
-            return obj;
-        }
-
-        electricity = createSpecialObject(true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
+        electricity = createSpecialObject(true, true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
             "__core__/graphics/icons/alerts/electricity-icon-unplugged.png", "signal-E");
-        fuels.Add(SpecialNames.Electricity, electricity);
 
-        heat = createSpecialObject(true, SpecialNames.Heat, "Heat", "This is an object that represents heat energy", "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
-        fuels.Add(SpecialNames.Heat, heat);
+        heat = createSpecialObject(true, true, SpecialNames.Heat, "Heat", "This is an object that represents heat energy", "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
 
-        voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
+        voidEnergy = createSpecialObject(true, false, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
         voidEnergy.isVoid = true;
-        voidEnergy.isLinkable = false;
-        voidEnergy.showInExplorers = false;
-        fuels.Add(SpecialNames.Void, voidEnergy);
-        rootAccessible.Add(voidEnergy);
 
-        rocketLaunch = createSpecialObject(false, SpecialNames.RocketLaunch, "Rocket launch slot",
+        rocketLaunch = createSpecialObject(false, true, SpecialNames.RocketLaunch, "Rocket launch slot",
             "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/rocket-static-pod.png", "signal-R");
 
         science = GetObject<Item>("science");
@@ -106,8 +92,10 @@ internal partial class FactorioDataDeserializer {
         voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
         laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
 
-        totalItemInput = createSpecialItem("item-total-input", "Total item consumption", "This item represents the combined total item input of a multi-ingredient recipe. It can be used to set or measure the number of sushi belts required to supply this recipe row.", "__base__/graphics/icons/signal/signal_I.png");
-        totalItemOutput = createSpecialItem("item-total-output", "Total item production", "This item represents the combined total item output of a multi-product recipe. It can be used to set or measure the number of sushi belts required to handle the products of this recipe row.", "__base__/graphics/icons/signal/signal_O.png");
+        totalItemInput = createSpecialObject(false, false, "total-item-input", "Total item consumption", "This item represents the combined total item input of a multi-ingredient recipe. It can be used to set or measure the number of sushi belts required to supply this recipe row.", "__base__/graphics/icons/signal/signal_I.png", null);
+        totalItemOutput = createSpecialObject(false, false, "total-item-output", "Total item production", "This item represents the combined total item output of a multi-product recipe. It can be used to set or measure the number of sushi belts required to handle the products of this recipe row.", "__base__/graphics/icons/signal/signal_O.png", null);
+        formerAliases["Item.item-total-input"] = totalItemInput;
+        formerAliases["Item.item-total-output"] = totalItemOutput;
     }
 
     /// <summary>

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -176,13 +176,13 @@ internal partial class FactorioDataDeserializer {
         }
 
         Database.allSciencePacks = [.. sciencePacks];
-        Database.voidEnergy = voidEnergy;
-        Database.science = science;
-        Database.itemInput = totalItemInput;
-        Database.itemOutput = totalItemOutput;
-        Database.electricity = electricity;
-        Database.electricityGeneration = generatorProduction;
-        Database.heat = heat;
+        Database.voidEnergy = new(voidEnergy, Quality.Normal);
+        Database.science = new(science, Quality.Normal);
+        Database.itemInput = new(totalItemInput, Quality.Normal);
+        Database.itemOutput = new(totalItemOutput, Quality.Normal);
+        Database.electricity = new(electricity, Quality.Normal);
+        Database.electricityGeneration = new(generatorProduction, Quality.Normal);
+        Database.heat = new(heat, Quality.Normal);
         Database.character = character;
         int firstSpecial = 0;
         int firstItem = Skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -52,6 +52,7 @@ internal partial class FactorioDataDeserializer {
         }
         quality.BeaconConsumptionFactor = table.Get("beacon_power_usage_multiplier", 1f);
         quality.level = table.Get("level", 0);
+        quality.UpgradeChance = table.Get("next_probability", 0f);
     }
 
     private void UpdateRecipeCatalysts() {

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -326,7 +326,7 @@ public static class ImGuiUtils {
         private ImGui.Context savedContext;
         private readonly RectAllocator savedAllocator;
         private readonly ImGui gui;
-        private readonly int elementsPerRow;
+        public readonly int elementsPerRow;
         private readonly float elementWidth;
         private readonly float spacing;
         private int currentRowIndex;

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -396,19 +396,21 @@ public static class ImmediateWidgets {
         }
 
         using ImGui.OverlappingAllocations controller = gui.StartOverlappingAllocations(false);
-        drawGrid(gui, ref newQuality);
+        drawGrid(gui, ref newQuality, out bool addSpacing);
         float width = gui.lastRect.Width;
         controller.StartNextAllocatePass(true);
         using (gui.EnterRow(0)) {
-            if (drawCentered) {
+            if (drawCentered && addSpacing) {
                 gui.AllocateRect((gui.statePosition.Width - width) / 2, 0);
             }
-            return drawGrid(gui, ref newQuality);
+            return drawGrid(gui, ref newQuality, out _);
         }
 
-        static bool drawGrid(ImGui gui, ref Quality? newQuality) {
+        static bool drawGrid(ImGui gui, ref Quality? newQuality, out bool addSpacing) {
+            addSpacing = false;
             using ImGuiUtils.InlineGridBuilder grid = gui.EnterInlineGrid(2, .5f);
             Quality? drawQuality = Quality.Normal;
+            int qualityCount = 0;
             while (drawQuality != null) {
                 grid.Next();
                 if (newQuality == drawQuality) {
@@ -416,10 +418,13 @@ public static class ImmediateWidgets {
                 }
                 else if (gui.BuildFactorioObjectButton(drawQuality, ButtonDisplayStyle.Default) == Click.Left) {
                     newQuality = drawQuality;
+                    addSpacing = false; // This has to be the second call, where the value doesn't matter.
                     return true;
                 }
+                qualityCount++;
                 drawQuality = drawQuality.nextQuality;
             }
+            addSpacing = qualityCount <= grid.elementsPerRow;
             return false;
         }
     }

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -85,7 +85,7 @@ public static class ImmediateWidgets {
                 Vector2 size = new Vector2(displayStyle.Size / 2f);
                 var delta = contain ? size : size / 2f;
                 Rect milestoneIcon = new Rect(gui.lastRect.BottomRight - delta, size);
-                var icon = milestone == Database.voidEnergy ? DataUtils.HandIcon : milestone.icon;
+                var icon = milestone == Database.voidEnergy.target ? DataUtils.HandIcon : milestone.icon;
                 gui.DrawIcon(milestoneIcon, icon, color);
             }
         }
@@ -197,7 +197,7 @@ public static class ImmediateWidgets {
         return gui.BuildFactorioObjectButtonBackground(gui.lastRect, obj, tooltipOptions: tooltipOptions);
     }
 
-    internal static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, [NotNullWhen(true)] out T? selected, ObjectSelectOptions<T> options) where T : FactorioObject {
+    internal static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, [NotNullWhen(true)] out T? selected, ObjectSelectOptions<T> options) where T : class, IFactorioObjectWrapper {
         gui.BuildText(options.Header, Font.productionTableHeader);
         IEnumerable<T> sortedList = list;
 
@@ -456,7 +456,7 @@ public record DisplayAmount(float Value, UnitOfMeasure Unit = UnitOfMeasure.None
 /// Not used when selecting with a 'None' item or when <paramref name="Multiple"/> is <see langword="false"/>.</param>
 /// <param name="ExtraText">If not <see langword="null"/>, this will be called to get extra text to be displayed right-justified after the item's name.</param>
 public sealed record ObjectSelectOptions<T>(string Header, [AllowNull] IComparer<T> Ordering = null, int MaxCount = 6, bool Multiple = false, Predicate<T>? Checkmark = null,
-    Func<T, string>? ExtraText = null) where T : FactorioObject {
+    Func<T, string>? ExtraText = null) where T : IFactorioObjectWrapper {
 
-    public IComparer<T> Ordering { get; init; } = Ordering ?? DataUtils.DefaultOrdering;
+    public IComparer<T> Ordering { get; init; } = Ordering ?? (IComparer<T>)DataUtils.DefaultOrdering;
 }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -665,26 +665,31 @@ doneDrawing:;
     }
 
     private static void BuildQuality(Quality quality, ImGui gui) {
-        BuildSubHeader(gui, "Quality bonuses");
-        if (quality == Quality.Normal) {
-            using (gui.EnterGroup(contentPadding)) {
-                gui.BuildText("Normal quality provides no bonuses.", TextBlockDisplayStyle.WrappedText);
-            }
-            return;
-        }
-        gui.allocator = RectAllocator.LeftAlign;
-        (string left, string right)[] text = [
-            ("Crafting speed:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
-            ("Accumulator capacity:", '+' + DataUtils.FormatAmount(quality.AccumulatorCapacityBonus, UnitOfMeasure.Percent)),
-            ("Module effects:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent) + '*'),
-            ("Beacon transmission efficiency:", '+' + DataUtils.FormatAmount(quality.BeaconTransmissionBonus, UnitOfMeasure.None)),
-            ("Time before spoiling:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
-            ("Lightning attractor range & efficiency:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
-        ];
-
-        float rightWidth = text.Max(t => gui.GetTextDimensions(out _, t.right).X);
-
         using (gui.EnterGroup(contentPadding)) {
+            if (quality.UpgradeChance > 0) {
+                gui.BuildText("Upgrade chance: " + DataUtils.FormatAmount(quality.UpgradeChance, UnitOfMeasure.Percent) + " (multiplied by module bonus)");
+            }
+        }
+
+        BuildSubHeader(gui, "Quality bonuses");
+        using (gui.EnterGroup(contentPadding)) {
+            if (quality == Quality.Normal) {
+                gui.BuildText("Normal quality provides no bonuses.", TextBlockDisplayStyle.WrappedText);
+                return;
+            }
+
+            gui.allocator = RectAllocator.LeftAlign;
+            (string left, string right)[] text = [
+                ("Crafting speed:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
+                ("Accumulator capacity:", '+' + DataUtils.FormatAmount(quality.AccumulatorCapacityBonus, UnitOfMeasure.Percent)),
+                ("Module effects:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent) + '*'),
+                ("Beacon transmission efficiency:", '+' + DataUtils.FormatAmount(quality.BeaconTransmissionBonus, UnitOfMeasure.None)),
+                ("Time before spoiling:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
+                ("Lightning attractor range & efficiency:", '+' + DataUtils.FormatAmount(quality.StandardBonus, UnitOfMeasure.Percent)),
+            ];
+
+            float rightWidth = text.Max(t => gui.GetTextDimensions(out _, t.right).X);
+
             gui.allocator = RectAllocator.LeftAlign;
             foreach (var (left, right) in text) {
                 gui.BuildText(left);

--- a/Yafc/Windows/MainScreen.PageListSearch.cs
+++ b/Yafc/Windows/MainScreen.PageListSearch.cs
@@ -102,16 +102,16 @@ public partial class MainScreen {
                     yield return page;
                 }
                 else if (page.content is ProductionTable table) {
-                    if (checkboxValues[(int)PageSearchOption.DesiredProducts] && table.links.Any(l => l.amount != 0 && isMatch(l.goods.name, l.goods.locName))) {
+                    if (checkboxValues[(int)PageSearchOption.DesiredProducts] && table.links.Any(l => l.amount != 0 && isMatch(l.goods.target.name, l.goods.target.locName))) {
                         yield return page;
                     }
-                    else if (checkboxValues[(int)PageSearchOption.Ingredients] && table.flow.Any(f => f.amount < 0 && isMatch(f.goods.name, f.goods.locName))) {
+                    else if (checkboxValues[(int)PageSearchOption.Ingredients] && table.flow.Any(f => f.amount < 0 && isMatch(f.goods.target.name, f.goods.target.locName))) {
                         yield return page;
                     }
-                    else if (checkboxValues[(int)PageSearchOption.ExtraProducts] && table.flow.Any(f => f.amount > 0 && isMatch(f.goods.name, f.goods.locName))) {
+                    else if (checkboxValues[(int)PageSearchOption.ExtraProducts] && table.flow.Any(f => f.amount > 0 && isMatch(f.goods.target.name, f.goods.target.locName))) {
                         yield return page;
                     }
-                    else if (checkboxValues[(int)PageSearchOption.Recipes] && table.GetAllRecipes().Any(r => isMatch(r.recipe.name, r.recipe.locName))) {
+                    else if (checkboxValues[(int)PageSearchOption.Recipes] && table.GetAllRecipes().Any(r => isMatch(r.recipe.target.name, r.recipe.target.locName))) {
                         yield return page;
                     }
                 }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -164,12 +164,12 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         public IEnumerable<ExportMaterial> Outputs { get; }
 
         public ExportRecipe(RecipeRow row) {
-            Recipe = row.recipe.name;
+            Recipe = row.recipe.QualityName();
             Building = row.entity;
             BuildingCount = row.buildingCount;
-            Fuel = new ExportMaterial(row.fuel?.name ?? "<No fuel selected>", row.FuelInformation.Amount);
-            Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.name ?? "Recipe disabled", i.Amount));
-            Outputs = row.Products.Select(p => new ExportMaterial(p.Goods?.name ?? "Recipe disabled", p.Amount));
+            Fuel = new ExportMaterial(row.fuel?.QualityName() ?? "<No fuel selected>", row.FuelInformation.Amount);
+            Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.QualityName() ?? "Recipe disabled", i.Amount));
+            Outputs = row.Products.Select(p => new ExportMaterial(p.Goods?.QualityName() ?? "Recipe disabled", p.Amount));
             Beacon = row.usedModules.beacon;
             BeaconCount = row.usedModules.beaconCount;
 

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -29,6 +29,24 @@ public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObje
         }, false);
     }
 
+    /// <summary>
+    /// Opens a <see cref="SelectMultiObjectPanel"/> to allow the user to select one or more <see cref="FactorioObject"/>s.
+    /// </summary>
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for each selected item when the panel is closed.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    public static void SelectWithQuality<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>> selectItem, Quality currentQuality,
+        IComparer<T>? ordering = null, Predicate<T>? checkMark = null) where T : FactorioObject {
+
+        SelectMultiObjectPanel panel = new(o => checkMark?.Invoke((T)o) ?? false); // This casting is messy, but pushing T all the way around the call stack and type tree was messier.
+        panel.SelectWithQuality(list, header, selectItem!, ordering, (objs, mappedAction) => { // null-forgiving: selectItem will not be called with null, because allowNone is false.
+            foreach (var obj in objs!) { // null-forgiving: mapResult will not be called with null, because allowNone is false.
+                mappedAction(obj);
+            }
+        }, false, null, currentQuality);
+    }
+
     protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
         SchemeColor bgColor = results.Contains(element) ? SchemeColor.Primary : SchemeColor.None;
         Click click = gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(bgColor), new() { ShowTypeInHeader = showTypeInHeader });

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -25,7 +25,7 @@ public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
 
     protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject?>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
 
-    protected void SelectQuality<U>(IEnumerable<U> list, string header, Action<ObjectWithQuality<U>?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult,
+    protected void SelectWithQuality<U>(IEnumerable<U> list, string header, Action<ObjectWithQuality<U>?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult,
         bool allowNone, string? noneTooltip, Quality? currentQuality) where U : FactorioObject
         => Select(list, header, u => selectItem((u, this.currentQuality!)), ordering, mapResult, allowNone, noneTooltip, currentQuality ?? Quality.Normal);
 

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -32,6 +32,20 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// <param name="selectItem">An action to be called for the selected item when the panel is closed.
     /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
+    public static void SelectWithQuality<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>> selectItem, Quality? currentQuality,
+        IComparer<T>? ordering = null) where T : FactorioObject
+      // null-forgiving: selectItem will not be called with null, because allowNone is false.
+      => Instance.SelectWithQuality(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false, null, currentQuality);
+
+    /// <summary>
+    /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>, or to clear the current selection by selecting
+    /// an extra "none" or "clear" option.
+    /// </summary>
+    /// <param name="list">The items to be displayed in this panel.</param>
+    /// <param name="header">The string that describes to the user why they're selecting these items.</param>
+    /// <param name="selectItem">An action to be called for the selected item when the panel is closed.
+    /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
+    /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
     /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
     public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
         => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
@@ -48,7 +62,7 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
     public static void SelectQualityWithNone<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>?> selectItem, Quality? currentQuality, IComparer<T>? ordering = null,
         string? noneTooltip = null) where T : FactorioObject
-        => Instance.SelectQuality(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip, currentQuality);
+        => Instance.SelectWithQuality(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip, currentQuality);
 
     protected override void NonNullElementDrawer(ImGui gui, FactorioObject element) {
         if (gui.BuildFactorioObjectButton(element, ButtonDisplayStyle.SelectObjectPanel(SchemeColor.None), tooltipOptions: new() { ShowTypeInHeader = showTypeInHeader }) == Click.Left) {

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -136,19 +136,19 @@ public class ShoppingListScreen : PseudoScreen {
         }
     }
 
-    private List<(T, int)> ExportGoods<T>() where T : Goods {
-        List<(T, int)> items = [];
-        foreach (((FactorioObject element, _), float amount) in list.data) {
+    private List<(IObjectWithQuality<T>, int)> ExportGoods<T>() where T : Goods {
+        List<(IObjectWithQuality<T>, int)> items = [];
+        foreach ((IObjectWithQuality<FactorioObject> element, float amount) in list.data) {
             int rounded = MathUtils.Round(amount);
             if (rounded == 0) {
                 continue;
             }
 
-            if (element is T g) {
+            if (element.Is(out IObjectWithQuality<T>? g)) {
                 items.Add((g, rounded));
             }
-            else if (element is Entity e && e.itemsToPlace.Length > 0) {
-                items.Add(((T)(object)e.itemsToPlace[0], rounded));
+            else if (element.Is(out IObjectWithQuality<Entity>? e) && e.target.itemsToPlace.Length > 0) {
+                items.Add((new ObjectWithQuality<T>((T)(object)e.target.itemsToPlace[0], e.quality), rounded));
             }
         }
 

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Yafc.Model;
 using Yafc.UI;
@@ -141,13 +140,13 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
                 if (recipe.entity != null) {
                     float power = effects.energyUsageMod * recipe.entity.GetPower() / recipe.entity.target.energy.effectivity;
-                    if (!recipe.recipe.flags.HasFlagAny(RecipeFlags.UsesFluidTemperature | RecipeFlags.ScaleProductionWithPower) && recipe.entity != null) {
+                    if (!recipe.recipe.target.flags.HasFlagAny(RecipeFlags.UsesFluidTemperature | RecipeFlags.ScaleProductionWithPower) && recipe.entity != null) {
                         energyUsageLine += " (" + DataUtils.FormatAmount(power, UnitOfMeasure.Megawatt) + " per building)";
                     }
 
                     gui.BuildText(energyUsageLine);
 
-                    float pps = craftingSpeed * (1f + MathF.Max(0f, effects.productivity)) / recipe.recipe.time;
+                    float pps = craftingSpeed * (1f + MathF.Max(0f, effects.productivity)) / recipe.recipe.target.time;
                     gui.BuildText("Overall crafting speed (including productivity): " + DataUtils.FormatAmount(pps, UnitOfMeasure.PerSecond));
                     gui.BuildText("Energy cost per recipe output: " + DataUtils.FormatAmount(power / pps, UnitOfMeasure.Megajoule));
                 }
@@ -195,7 +194,9 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
     }
 
     private Module[] GetModules(ObjectWithQuality<EntityBeacon>? beacon) {
-        var modules = (beacon == null && recipe is { recipe: Recipe rec }) ? [.. Database.allModules.Where(rec.CanAcceptModule)] : Database.allModules;
+        var modules = (beacon == null && recipe is { recipe: IObjectWithQuality<RecipeOrTechnology> rec })
+            ? [.. Database.allModules.Where(rec.CanAcceptModule)]
+            : Database.allModules;
         EntityWithModules? filter = (EntityWithModules?)beacon?.target ?? recipe?.entity?.target;
         if (filter == null) {
             return modules;

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -135,6 +135,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 gui.BuildText("Productivity bonus: " + DataUtils.FormatAmount(effects.productivity, UnitOfMeasure.Percent));
                 gui.BuildText("Speed bonus: " + DataUtils.FormatAmount(effects.speedMod - 1, UnitOfMeasure.Percent) + " (Crafting speed: " +
                     DataUtils.FormatAmount(craftingSpeed, UnitOfMeasure.None) + ")");
+                gui.BuildText("Quality bonus: " + DataUtils.FormatAmount(effects.qualityMod, UnitOfMeasure.Percent) + " (multiplied by quality upgrade chance)");
 
                 string energyUsageLine = "Energy usage: " + DataUtils.FormatAmount(effects.energyUsageMod, UnitOfMeasure.Percent);
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1520,6 +1520,8 @@ goodsHaveNoProduction:;
             "It also depends on the distance between adjacent collectors. These dependencies are not modeled. Expect widely varied performance."},
         {WarningFlags.AssumesFulgoraAndModel, "Energy production values assume Fulgoran storms and attractors in a square grid.\n" +
             "The accumulator estimate tries to store 10% of the energy captured by the attractors."},
+        {WarningFlags.UselessQuality, "The quality bonus on this recipe has no effect. " +
+            "Make sure the recipe produces items and that all milestones for the next quality are unlocked."},
     };
 
     private static readonly (Icon icon, SchemeColor color)[] tagIcons = [

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Date:
     Features:
         - Detect lightning rods/collectors as electricity sources, and estimate the required accumulator count.
         - Added button to remove link from link summary screen.
+        - Support production of quality items from quality inputs and/or quality modules.
     Fixes:
         - When creating launch recipes, obey the rocket capacity, not the item stack size.
         - Improve detection of special (e.g. barrelling, caging) recipes, especially with SA's recycling recipes.


### PR DESCRIPTION
These changes allow Yafc to calculate production with quality bonuses and quality input items. Recipes and Items now have quality levels. Several other objects such as Mechanics and Fluids pretend to have quality levels for compatibility, but only ever exist in normal quality.

It covers two of the remaining four tasks in #311, leaving out `fixed_quality` and quality science packs. Properly consuming quality science packs is next on my list, but they are being obstinate.

Quality modules only produce qualities that are unlocked based on the selected milestones. To make this more discoverable, there is also a new warning message telling the user to "Make sure ... all milestones for the next quality are unlocked." I considered, but later removed, additional code that adds all non-normal qualities as default milestones. If we want to add more default milestones, I can put it back.

I used [this project](https://github.com/user-attachments/files/18812864/QualityTest.zip) for testing and to trial various possible answers to my most pressing question about quality bonuses, namely: How do I maximize the output of legendary prod 3 modules from a single captive spawner?