### PR TITLE
Restore belt counts on the virtual I and O sushi items

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -817,6 +817,9 @@ public interface IObjectWithQuality<out T> : IFactorioObjectWrapper where T : Fa
 /// <param name="quality">The quality for this object.</param>
 [Serializable]
 public sealed class ObjectWithQuality<T>(T target, Quality quality) : IObjectWithQuality<T>, ICustomJsonDeserializer<ObjectWithQuality<T>> where T : FactorioObject {
+    // These items do not support quality:
+    private static readonly HashSet<string> nonQualityItemNames = ["science", "item-total-input", "item-total-output"];
+
     /// <inheritdoc/>
     public T target { get; } = target ?? throw new ArgumentNullException(nameof(target));
     /// <inheritdoc/>
@@ -826,9 +829,9 @@ public sealed class ObjectWithQuality<T>(T target, Quality quality) : IObjectWit
         // Things that don't support quality:
         Fluid or Location or Mechanics { source: Entity } or Quality or Special or Technology or Tile => Quality.Normal,
         Recipe r when r.ingredients.All(i => i.goods is Fluid) => Quality.Normal,
-        // Everything else supports quality (except science):
-        // null-checking: Database.science is null when constructing the object that is stored in Database.science.
-        _ => target == Database.science?.target ? Quality.Normal : quality
+        // Most other things support quality, but a few items are excluded:
+        Item when nonQualityItemNames.Contains(target.name) => Quality.Normal,
+        _ => quality
     };
 
     /// <summary>

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -29,8 +29,8 @@ internal partial class FactorioDataDeserializer {
     private readonly Special electricity;
     private readonly Special rocketLaunch;
     private readonly Item science;
-    private readonly Special totalItemOutput;
-    private readonly Special totalItemInput;
+    // Note: These must be Items (or possibly a derived type) so belt capacity can be displayed and set.
+    private readonly Item totalItemOutput, totalItemInput;
     private readonly EntityEnergy voidEntityEnergy;
     private readonly EntityEnergy laborEntityEnergy;
     private Entity? character;
@@ -43,7 +43,7 @@ internal partial class FactorioDataDeserializer {
     public FactorioDataDeserializer(Version factorioVersion) {
         this.factorioVersion = factorioVersion;
 
-        Special createSpecialObject(bool isPower, bool isUsable, string name, string locName, string locDescr, string icon, string? signal) {
+        Special createSpecialObject(bool isPower, string name, string locName, string locDescr, string icon, string signal) {
             var obj = GetObject<Special>(name);
             obj.virtualSignal = signal;
             obj.factorioType = "special";
@@ -55,23 +55,35 @@ internal partial class FactorioDataDeserializer {
                 obj.fuelValue = 1f;
                 fuels.Add(name, obj);
             }
-            obj.isLinkable = isUsable;
-            obj.showInExplorers = isUsable;
-            if (!isUsable) {
-                rootAccessible.Add(obj);
-            }
+
             return obj;
         }
 
-        electricity = createSpecialObject(true, true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
+        Item createSpecialItem(string name, string locName, string locDescr, string icon) {
+            Item obj = GetObject<Item>(name);
+            obj.factorioType = "special";
+            obj.locName = locName;
+            obj.locDescr = locDescr;
+            obj.iconSpec = [new FactorioIconPart(icon)];
+            obj.isLinkable = false;
+            obj.showInExplorers = false;
+            rootAccessible.Add(obj);
+
+            return obj;
+        }
+
+        electricity = createSpecialObject(true, SpecialNames.Electricity, "Electricity", "This is an object that represents electric energy",
             "__core__/graphics/icons/alerts/electricity-icon-unplugged.png", "signal-E");
 
-        heat = createSpecialObject(true, true, SpecialNames.Heat, "Heat", "This is an object that represents heat energy", "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
+        heat = createSpecialObject(true, SpecialNames.Heat, "Heat", "This is an object that represents heat energy", "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
 
-        voidEnergy = createSpecialObject(true, false, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
+        voidEnergy = createSpecialObject(true, SpecialNames.Void, "Void", "This is an object that represents infinite energy", "__core__/graphics/icons/mip/infinity.png", "signal-V");
         voidEnergy.isVoid = true;
+        voidEnergy.isLinkable = false;
+        voidEnergy.showInExplorers = false;
+        rootAccessible.Add(voidEnergy);
 
-        rocketLaunch = createSpecialObject(false, true, SpecialNames.RocketLaunch, "Rocket launch slot",
+        rocketLaunch = createSpecialObject(false, SpecialNames.RocketLaunch, "Rocket launch slot",
             "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/rocket-static-pod.png", "signal-R");
 
         science = GetObject<Item>("science");
@@ -92,10 +104,11 @@ internal partial class FactorioDataDeserializer {
         voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
         laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
 
-        totalItemInput = createSpecialObject(false, false, "total-item-input", "Total item consumption", "This item represents the combined total item input of a multi-ingredient recipe. It can be used to set or measure the number of sushi belts required to supply this recipe row.", "__base__/graphics/icons/signal/signal_I.png", null);
-        totalItemOutput = createSpecialObject(false, false, "total-item-output", "Total item production", "This item represents the combined total item output of a multi-product recipe. It can be used to set or measure the number of sushi belts required to handle the products of this recipe row.", "__base__/graphics/icons/signal/signal_O.png", null);
-        formerAliases["Item.item-total-input"] = totalItemInput;
-        formerAliases["Item.item-total-output"] = totalItemOutput;
+        // Note: These must be Items (or possibly a derived type) so belt capacity can be displayed and set.
+        totalItemInput = createSpecialItem("item-total-input", "Total item consumption", "This item represents the combined total item input of a multi-ingredient recipe. It can be used to set or measure the number of sushi belts required to supply this recipe row.", "__base__/graphics/icons/signal/signal_I.png");
+        totalItemOutput = createSpecialItem("item-total-output", "Total item production", "This item represents the combined total item output of a multi-product recipe. It can be used to set or measure the number of sushi belts required to handle the products of this recipe row.", "__base__/graphics/icons/signal/signal_O.png");
+        formerAliases["Special.total-item-input"] = totalItemInput;
+        formerAliases["Special.total-item-output"] = totalItemOutput;
     }
 
     /// <summary>

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,7 +21,9 @@ Date:
         - Open the preferences or milestones when you click on the icon for the reactor or quality warning messages.
         - Implemented Auto Save.
         - (SA) Research recipes correctly consume quality science packs, and the UI explains this.
+    Fixes:
         - Fix export of blueprint chests from shopping list (broken in factorio >= 2.0.35)
+        - (regression) The total sushi-input/-output items display belt counts again, and allow them as input.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.10.0
 Date: March 5th 2025


### PR DESCRIPTION
The virtual I and O items have to be `Item`s so belt and inserter information will be displayed, and so amounts (both fixed and calculated) can be expressed in belts.
![image](https://github.com/user-attachments/assets/9d6db986-743d-466d-ae98-43c0b22fc02b)

This makes them Items again (reverting b0aa6b7), and adds some comments that will hopefully prevent anyone else from making this mistake again.