### PR TITLE
fix: Incorrect quality bonuses/penalties from beacon modules.

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -16,7 +16,7 @@ public struct ModuleEffects {
     public readonly float speedMod => MathF.Max(1f + speed, 0.2f);
     public readonly float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
     public readonly float qualityMod => MathF.Max(quality, 0);
-    public void AddModules(ObjectWithQuality<Module> module, float count, AllowedEffects allowedEffects) {
+    public void AddModules(ObjectWithQuality<Module> module, float count, AllowedEffects allowedEffects = AllowedEffects.All) {
         ModuleSpecification spec = module.target.moduleSpecification;
         Quality quality = module.quality;
         if (allowedEffects.HasFlags(AllowedEffects.Speed)) {
@@ -32,21 +32,8 @@ public struct ModuleEffects {
         }
 
         if (allowedEffects.HasFlags(AllowedEffects.Quality)) {
-            this.quality += spec.Consumption(quality) * count;
+            this.quality += spec.Quality(quality) * count;
         }
-    }
-
-    public void AddModules(ObjectWithQuality<Module> module, float count) {
-        ModuleSpecification spec = module.target.moduleSpecification;
-        Quality quality = module.quality;
-        speed += spec.Speed(quality) * count;
-
-        if (spec.baseProductivity > 0f) {
-            productivity += spec.Productivity(quality) * count;
-        }
-
-        consumption += spec.Consumption(quality) * count;
-        this.quality += spec.Quality(quality) * count;
     }
 
     public readonly int GetModuleSoftLimit(ObjectWithQuality<Module> module, int hardLimit) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Add related recipes to the Link Summary screen.
     Fixes:
         - (regression) Legacy summary pages could not be saved or loaded.
+        - Quality bonuses/penalties in beacons were not handled correctly.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.8.1
 Date: February 20th 2025


### PR DESCRIPTION
As reported [on Discord](https://discord.com/channels/560199483065892894/1210135763422027837/1343188155515539457), speed modules in beacons mess up quality calculations.

This was a copy/paste and duplicated code issue; the erroneous method was only called once, while the working one was called in seven different places.