### PR TITLE
Fix saving legacy summaries

### DIFF
--- a/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
@@ -1,0 +1,339 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Yafc.Model.Serialization.Tests;
+
+public class SerializationTreeChangeDetection {
+    private static readonly Dictionary<Type, Dictionary<string, Type>> propertyTree = new() {
+        [typeof(AutoPlanner)] = new() {
+            [nameof(AutoPlanner.goals)] = typeof(List<AutoPlannerGoal>),
+            [nameof(AutoPlanner.done)] = typeof(HashSet<Recipe>),
+            [nameof(AutoPlanner.roots)] = typeof(HashSet<Goods>),
+        },
+        [typeof(ModuleFillerParameters)] = new() {
+            [nameof(ModuleFillerParameters.fillMiners)] = typeof(bool),
+            [nameof(ModuleFillerParameters.autoFillPayback)] = typeof(float),
+            [nameof(ModuleFillerParameters.fillerModule)] = typeof(ObjectWithQuality<Module>),
+            [nameof(ModuleFillerParameters.beacon)] = typeof(ObjectWithQuality<EntityBeacon>),
+            [nameof(ModuleFillerParameters.beaconModule)] = typeof(ObjectWithQuality<Module>),
+            [nameof(ModuleFillerParameters.beaconsPerBuilding)] = typeof(int),
+            [nameof(ModuleFillerParameters.overrideCrafterBeacons)] = typeof(OverrideCrafterBeacons),
+        },
+        [typeof(ProductionSummaryGroup)] = new() {
+            [nameof(ProductionSummaryGroup.elements)] = typeof(List<ProductionSummaryEntry>),
+            [nameof(ProductionSummaryGroup.expanded)] = typeof(bool),
+            [nameof(ProductionSummaryGroup.name)] = typeof(string),
+        },
+        [typeof(ProductionSummaryEntry)] = new() {
+            [nameof(ProductionSummaryEntry.multiplier)] = typeof(float),
+            [nameof(ProductionSummaryEntry.page)] = typeof(PageReference),
+            [nameof(ProductionSummaryEntry.subgroup)] = typeof(ProductionSummaryGroup),
+        },
+        [typeof(ProductionSummaryColumn)] = new() {
+            [nameof(ProductionSummaryColumn.goods)] = typeof(ObjectWithQuality<Goods>),
+        },
+        [typeof(ProductionSummary)] = new() {
+            [nameof(ProductionSummary.group)] = typeof(ProductionSummaryGroup),
+            [nameof(ProductionSummary.columns)] = typeof(List<ProductionSummaryColumn>),
+        },
+        [typeof(ProductionTable)] = new() {
+            [nameof(ProductionTable.expanded)] = typeof(bool),
+            [nameof(ProductionTable.links)] = typeof(List<ProductionLink>),
+            [nameof(ProductionTable.recipes)] = typeof(List<RecipeRow>),
+            [nameof(ProductionTable.modules)] = typeof(ModuleFillerParameters),
+        },
+        [typeof(RecipeRowCustomModule)] = new() {
+            [nameof(RecipeRowCustomModule.module)] = typeof(ObjectWithQuality<Module>),
+            [nameof(RecipeRowCustomModule.fixedCount)] = typeof(int),
+        },
+        [typeof(ModuleTemplate)] = new() {
+            [nameof(ModuleTemplate.beacon)] = typeof(ObjectWithQuality<EntityBeacon>),
+            [nameof(ModuleTemplate.list)] = typeof(ReadOnlyCollection<RecipeRowCustomModule>),
+            [nameof(ModuleTemplate.beaconList)] = typeof(ReadOnlyCollection<RecipeRowCustomModule>),
+        },
+        [typeof(RecipeRow)] = new() {
+            [nameof(RecipeRow.recipe)] = typeof(ObjectWithQuality<RecipeOrTechnology>),
+            [nameof(RecipeRow.entity)] = typeof(ObjectWithQuality<EntityCrafter>),
+            [nameof(RecipeRow.fuel)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(RecipeRow.fixedBuildings)] = typeof(float),
+            [nameof(RecipeRow.fixedFuel)] = typeof(bool),
+            [nameof(RecipeRow.fixedIngredient)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(RecipeRow.fixedProduct)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(RecipeRow.builtBuildings)] = typeof(int?),
+            [nameof(RecipeRow.showTotalIO)] = typeof(bool),
+            [nameof(RecipeRow.enabled)] = typeof(bool),
+            [nameof(RecipeRow.tag)] = typeof(int),
+            [nameof(RecipeRow.modules)] = typeof(ModuleTemplate),
+            [nameof(RecipeRow.subgroup)] = typeof(ProductionTable),
+            [nameof(RecipeRow.variants)] = typeof(HashSet<FactorioObject>),
+        },
+        [typeof(ProductionLink)] = new() {
+            [nameof(ProductionLink.goods)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(ProductionLink.amount)] = typeof(float),
+            [nameof(ProductionLink.algorithm)] = typeof(LinkAlgorithm),
+        },
+        [typeof(Project)] = new() {
+            [nameof(Project.settings)] = typeof(ProjectSettings),
+            [nameof(Project.preferences)] = typeof(ProjectPreferences),
+            [nameof(Project.sharedModuleTemplates)] = typeof(List<ProjectModuleTemplate>),
+            [nameof(Project.yafcVersion)] = typeof(string),
+            [nameof(Project.pages)] = typeof(List<ProjectPage>),
+            [nameof(Project.displayPages)] = typeof(List<Guid>),
+        },
+        [typeof(ProjectSettings)] = new() {
+            [nameof(ProjectSettings.milestones)] = typeof(List<FactorioObject>),
+            [nameof(ProjectSettings.itemFlags)] = typeof(SortedList<FactorioObject, ProjectPerItemFlags>),
+            [nameof(ProjectSettings.miningProductivity)] = typeof(float),
+            [nameof(ProjectSettings.researchSpeedBonus)] = typeof(float),
+            [nameof(ProjectSettings.researchProductivity)] = typeof(float),
+            [nameof(ProjectSettings.productivityTechnologyLevels)] = typeof(Dictionary<Technology, int>),
+            [nameof(ProjectSettings.reactorSizeX)] = typeof(int),
+            [nameof(ProjectSettings.reactorSizeY)] = typeof(int),
+            [nameof(ProjectSettings.PollutionCostModifier)] = typeof(float),
+            [nameof(ProjectSettings.spoilingRate)] = typeof(float),
+        },
+        [typeof(ProjectPreferences)] = new() {
+            [nameof(ProjectPreferences.time)] = typeof(int),
+            [nameof(ProjectPreferences.itemUnit)] = typeof(float),
+            [nameof(ProjectPreferences.fluidUnit)] = typeof(float),
+            [nameof(ProjectPreferences.defaultBelt)] = typeof(EntityBelt),
+            [nameof(ProjectPreferences.defaultInserter)] = typeof(EntityInserter),
+            [nameof(ProjectPreferences.inserterCapacity)] = typeof(int),
+            [nameof(ProjectPreferences.sourceResources)] = typeof(HashSet<FactorioObject>),
+            [nameof(ProjectPreferences.favorites)] = typeof(HashSet<FactorioObject>),
+            [nameof(ProjectPreferences.targetTechnology)] = typeof(Technology),
+            [nameof(ProjectPreferences.iconScale)] = typeof(float),
+            [nameof(ProjectPreferences.maxMilestonesPerTooltipLine)] = typeof(int),
+            [nameof(ProjectPreferences.showMilestoneOnInaccessible)] = typeof(bool),
+        },
+        [typeof(ProjectModuleTemplate)] = new() {
+            [nameof(ProjectModuleTemplate.template)] = typeof(ModuleTemplate),
+            [nameof(ProjectModuleTemplate.icon)] = typeof(FactorioObject),
+            [nameof(ProjectModuleTemplate.name)] = typeof(string),
+            [nameof(ProjectModuleTemplate.filterEntities)] = typeof(List<Entity>),
+        },
+        [typeof(ProjectPage)] = new() {
+            [nameof(ProjectPage.icon)] = typeof(FactorioObject),
+            [nameof(ProjectPage.name)] = typeof(string),
+            [nameof(ProjectPage.guid)] = typeof(Guid),
+            [nameof(ProjectPage.contentType)] = typeof(Type),
+            [nameof(ProjectPage.content)] = typeof(ProjectPageContents),
+        },
+        [typeof(Summary)] = new() {
+            [nameof(Summary.showOnlyIssues)] = typeof(bool),
+        },
+        [typeof(AutoPlannerGoal)] = new() {
+            [nameof(AutoPlannerGoal.item)] = typeof(Goods),
+            [nameof(AutoPlannerGoal.amount)] = typeof(float),
+        },
+        [typeof(ObjectWithQuality<Module>)] = new() {
+            [nameof(ObjectWithQuality<Module>.target)] = typeof(Module),
+            [nameof(ObjectWithQuality<Module>.quality)] = typeof(Quality),
+        },
+        [typeof(ObjectWithQuality<EntityBeacon>)] = new() {
+            [nameof(ObjectWithQuality<EntityBeacon>.target)] = typeof(EntityBeacon),
+            [nameof(ObjectWithQuality<EntityBeacon>.quality)] = typeof(Quality),
+        },
+        [typeof(BeaconOverrideConfiguration)] = new() {
+            [nameof(BeaconOverrideConfiguration.beacon)] = typeof(ObjectWithQuality<EntityBeacon>),
+            [nameof(BeaconOverrideConfiguration.beaconCount)] = typeof(int),
+            [nameof(BeaconOverrideConfiguration.beaconModule)] = typeof(ObjectWithQuality<Module>),
+        },
+        [typeof(ObjectWithQuality<Goods>)] = new() {
+            [nameof(ObjectWithQuality<Goods>.target)] = typeof(Goods),
+            [nameof(ObjectWithQuality<Goods>.quality)] = typeof(Quality),
+        },
+        [typeof(ObjectWithQuality<RecipeOrTechnology>)] = new() {
+            [nameof(ObjectWithQuality<RecipeOrTechnology>.target)] = typeof(RecipeOrTechnology),
+            [nameof(ObjectWithQuality<RecipeOrTechnology>.quality)] = typeof(Quality),
+        },
+        [typeof(ObjectWithQuality<EntityCrafter>)] = new() {
+            [nameof(ObjectWithQuality<EntityCrafter>.target)] = typeof(EntityCrafter),
+            [nameof(ObjectWithQuality<EntityCrafter>.quality)] = typeof(Quality),
+        },
+    };
+
+    private readonly HashSet<Type> queuedTypes = [.. AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes())
+        .Where(t => typeof(ModelObject).IsAssignableFrom(t) && !t.IsAbstract)];
+    private readonly Queue<Type> queue;
+
+    public SerializationTreeChangeDetection() => queue = new(queuedTypes);
+
+    [Fact]
+    // Walk all serialized types (starting with all concrete ModelObjects), and check which types are serialized and the types of their
+    // properties. Changes to this list may result in save/load issues, so require an extra step (modifying the above dictionary initializer)
+    // to ensure those changes are intentional.
+    public void TreeHasNotChanged() {
+        while (queue.TryDequeue(out Type type)) {
+            Assert.True(propertyTree.Remove(type, out var expectedProperties), $"Serializing new type {MakeTypeName(type)}. Add `[typeof({MakeTypeName(type)})] = new() {{ /*properties*/ }},` to the propertyTree initializer.");
+
+            var constructorWritable = SerializationTypeValidation.FindConstructor(type).GetParameters().Select(p => p.Name);
+            if (typeof(ModelObject).IsAssignableFrom(type)) {
+                // Skip the parent/owner parameter
+                constructorWritable = constructorWritable.Skip(1);
+            }
+            HashSet<string> constructorParameters = [.. constructorWritable];
+
+            foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)) {
+                if (property.GetCustomAttribute<ObsoleteAttribute>() != null || property.GetCustomAttribute<SkipSerializationAttribute>() != null) {
+                    continue;
+                }
+
+                Type propertyType = property.PropertyType;
+
+                if (property.GetSetMethod() != null || constructorParameters.Contains(property.Name)) {
+                    // Writable properties are always serialized
+                    AssertPropertyType(type, expectedProperties, property, propertyType);
+                    QueueSerializedType(propertyType);
+                }
+                else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>)
+                    && ValueSerializer.IsValueSerializerSupported(propertyType.GenericTypeArguments[0])) {
+
+                    // ReadOnlyCollection<T> is serialized as T
+                    AssertPropertyType(type, expectedProperties, property, propertyType);
+                    QueueSerializedType(propertyType.GenericTypeArguments[0]);
+                }
+                else if (propertyType.IsAssignableTo(typeof(ModelObject))) {
+                    // Read-only model objects are serialized in-place.
+                    AssertPropertyType(type, expectedProperties, property, propertyType);
+                    QueueSerializedType(propertyType); // Only for consistency; the queue is initialized with all ModelObjects.
+                }
+                else {
+                    var interfaces = propertyType.GetInterfaces().Where(i => i.IsGenericType).DistinctBy(i => i.GetGenericTypeDefinition()).ToList();
+                    if (interfaces.FirstOrDefault(i => i.GetGenericTypeDefinition() == typeof(IDictionary<,>)) is Type iDictionary) {
+                        if (ValueSerializer.IsValueSerializerSupported(iDictionary.GenericTypeArguments[0])
+                            && ValueSerializer.IsValueSerializerSupported(iDictionary.GenericTypeArguments[1])) {
+
+                            var types = iDictionary.GenericTypeArguments;
+                            AssertPropertyType(type, expectedProperties, property, propertyType);
+                            QueueSerializedType(types[0]);
+                            QueueSerializedType(types[1]);
+                        }
+                    }
+                    else if (interfaces.FirstOrDefault(i => i.GetGenericTypeDefinition() == typeof(ICollection<>)) is Type iCollection) {
+                        if (ValueSerializer.IsValueSerializerSupported(iCollection.GenericTypeArguments[0])) {
+                            var types = iCollection.GenericTypeArguments;
+                            AssertPropertyType(type, expectedProperties, property, propertyType);
+                            QueueSerializedType(types[0]);
+                        }
+                    }
+                }
+            }
+
+            if (expectedProperties.Keys.FirstOrDefault() is string missingProperty) {
+                Assert.Fail($"Expected to serialize property {MakeTypeName(type)}.{missingProperty}. Remove its entry from the propertyTree initializer if it is obsolete or no longer supported.");
+            }
+        }
+
+        if (propertyTree.Keys.FirstOrDefault() is Type missingType) {
+            Assert.Fail($"Expected to serialize type {MakeTypeName(missingType)}. Remove its entry from the propertyTree initializer if it is obsolete or no longer supported.");
+        }
+    }
+
+    // Not explictly called, but you can call this from the debugger to generate the initializer as a string.
+    public string BuildPropertyTree() {
+        StringBuilder result = new("    private static readonly Dictionary<Type, Dictionary<string, Type>> propertyTree = new() {\r\n");
+        HashSet<Type> queuedTypes = [.. this.queuedTypes];
+        Queue<Type> queue = new(queuedTypes);
+        while (queue.TryDequeue(out Type type)) {
+            result.AppendLine($"        [typeof({MakeTypeName(type)})] = new() {{");
+            foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)) {
+                if (property.GetCustomAttribute<ObsoleteAttribute>() != null || property.GetCustomAttribute<SkipSerializationAttribute>() != null) {
+                    continue;
+                }
+
+                var constructorWritable = SerializationTypeValidation.FindConstructor(type).GetParameters().Select(p => p.Name);
+                if (typeof(ModelObject).IsAssignableFrom(type)) {
+                    // Skip the parent/owner parameter
+                    constructorWritable = constructorWritable.Skip(1);
+                }
+                HashSet<string> constructorParameters = [.. constructorWritable];
+
+                Type propertyType = property.PropertyType;
+
+                if (property.GetSetMethod() != null || constructorParameters.Contains(property.Name)) {
+                    // Writable properties are always serialized
+                    addPropertyType(type, property, propertyType);
+                    queueSerializedType(propertyType);
+                }
+                else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>)
+                    && ValueSerializer.IsValueSerializerSupported(propertyType.GenericTypeArguments[0])) {
+
+                    // ReadOnlyCollection<T> is serialized as T
+                    addPropertyType(type, property, propertyType);
+                    queueSerializedType(propertyType.GenericTypeArguments[0]);
+                }
+                else if (propertyType.IsAssignableTo(typeof(ModelObject))) {
+                    // Read-only model objects are serialized in-place
+                    addPropertyType(type, property, propertyType);
+                    queueSerializedType(propertyType);
+                }
+                else {
+                    var interfaces = propertyType.GetInterfaces().Where(i => i.IsGenericType).DistinctBy(i => i.GetGenericTypeDefinition()).ToList();
+                    if (interfaces.FirstOrDefault(i => i.GetGenericTypeDefinition() == typeof(IDictionary<,>)) is Type iDictionary) {
+                        if (ValueSerializer.IsValueSerializerSupported(iDictionary.GenericTypeArguments[0])
+                            && ValueSerializer.IsValueSerializerSupported(iDictionary.GenericTypeArguments[1])) {
+
+                            var types = iDictionary.GenericTypeArguments;
+                            addPropertyType(type, property, propertyType);
+                            queueSerializedType(types[0]);
+                            queueSerializedType(types[1]);
+                        }
+                    }
+                    else if (interfaces.FirstOrDefault(i => i.GetGenericTypeDefinition() == typeof(ICollection<>)) is Type iCollection) {
+                        if (ValueSerializer.IsValueSerializerSupported(iCollection.GenericTypeArguments[0])) {
+                            var types = iCollection.GenericTypeArguments;
+                            addPropertyType(type, property, propertyType);
+                            queueSerializedType(types[0]);
+                        }
+                    }
+                }
+            }
+            result.AppendLine("        },");
+        }
+
+        return result.AppendLine("    };").ToString();
+
+        void addPropertyType(Type type, PropertyInfo property, Type propertyType)
+            => result.AppendLine($"            [nameof({MakeTypeName(type)}.{property.Name})] = typeof({MakeTypeName(propertyType)}),");
+
+        void queueSerializedType(Type serializationType) {
+            if ((serializationType.GetCustomAttribute<SerializableAttribute>() != null && serializationType.FullName.StartsWith("Yafc.")) || serializationType.IsAssignableTo(typeof(ModelObject))) {
+                if (!serializationType.IsAbstract && queuedTypes.Add(serializationType)) {
+                    queue.Enqueue(serializationType);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Assert that <paramref name="property"/> is expected to be serialized and has the expected type.
+    /// </summary>
+    private static void AssertPropertyType(Type type, Dictionary<string, Type> expectedProperties, PropertyInfo property, Type propertyType) {
+        Assert.True(expectedProperties.Remove(property.Name, out Type expectedPropertyType),
+            $"Serializing a new property '{MakeTypeName(type)}.{property.Name}'. If this is intentional, add `[nameof({MakeTypeName(type)}.{property.Name})] = typeof({MakeTypeName(property.PropertyType)}),` to the propertyTree initializer, under [typeof({MakeTypeName(type)})].");
+        Assert.True(expectedPropertyType == propertyType,
+            $"The type of '{MakeTypeName(type)}.{property.Name}' has changed from {MakeTypeName(expectedPropertyType)} to {MakeTypeName(propertyType)}. If this is intentional, update the property type in the propertyTree initializer, under [typeof({MakeTypeName(type)})].");
+    }
+
+    /// <summary>
+    /// If appropriate, queue <paramref name="serializationType"/> for inspection of its property types.
+    /// Native and native-like types do not get inspected, and each type is inspected at most once.
+    /// </summary>
+    private void QueueSerializedType(Type serializationType) {
+        if ((serializationType.GetCustomAttribute<SerializableAttribute>() != null && serializationType.FullName.StartsWith("Yafc."))
+            || (serializationType.IsAssignableTo(typeof(ModelObject)) && !serializationType.IsAbstract)) {
+
+            if (queuedTypes.Add(serializationType)) {
+                queue.Enqueue(serializationType);
+            }
+        }
+    }
+
+    private static string MakeTypeName(Type type) => SerializationTypeValidation.MakeTypeName(type);
+}

--- a/Yafc.Model.Tests/Serialization/SerializationTypeValidation.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTypeValidation.cs
@@ -50,7 +50,7 @@ public class SerializationTypeValidation {
         }
     }
 
-    private static ConstructorInfo FindConstructor(Type type) {
+    internal static ConstructorInfo FindConstructor(Type type) {
         BindingFlags flags = BindingFlags.Instance;
         if (type.GetCustomAttribute<DeserializeWithNonPublicConstructorAttribute>() != null) {
             flags |= BindingFlags.NonPublic;
@@ -111,7 +111,7 @@ public class SerializationTypeValidation {
         }
     }
 
-    private static string MakeTypeName(Type type) {
+    internal static string MakeTypeName(Type type) {
         if (type.IsGenericType) {
             if (type.GetGenericTypeDefinition() == typeof(Nullable<>)) {
                 return MakeTypeName(type.GetGenericArguments()[0]) + '?';

--- a/Yafc.Model.Tests/Serialization/SerializationTypeValidation.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTypeValidation.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Xunit;
+
+namespace Yafc.Model.Serialization.Tests;
+
+public class SerializationTypeValidation {
+    [Fact]
+    // Ensure that all concrete types derived from ModelObject obey the serialization rules.
+    public void ModelObjects_AreSerializable() {
+        var types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes())
+            .Where(t => typeof(ModelObject).IsAssignableFrom(t) && !t.IsAbstract);
+
+        foreach (Type type in types) {
+            ConstructorInfo constructor = FindConstructor(type);
+
+            PropertyInfo ownerProperty = type.GetProperty("owner");
+            if (ownerProperty != null) {
+                // If derived from ModelObject<T> (as tested by "There's an 'owner' property"), the first constructor parameter must be T.
+                Assert.True(constructor.GetParameters().Length > 0, $"The first constructor parameter for type {MakeTypeName(type)} should be the parent object.");
+                Type baseType = typeof(ModelObject<>).MakeGenericType(ownerProperty.PropertyType);
+                Assert.True(baseType.IsAssignableFrom(type), $"The first constructor parameter for type {MakeTypeName(type)} is not the parent type.");
+            }
+
+            // Cheating a bit here: Project is the only ModelObject that is not a ModelObject<T>, and its constructor has no parameters.
+            // So we're just skipping a parameter that doesn't exist.
+            AssertConstructorParameters(type, constructor.GetParameters().Skip(1));
+            AssertSettableProperties(type);
+            AssertDictionaryKeys(type);
+        }
+    }
+
+    [Fact]
+    // Ensure that all [Serializable] types in the Yafc namespace obey the serialization rules,
+    // except compiler-generated types and those in Yafc.Blueprints.
+    public void Serializables_AreSerializable() {
+        var types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes())
+            .Where(t => t.GetCustomAttribute<SerializableAttribute>() != null && t.FullName.StartsWith("Yafc.") && !t.FullName.StartsWith("Yafc.Blueprints"));
+
+        foreach (Type type in types.Where(type => type.GetCustomAttribute<CompilerGeneratedAttribute>() == null)) {
+            ConstructorInfo constructor = FindConstructor(type);
+
+            AssertConstructorParameters(type, constructor.GetParameters());
+            AssertSettableProperties(type);
+            AssertDictionaryKeys(type);
+        }
+    }
+
+    private static ConstructorInfo FindConstructor(Type type) {
+        BindingFlags flags = BindingFlags.Instance;
+        if (type.GetCustomAttribute<DeserializeWithNonPublicConstructorAttribute>() != null) {
+            flags |= BindingFlags.NonPublic;
+        }
+        else {
+            flags |= BindingFlags.Public;
+        }
+
+        // The constructor (public or non-public, depending on the attribute) must exist
+        ConstructorInfo constructor = type.GetConstructors(flags).FirstOrDefault();
+        Assert.True(constructor != null, $"Could not find the constructor for type {MakeTypeName(type)}.");
+        return constructor;
+    }
+
+
+    private static void AssertConstructorParameters(Type type, IEnumerable<ParameterInfo> parameters) {
+        foreach (ParameterInfo parameter in parameters) {
+            // Constructor parameters must be IsValueSerializerSupported
+            Assert.True(ValueSerializer.IsValueSerializerSupported(parameter.ParameterType),
+                $"Constructor of type {MakeTypeName(type)} parameter '{parameter.Name}' should be a supported value type.");
+
+            // and must have a matching property
+            PropertyInfo property = type.GetProperty(parameter.Name);
+            Assert.True(property != null, $"Constructor of type {MakeTypeName(type)} parameter '{parameter.Name}' does not have a matching property.");
+            Assert.True(parameter.ParameterType == property.PropertyType,
+                $"Constructor of type {MakeTypeName(type)} parameter '{parameter.Name}' does not have the same type as its property.");
+        }
+    }
+
+    private static void AssertSettableProperties(Type type) {
+        foreach (PropertyInfo property in type.GetProperties().Where(p => p.GetSetMethod() != null)) {
+            if (property.GetCustomAttribute<SkipSerializationAttribute>() == null) {
+                // Properties with a public setter must be IsValueSerializerSupported
+                Assert.True(ValueSerializer.IsValueSerializerSupported(property.PropertyType),
+                    $"The type of property {MakeTypeName(type)}.{property.Name} should be a supported value type.");
+            }
+        }
+    }
+
+    private void AssertDictionaryKeys(Type type) {
+        foreach (PropertyInfo property in type.GetProperties().Where(p => p.GetSetMethod() == null)) {
+            if (property.GetCustomAttribute<SkipSerializationAttribute>() == null) {
+                Type iDictionary = property.PropertyType.GetInterfaces()
+                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+                if (iDictionary != null) {
+                    if (ValueSerializer.IsValueSerializerSupported(iDictionary.GenericTypeArguments[0])
+                        && ValueSerializer.IsValueSerializerSupported(iDictionary.GenericTypeArguments[1])) {
+
+                        object serializer = typeof(ValueSerializer<>).MakeGenericType(iDictionary.GenericTypeArguments[0]).GetField("Default").GetValue(null);
+                        MethodInfo getJsonProperty = serializer.GetType().GetMethod(nameof(ValueSerializer<string>.GetJsonProperty));
+                        // Dictionary keys must be serialized by an overridden ValueSerializer<T>.GetJsonProperty() method.
+                        Assert.True(getJsonProperty != getJsonProperty.GetBaseDefinition(),
+                            $"In {MakeTypeName(type)}.{property.Name}, the dictionary keys are of an unsupported type.");
+                    }
+                }
+            }
+        }
+    }
+
+    private static string MakeTypeName(Type type) {
+        if (type.IsGenericType) {
+            if (type.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                return MakeTypeName(type.GetGenericArguments()[0]) + '?';
+            }
+            StringBuilder result = new(type.Name.Split('`')[0]);
+            result.Append('<').AppendJoin(", ", type.GenericTypeArguments.Select(MakeTypeName)).Append('>');
+            return result.ToString();
+        }
+
+        if (type == typeof(bool)) { return "bool"; }
+        if (type == typeof(byte)) { return "byte"; }
+        if (type == typeof(sbyte)) { return "sbyte"; }
+        if (type == typeof(char)) { return "char"; }
+        if (type == typeof(short)) { return "short"; }
+        if (type == typeof(ushort)) { return "ushort"; }
+        if (type == typeof(int)) { return "int"; }
+        if (type == typeof(uint)) { return "uint"; }
+        if (type == typeof(long)) { return "long"; }
+        if (type == typeof(ulong)) { return "ulong"; }
+        if (type == typeof(nint)) { return "nint"; }
+        if (type == typeof(nuint)) { return "nuint"; }
+        if (type == typeof(float)) { return "float"; }
+        if (type == typeof(double)) { return "double"; }
+        if (type == typeof(decimal)) { return "decimal"; }
+        if (type == typeof(string)) { return "string"; }
+        if (type == typeof(object)) { return "object"; }
+
+        return type.Name;
+    }
+}

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -155,8 +155,8 @@ public class ProductionSummaryEntry(ProductionSummaryGroup owner) : ModelObject<
     }
 }
 
-public class ProductionSummaryColumn(ProductionSummary owner, IObjectWithQuality<Goods> goods) : ModelObject<ProductionSummary>(owner) {
-    public IObjectWithQuality<Goods> goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
+public class ProductionSummaryColumn(ProductionSummary owner, ObjectWithQuality<Goods> goods) : ModelObject<ProductionSummary>(owner) {
+    public ObjectWithQuality<Goods> goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
 }
 
 public class ProductionSummary : ProjectPageContents, IComparer<(IObjectWithQuality<Goods> goods, float amount)> {
@@ -169,7 +169,7 @@ public class ProductionSummary : ProjectPageContents, IComparer<(IObjectWithQual
     [SkipSerialization] public HashSet<IObjectWithQuality<Goods>> columnsExist { get; } = [];
 
     public override void InitNew() {
-        columns.Add(new ProductionSummaryColumn(this, Database.electricity));
+        columns.Add(new ProductionSummaryColumn(this, new(Database.electricity.target, Quality.Normal)));
         base.InitNew();
     }
 

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -78,7 +78,7 @@ public class RecipeRowCustomModule(ModuleTemplate owner, ObjectWithQuality<Modul
 /// The template that determines what modules are (or will be) applied to a <see cref="RecipeRow"/>.
 /// </summary>
 /// <remarks>Immutable. To modify, call <see cref="GetBuilder"/>, modify the builder, and call <see cref="ModuleTemplateBuilder.Build"/>.</remarks>
-[Serializable, DeserializeWithNonPublicConstructor]
+[DeserializeWithNonPublicConstructor]
 public class ModuleTemplate : ModelObject<ModelObject> {
     /// <summary>
     /// The beacon to use, if any, for the associated <see cref="RecipeRow"/>.

--- a/Yafc.Model/Yafc.Model.csproj
+++ b/Yafc.Model/Yafc.Model.csproj
@@ -7,10 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="Yafc.Model.Tests" />
       <PackageReference Include="Google.OrTools" Version="9.11.4210" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\Yafc.UI\Yafc.UI.csproj" />
     </ItemGroup>
 

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -266,7 +266,7 @@ public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
         }
 
         if (!found) {
-            model.columns.Add(new ProductionSummaryColumn(model, goods));
+            model.columns.Add(new ProductionSummaryColumn(model, new(goods.target, goods.quality)));
         }
     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,8 @@ Version:
 Date:
     Features:
         - Add related recipes to the Link Summary screen.
+    Fixes:
+        - (regression) Legacy summary pages could not be saved or loaded.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.8.1
 Date: February 20th 2025


### PR DESCRIPTION
As reported [in Discord](https://discord.com/channels/560199483065892894/1210135941700919296/1342927292254523574), the legacy summary page cannot be saved.

I broke the serialization rules, and I don't think it's the first time, so I also added some tests to watch the serializable types and complain when they change and/or are out of compliance.

`SerializationTreeChangeDetection.TreeHasNotChanged` might turn out to be too aggressive, but it seemed like a good idea.