### PR TITLE
Feat: add checkbox if recipe is on the page

### DIFF
--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -219,6 +219,9 @@ public static class ImmediateWidgets {
             if (gui.isBuilding && (options.Checkmark?.Invoke(elem) ?? false)) {
                 gui.DrawIcon(Rect.Square(gui.lastRect.Right - 1f, gui.lastRect.Center.Y, 1.5f), Icon.Check, SchemeColor.Green);
             }
+            else if (gui.isBuilding && (options.YellowMark?.Invoke(elem) ?? false)) {
+                gui.DrawIcon(Rect.Square(gui.lastRect.Right - 1f, gui.lastRect.Center.Y, 1.5f), Icon.Check, SchemeColor.TagColorYellowText);
+            }
         }
 
         return selected != null;
@@ -235,7 +238,7 @@ public static class ImmediateWidgets {
 
             if (list.Count > options.MaxCount && gui.BuildButton("See full list") && gui.CloseDropdown()) {
                 if (options.Multiple) {
-                    SelectMultiObjectPanel.Select(list, options.Header, selectItem, options.Ordering, options.Checkmark);
+                    SelectMultiObjectPanel.Select(list, options.Header, selectItem, options.Ordering, options.Checkmark, options.YellowMark);
                 }
                 else {
                     SelectSingleObjectPanel.Select(list, options.Header, selectItem, options.Ordering);
@@ -461,9 +464,10 @@ public record DisplayAmount(float Value, UnitOfMeasure Unit = UnitOfMeasure.None
 /// Not used (treated as <see langword="false"/>) when selecting with a 'None' item.</param>
 /// <param name="Checkmark">If not <see langword="null"/>, this will be called to determine if a checkmark should be drawn on the item.
 /// Not used when selecting with a 'None' item or when <paramref name="Multiple"/> is <see langword="false"/>.</param>
+/// <param name="YellowMark">If Checkmark is not set, draw a less distinct checkmark instead.</param>
 /// <param name="ExtraText">If not <see langword="null"/>, this will be called to get extra text to be displayed right-justified after the item's name.</param>
 public sealed record ObjectSelectOptions<T>(string? Header, [AllowNull] IComparer<T> Ordering = null, int MaxCount = 6, bool Multiple = false, Predicate<T>? Checkmark = null,
-    Func<T, string>? ExtraText = null) where T : IFactorioObjectWrapper {
+    Predicate<T>? YellowMark = null, Func<T, string>? ExtraText = null) where T : IFactorioObjectWrapper {
 
     public IComparer<T> Ordering { get; init; } = Ordering ?? (IComparer<T>)DataUtils.DefaultOrdering;
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Open the preferences or milestones when you click on the icon for the reactor or quality warning messages.
         - Implemented Auto Save.
         - (SA) Research recipes correctly consume quality science packs, and the UI explains this.
+        - Added marker to recipes already used on the current page.
     Fixes:
         - Fix export of blueprint chests from shopping list (broken in factorio >= 2.0.35)
         - (regression) The total sushi-input/-output items display belt counts again, and allow them as input.


### PR DESCRIPTION
This adds a (yellow) checkbox to recipes already added to the sheet, but not part of the current sub-table (those are already marked with a greencheckbx).

![afbeelding](https://github.com/user-attachments/assets/ceaeb50c-a991-4cc6-827a-4eb1b59e55e6)

Also works for the see full list:
![afbeelding](https://github.com/user-attachments/assets/77fad4cb-bf63-4025-a732-cc6463a59517)


A list of nice-to-have things:
* [x] A changelog entry.
* The link from the PR to the issue that it fixes. -> This Pr describes the function.
* A description of what testing was done. -> Tried various recipe combinations, including recipes part of parent nodes, sibling nodes, also green checkbox should always override yellow.
