### PR TITLE
Fix #441 incorrect spent fuel amounts

### DIFF
--- a/Yafc.Model.Tests/LuaDependentTestHelper.cs
+++ b/Yafc.Model.Tests/LuaDependentTestHelper.cs
@@ -88,7 +88,7 @@ internal static class LuaDependentTestHelper {
         DataUtils.SetupForProject(project);
         project.undo.Suspend(); // The undo system relies on SDL.
 
-        return project;
+        return Project.current = project;
     }
 
     // Get the stream named either "Yafc.Model.Tests.TestClass.TestMethod.lua" (primary) or "Yafc.Model.Tests.TestClass.lua" (secondary)

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.lua
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.lua
@@ -303,6 +303,30 @@ data = {
           { type = "item", name = "ash", amount = 3 },
         },
       },
+      recipe2 = {
+        type = "recipe",
+        name = "recipe2",
+        ingredients = {
+          { type = "item", name = "dummy_1", amount = 5 },
+          { type = "item", name = "dummy_2", amount = 10 },
+        },
+        energy_required = 5,
+        results = {
+          { type = "item", name = "dummy_3", amount = 5 },
+        },
+      },
+    },
+    quality = {
+      normal = {
+        name = "normal",
+        type = "quality",
+        level = 0,
+      },
+      uncommon = {
+        name = "uncommon",
+        type = "quality",
+        level = 1,
+      },
     },
   },
 }

--- a/Yafc.Model.Tests/TestHelpers.cs
+++ b/Yafc.Model.Tests/TestHelpers.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Yafc.Model.Tests;
+
+internal static class TestHelpers {
+    /// <summary>
+    /// Produces the <see cref="IObjectWithQuality{T}"/>s corresponding to each pair of 'input value' and 'defined quality'.
+    /// </summary>
+    /// <typeparam name="T">The type of the input objects. Must be <see cref="FactorioObject"/> or one of its subclasses.</typeparam>
+    /// <param name="values">The sequence of values that should have qualities applied to them.</param>
+    /// <returns>The cartesian product of <paramref name="values"/> and the members of <see cref="Database.qualities"/>.</returns>
+    public static IEnumerable<ObjectWithQuality<T>> WithAllQualities<T>(this IEnumerable<T> values) where T : FactorioObject
+        => values.SelectMany(c => Database.qualities.all.Select(q => c.With(q))).Distinct();
+}

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -567,7 +567,7 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
 
         if (!handledFuel) {
             // null-forgiving: handledFuel is always true if spentFuel is null.
-            yield return (new(spentFuel!.target, spentFuel.quality), parameters.fuelUsagePerSecondPerRecipe, links.spentFuel, 0, null);
+            yield return (new(spentFuel!.target, spentFuel.quality), parameters.fuelUsagePerSecondPerRecipe * factor, links.spentFuel, 0, null);
         }
     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date:
     Fixes:
         - Fix export of blueprint chests from shopping list (broken in factorio >= 2.0.35)
         - (regression) The total sushi-input/-output items display belt counts again, and allow them as input.
+        - (regression) Spent fuel amounts could be displayed with wrong value.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.10.0
 Date: March 5th 2025


### PR DESCRIPTION
This fixes #441; the spent fuel amount was displayed incorrectly when it was not also a recipe product.

I also added a new test for this; it should catch any situation where the solver and the UI use unexpectedly different values in the future. The test also verifies the case where the values are expected to be different: When the spent fuel is also a recipe product, the solver handles them independently, but the UI displays the sum.