### PR TITLE
fix(#419): Products after a fluid did not link correctly.

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -461,7 +461,6 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
 
     private IEnumerable<RecipeRowProduct> BuildProducts(bool forSolver) {
         float factor = forSolver ? 1 : (float)recipesPerSecond; // recipesPerSecond can be 0 when running the solver, which would create useless results.
-        int i = 0;
         IObjectWithQuality<Item>? spentFuel = fuel.FuelResult();
         bool handledFuel = spentFuel == null || forSolver; // If we're running the solver or there's no spent fuel, it's already handled.
 
@@ -481,7 +480,9 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
             }
         }
 
-        foreach (Product product in recipe.target.products) {
+        for (int i = 0; i < recipe.target.products.Length; i++) {
+            Product product = recipe.target.products[i];
+
             if (hierarchyEnabled) {
                 Quality quality = recipe.quality;
                 float baseAmount = product.GetAmountPerRecipe(parameters.productivity);
@@ -504,8 +505,6 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
                         }
                         quality = quality.nextQuality!;
                     }
-
-                    i++;
                 }
             }
             else {

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Fixes:
+        - (regression) Links for recipes with fluid outputs were not handled correctly.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.8.0
 Date: February 19th 2025
     Features:


### PR DESCRIPTION
Fluid products caused subsequent products to display the wrong link information. Moving the `i++` out one set of curlies fixed things in Simon's sample, and then I looked at it and realized it should just be a for loop, rather than a foreach-with-counter loop.