### PR TITLE
Load and display heating information

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -521,6 +521,7 @@ public class Entity : FactorioObject {
     internal List<Ammo> captureAmmo { get; } = [];
     internal List<Entity> sourceEntities { get; set; } = null!;
     internal string? autoplaceControl { get; set; }
+    public float heatingPower { get; internal set; }
     public int size { get; internal set; }
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Entities;
     public override string type => "Entity";

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -621,6 +621,8 @@ internal partial class FactorioDataDeserializer {
             fuelUsers.Add(entity, SpecialNames.Void);
         }
 
+        entity.heatingPower = ParseEnergy(table.Get<string>("heating_energy"));
+
         if (table.Get("production_health_effect", out LuaTable? healthEffect) && healthEffect.Get("not_producing", out float? lossPerTick)) {
             entity.baseSpoilTime = (float)(table.Get<float>("max_health") * -60 * lossPerTick.Value);
             table.Get<LuaTable>("dying_trigger_effect")?.ReadObjectOrArray(readDeathEffect);

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -198,7 +198,9 @@ public static class ImmediateWidgets {
     }
 
     internal static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, [NotNullWhen(true)] out T? selected, ObjectSelectOptions<T> options) where T : class, IFactorioObjectWrapper {
-        gui.BuildText(options.Header, Font.productionTableHeader);
+        if (options.Header != null) {
+            gui.BuildText(options.Header, Font.productionTableHeader);
+        }
         IEnumerable<T> sortedList = list;
 
         if (options.Ordering != DataUtils.AlreadySortedRecipe) {
@@ -460,7 +462,7 @@ public record DisplayAmount(float Value, UnitOfMeasure Unit = UnitOfMeasure.None
 /// <param name="Checkmark">If not <see langword="null"/>, this will be called to determine if a checkmark should be drawn on the item.
 /// Not used when selecting with a 'None' item or when <paramref name="Multiple"/> is <see langword="false"/>.</param>
 /// <param name="ExtraText">If not <see langword="null"/>, this will be called to get extra text to be displayed right-justified after the item's name.</param>
-public sealed record ObjectSelectOptions<T>(string Header, [AllowNull] IComparer<T> Ordering = null, int MaxCount = 6, bool Multiple = false, Predicate<T>? Checkmark = null,
+public sealed record ObjectSelectOptions<T>(string? Header, [AllowNull] IComparer<T> Ordering = null, int MaxCount = 6, bool Multiple = false, Predicate<T>? Checkmark = null,
     Func<T, string>? ExtraText = null) where T : IFactorioObjectWrapper {
 
     public IComparer<T> Ordering { get; init; } = Ordering ?? (IComparer<T>)DataUtils.DefaultOrdering;

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -317,6 +317,16 @@ doneDrawing:;
             }
         }
 
+        if (entity.heatingPower != 0) {
+            using (gui.EnterGroup(contentPadding))
+            using (gui.EnterRow(0)) {
+                gui.AllocateRect(0, 1.5f);
+                gui.BuildText($"Requires {DataUtils.FormatAmount(entity.heatingPower, UnitOfMeasure.Megawatt)}");
+                gui.BuildFactorioObjectIcon(Database.heat, IconDisplayStyle.Default with { Size = 1.5f });
+                gui.BuildText("heat on cold planets.");
+            }
+        }
+
         string? miscText = null;
 
         switch (entity) {

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -20,7 +20,7 @@ public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObje
     /// <param name="header">The string that describes to the user why they're selecting these items.</param>
     /// <param name="selectItem">An action to be called for each selected item when the panel is closed.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-    public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null, Predicate<T>? checkMark = null) where T : FactorioObject {
+    public static void Select<T>(IEnumerable<T> list, string? header, Action<T> selectItem, IComparer<T>? ordering = null, Predicate<T>? checkMark = null) where T : FactorioObject {
         SelectMultiObjectPanel panel = new(o => checkMark?.Invoke((T)o) ?? false); // This casting is messy, but pushing T all the way around the call stack and type tree was messier.
         panel.Select(list, header, selectItem!, ordering, (objs, mappedAction) => { // null-forgiving: selectItem will not be called with null, because allowNone is false.
             foreach (var obj in objs!) { // null-forgiving: mapResult will not be called with null, because allowNone is false.

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -13,7 +13,7 @@ namespace Yafc;
 /// <typeparam name="T">The type of result the panel can generate.</typeparam>
 public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
     private readonly SearchableList<FactorioObject?> list;
-    private string header = null!; // null-forgiving: set by Select
+    private string? header;
     private Rect searchBox;
     private string? noneTooltip;
     private Quality? currentQuality;
@@ -25,7 +25,7 @@ public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
 
     protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject?>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
 
-    protected void SelectWithQuality<U>(IEnumerable<U> list, string header, Action<ObjectWithQuality<U>?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult,
+    protected void SelectWithQuality<U>(IEnumerable<U> list, string? header, Action<ObjectWithQuality<U>?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult,
         bool allowNone, string? noneTooltip, Quality? currentQuality) where U : FactorioObject
         => Select(list, header, u => selectItem((u, this.currentQuality!)), ordering, mapResult, allowNone, noneTooltip, currentQuality ?? Quality.Normal);
 
@@ -44,7 +44,7 @@ public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
     /// <param name="allowNone">If <see langword="true"/>, a "none" option will be displayed. Selection of this item will be conveyed by calling <paramref name="mapResult"/>
     /// and <paramref name="selectItem"/> with <see langword="default"/> values for <typeparamref name="T"/> and <typeparamref name="U"/>.</param>
     /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
-    protected void Select<U>(IEnumerable<U> list, string header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone,
+    protected void Select<U>(IEnumerable<U> list, string? header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone,
         string? noneTooltip = null, Quality? currentQuality = null) where U : FactorioObject {
 
         _ = MainScreen.Instance.ShowPseudoScreen(this);

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -19,7 +19,7 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// <param name="header">The string that describes to the user why they're selecting these items.</param>
     /// <param name="selectItem">An action to be called for the selected item when the panel is closed.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-    public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
+    public static void Select<T>(IEnumerable<T> list, string? header, Action<T> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
         // null-forgiving: selectItem will not be called with null, because allowNone is false.
         => Instance.Select(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false);
 
@@ -47,7 +47,7 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
     /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
-    public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
+    public static void SelectWithNone<T>(IEnumerable<T> list, string? header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
         => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
 
     /// <summary>
@@ -60,7 +60,7 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
     /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
-    public static void SelectQualityWithNone<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>?> selectItem, Quality? currentQuality, IComparer<T>? ordering = null,
+    public static void SelectQualityWithNone<T>(IEnumerable<T> list, string? header, Action<ObjectWithQuality<T>?> selectItem, Quality? currentQuality, IComparer<T>? ordering = null,
         string? noneTooltip = null) where T : FactorioObject
         => Instance.SelectWithQuality(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip, currentQuality);
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,10 @@
 //         Bugfixes go there.
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
+Version:
+Date:
+    Features:
+        - (SA) Calculate the required heating and show it in tooltips and the shopping list.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.9.0
 Date: February 24th 2025


### PR DESCRIPTION
This loads and displays heat required on cold planets, provided it's non-zero. The new line in the tooltip and both lines in the shopping list will not appear if they would display zero.

![image](https://github.com/user-attachments/assets/29ef9952-fd90-4617-80e7-451e73c0493e)

![image](https://github.com/user-attachments/assets/297bf829-1a11-4ee5-b4ca-3bc3e88e7531)
The four links in the bottom line each pop up a list containing the described items; "other entities" are things likes radars, beacons, turrets, and roboports.

I'd like it to be more visible, but I'm not ready to tackle the task of making planet-specific tables or figuring out how the heat demand should integrate with the solver.