### PR TITLE
Adjust quality object serialization and document serialization

### DIFF
--- a/Docs/Architecture/Serialization.md
+++ b/Docs/Architecture/Serialization.md
@@ -27,7 +27,7 @@ Properties are handled as described here:
 |Other types|Error|Ignored|
 
 Notes:
-* The constructor must initialize non-writable serialized properties to a non-`null` value.
+* The constructor must initialize serialized collections to a non-`null` value.
 The property may be declared to return any type that matches the _Property type_ column above.
 * Value types are only supported if they appear in the list of [supported native types](#native-types).
 * `[Obsolete]` properties must follow all the same rules, except that they do not need a getter if they are writable.
@@ -47,7 +47,9 @@ Parameters may match either directly owned properties or properties inherited fr
 
 Writable properties that are not one of the supported types must have the `[SkipSerialization]` attribute.
 
-Non-writable serialized properties must be initialized by the constructor to a non-`null` value.
+Collection properties (always non-writable) must be initialized by the constructor to a non-`null` value.
+The constructor is not required to initialize non-writable `ModelObject` properties.
+If it does not, the serialization system will discard non-`null` values encountered in the project file.
 
 ### Collections
 Collection values must be stored in non-writable properties, must not be passed to the constructor, and must be initialized to an empty collection.

--- a/Docs/Architecture/Serialization.md
+++ b/Docs/Architecture/Serialization.md
@@ -42,6 +42,8 @@ The constructor may have any number of parameters, subject to the following limi
 It must be present, must be of type `T`, and can have any name.
 * Each (other) parameter must have the same type and name as one of the class's writable properties.
 Parameters may match either directly owned properties or properties inherited from a base class.
+* If the parameter has a default value, that value must be `default`.
+(Or an equivalent: e.g. `null` for reference types and `Nullable<>`, `0` for numeric types, and/or `new()` for value types without a explicit 0-parameter constructor.)
 
 Writable properties that are not one of the supported types must have the `[SkipSerialization]` attribute.
 

--- a/Docs/Architecture/Serialization.md
+++ b/Docs/Architecture/Serialization.md
@@ -1,0 +1,148 @@
+# Serialization system
+The project serialization system is somewhat fragile.
+It adapts properly to many changes, but can also fail silently.
+To reduce the chances of silent failures, it has some [guardrails in the tests](#guarding-tests), to ensure any relevant changes are intentional and functional.
+
+The serialization system only deals with public instance properties.
+Broadly, there are two kinds of public properties, which we'll call 'writable' and 'non-writable'.
+A writable property has a public setter, a constructor parameter with the same name and type, or both.
+Any other public property is non-writable.
+`[Obsolete]` writable properties may (and usually should) omit the getter.
+
+All constructor parameters, except for the first parameter when derived from `ModelObject<>`, must have the same name and type as a writable property.
+
+## Property types
+The primary data structures that get serialized and deserialized are types derived from `ModelOject` and concrete (non-abstract) classes with the `[Serializable]` attribute.
+These are serialized property-by-property, recursively.
+Properties are handled as described here:
+
+|Property type|Writable|Non-writable|
+|-|-|-|
+|[`ModelObject` and derived types](#modelobjects-and-serializable-types)|Supported if concrete|Supported|
+|[`[Serializable]` classes](#modelobjects-and-serializable-types)|Supported if concrete|Ignored|
+|[`ReadOnlyCollection<>` and types that implement `ICollection<>` or `IDictionary<,>`](#collections)|Error|Supported if content is supported|
+|[`FactorioOject`, all derived types, and `IObjectWithQuality<>`s](#factorioobjects-and-iobjectwithqualitys)|Supported, even when abstract|Ignored|
+|[Native and native-like types](#native-types)|Supported if listed|Ignored|
+|Any type, if the property has `[SkipSerialization]`|Ignored|Ignored|
+|Other types|Error|Ignored|
+
+Notes:
+* The constructor must initialize non-writable serialized properties to a non-`null` value.
+The property may be declared to return any type that matches the _Property type_ column above.
+* Value types are only supported if they appear in the list of [supported native types](#native-types).
+* `[Obsolete]` properties must follow all the same rules, except that they do not need a getter if they are writable.
+
+### `ModelObject`s and `[Serializable]` types
+Each class should have exactly one public constructor.
+If the class has multiple public constructors, the serialization system will use the first, for whatever definition of "first" the compiler happens to use.\
+**Exception**: If the class has the `[DeserializeWithNonPublicConstructor]` attribute, it should have exactly one non-public constructor instead.
+
+The constructor may have any number of parameters, subject to the following limitations:
+* The first constructor parameter for a type derived (directly or indirectly) from `ModelObject<T>` does not follow the normal rules.
+It must be present, must be of type `T`, and can have any name.
+* Each (other) parameter must have the same type and name as one of the class's writable properties.
+Parameters may match either directly owned properties or properties inherited from a base class.
+
+Writable properties that are not one of the supported types must have the `[SkipSerialization]` attribute.
+
+Non-writable serialized properties must be initialized by the constructor to a non-`null` value.
+
+### Collections
+Collection values must be stored in non-writable properties, must not be passed to the constructor, and must be initialized to an empty collection.
+Unsupported keys or values will cause the property to be silently ignored.
+Arrays and other fixed-size collections (of supported values) will cause an error when deserializing, even though they implement `ICollection<>`.
+
+Keys (for dictionaries) must be: `FactorioObject` or derived from it, `IObjectWithQuality<>`, `string`, `Guid`, or `Type`.
+
+Values may be of any type that can be stored in a writable property.
+Explicitly, values are allowed to contain collections, but may not themselves be collections.
+
+The serializer has special magic allowing it to modify a `ReadOnlyCollection<>`.
+Initialize the `ReadOnlyCollection<>` to `new([])`, and the serializer will populate it correctly.
+
+### `FactorioObject`s and `IObjectWithQuality<>`s
+When deserialized, `FactorioObject`s are set to the corresponding object from `Database.allObjects`.
+If that object cannot be found (for example, if the mod defining it was removed), it will be set to `null`.
+Properties may return `FactorioObject` or any derived type, even if the type is abstract.
+
+`IObjectWithQuality<>`s are the same, except that the object is fetched by calling `ObjectWithQuality.Get`.
+
+### Native types
+The supported native and native-like types are `int`, `float`, `bool`, `ulong`, `string`, `Type`, `Guid`, `PageReference`, and `enum`s (if backed by `int`).
+The `Nullable<>` versions of these types are also supported, where applicable.
+
+Any value types not listed above, including `Tuple`, `ValueTuple`, and all custom `struct`s, cannot be serialized/deserialized.
+
+## Guarding tests
+There are some "unit" tests guarding the types that are processed by the serialization system.
+These tests inspect things the serialization system is likely to encounter in the wild, and ensure that they comply with the rules given under [Property types](#property-types).
+They also check for changes to the serialized data, to ensure that any changes are intentional.
+
+The failure messages should tell you exactly why the test is unhappy.
+In general, the tests failures have the following meanings:
+* If [`ModelObjects_AreSerializable`](../../Yafc.Model.Tests/Serialization/SerializationTypeValidation.cs) fails, it thinks you violated one of [the rules](#modelobjects-and-serializable-types) in a type derived from `ModelObject`.
+* If [`Serializables_AreSerializable`](../../Yafc.Model.Tests/Serialization/SerializationTypeValidation.cs) fails, it thinks you violated one of [the rules](#modelobjects-and-serializable-types) in a `[Serializable]` type.
+* If [`TreeHasNotChanged`](../../Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs) fails, you have added, changed, or removed serialized types or properties.
+  * Ensure the change was intentional and does not break serialization (e.g. changing between `List<>` and `ReadOnlyCollection<>`) or that you have handled the necessary conversions (e.g. for changing from `FactorioObject` to `List<FactorioObject>`).
+Then update the dictionary initializer to match your changes.
+If you made significant changes, you should be able to run `BuildPropertyTree` in the debugger to produce the initializer that the test expects.
+* If you intended to add a new property to be serialized, but `TreeHasNotChanged` does not fail, the new property probably fell into one of the ["Ignored" categories](#property-types).
+* If you intended to add a new `[Serializable]` type to be serialized, but `TreeHasNotChanged` does not fail, make sure there is a writable property of that type.
+
+Test failures are usually related to writable properties.
+Non-writable properties that return array types will also cause test failures.
+
+## Handling property type changes
+The simplest solution is probably introducing a new property and applying `[Obsolete]` to the old property.
+The json deserializer will continue reading the corresponding  values from the project file, if present,
+but the undo system and the json serializer will ignore the old property.
+You may (should?) remove the getter from an obsolete writable property.
+
+Sometimes obsoleting a property is not reasonable, as was the case for the changes from `FactorioObject` to `ObjectWithQuality<>`.
+Depending on the requirements, you can either implement `ICustomJsonDeserializer<T>` (as used by `ObjectWithQuality<T>` in [081e9c0f](https://github.com/shpaass/yafc-ce/tree/081e9c0f6b47e155fbc82763590a70d90a64c83c/Yafc.Model/Data/DataClasses.cs#L819) and earlier),
+or create a new `ValueSerializer<T>` (as seen in the current `QualityObjectSerializer<T>` implementation).
+
+## Adding new supported types
+Consider workarounds such as using `List<NestedList<T>>` instead of `List<List<T>>`, where
+```c#
+[Serializable]
+public sealed class NestedList<T> : IEnumerable<T> /* do not implement ICollection<> or IList<> */ {
+    public List<T> List { get; } = [];
+    public IEnumerator<T> GetEnumerator() => List.GetEnumerator();
+}
+```
+
+### Writable properties and collection values
+If the type is already part of Yafc, you may be able to support it simply by adding `[Serializable]` to the type in question.
+If that isn't adequate, implement a new class derived from `ValueSerializer<T>`.
+The new type should be generic if the serialized type is generic or a type hierarchy.
+Add checks for your newly supported type(s) in `IsValueSerializerSupported` and `CreateValueSerializer`.
+
+The tests should automatically update themselves for newly supported types in writable properties and collections.
+
+### Dictionary keys
+Find the corresponding `ValueSerializer<T>` implementation, or create a new one as described in the previous section.
+Add an override for `GetJsonProperty`, to convert the value to a string.
+If `ReadFromJson` does not support reading from a `JsonTokenType.PropertyName`, update it to do so, or override `ReadFromJsonProperty`.
+In either case, return the desired object by reading the property name.
+Add a check for the newly supported type in `IsKeySerializerSupported`.
+
+The tests should automatically update themselves for newly supported types in dictionary keys.
+
+### Non-writable properties
+To add support for a new type in a non-writable property, implement a new
+```c#
+internal sealed class NewReadOnlyPropertySerializer<TOwner, TPropertyType[, TOtherTypes]>(PropertyInfo property)
+    where TPropertyType : NewPropertyType[<TOtherTypes>] where TOwner : class
+    : PropertySerializer<TOwner, TPropertyType>(property, PropertyType.Normal, false)
+```
+Include `TOtherTypes` if the newly supported  type is generic.
+Serialize nested objects using `ValueSerializer<TOtherType>.Default`, to ensure that newly introduced `ValueSerializer<T>` implementations are supported by your collection.
+
+If your newly supported type is an interface, add a check for the interface type in `GetInterfaceSerializer`.
+
+If your newly supported type is a class, find the two calls to `GetInterfaceSerializer`.
+In the outer else block, add another check for your newly supported type.
+
+Changes to non-writable property support may require changes to `SerializationTypeValidation` in the vicinity of the calls to `AssertNoArraysOfSerializableValues`,
+and will require changes to `TreeHasNotChanged` in the vicinity of the `typeof(ReadOnlyCollection<>)`, `typeof(IDictionary<,>)` and/or `typeof(ICollection<>)` tests.

--- a/Docs/CodeStyle.md
+++ b/Docs/CodeStyle.md
@@ -74,22 +74,3 @@ Most of the operators like `.` `+` `&&` go to the next line.
 The notable operators that stay on the same line are `=>`, `=> {`, and `,`.
 
 The wrapping of arguments in constructors and method-definitions is up to you.
-
-# Quality Implementation
-Despite several attempts, the implementation of quality levels is unpleasantly twisted.
-Here are some guidelines to keep handling of quality levels from causing additional problems:
-* **Serialization**
-  * All serialized values (public properties of `ModelObject`s and `[Serializable]` classes) must be a suitable concrete type.
-  (That is, `ObjectWithQuality<T>`, not `IObjectWithQuality<T>`)
-* **Equality**
-  * Where `==` operators are expected/used, prefer the concrete type.
-  The `==` operator will silently revert to reference equality if both sides of are the interface type.
-  * On the other hand, the `==` operator will fail to compile if the two sides are distinct concrete types.
-  Use `.As<type>()` to convert one side to the interface type.
-  * Types that call `Object.Equals`, such as `Dictionary` and `HashSet`, will behave correctly on both the interface and concrete types.
-  The interface type may be more convenient for things like dictionary keys or hashset values.
-* **Conversion**
-  * There is a conversion from `(T?, Quality)` to `ObjectWithQuality<T>?`, where a null input will return a null result.
-  If the input is definitely not null, use the constructor instead.
-  C# prohibits conversions to or from interface types.
-  * The interface types are covariant; an `IObjectWithQuality<Item>` may be used as an `IObjectWithQuality<Goods>` in the same way that an `Item` may be used as a `Goods`.

--- a/Yafc.Model.Tests/Model/ProductionTableTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.cs
@@ -15,7 +15,7 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal), DataUtils.DeterministicComparer);
 
         ErrorCollector collector = new();
         using MemoryStream stream = new();
@@ -33,7 +33,7 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
         row.subgroup = new ProductionTable(row);
 
@@ -53,10 +53,10 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
         row.subgroup = new ProductionTable(row);
-        row.subgroup.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
+        row.subgroup.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal), DataUtils.DeterministicComparer);
 
         ErrorCollector collector = new();
         using MemoryStream stream = new();
@@ -74,7 +74,7 @@ public class ProductionTableTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe((Database.recipes.all.Single(r => r.name == "recipe"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
         row.subgroup = new ProductionTable(row);
 

--- a/Yafc.Model.Tests/Model/RecipeParametersTests.cs
+++ b/Yafc.Model.Tests/Model/RecipeParametersTests.cs
@@ -14,8 +14,8 @@ public class RecipeParametersTests {
         ProjectPage page = new(project, typeof(ProductionTable));
         project.pages.Add(page);
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "boiler.boiler.steam"), Quality.Normal), DataUtils.DeterministicComparer);
-        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "boiler.heat-exchanger.steam"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "boiler.boiler.steam").With(Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "boiler.heat-exchanger.steam").With(Quality.Normal), DataUtils.DeterministicComparer);
 
         List<Fluid> water = Database.fluidVariants["Fluid.water"];
 

--- a/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
+++ b/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
@@ -12,7 +12,7 @@ public class SelectableVariantsTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "generator.electricity"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "generator.electricity").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         // Solve is not necessary in this test, but I'm calling it in case we decide to hide the fuel on disabled recipes.
@@ -31,7 +31,7 @@ public class SelectableVariantsTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe(new(Database.recipes.all.Single(r => r.name == "generator.electricity"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "generator.electricity").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         // Solve is not necessary in this test, but I'm calling it in case we decide to hide the fuel on disabled recipes.
@@ -49,7 +49,7 @@ public class SelectableVariantsTests {
 
         ProjectPage page = new ProjectPage(project, typeof(ProductionTable));
         ProductionTable table = (ProductionTable)page.content;
-        table.AddRecipe((Database.recipes.all.Single(r => r.name == "steam_void"), Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(Database.recipes.all.Single(r => r.name == "steam_void").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
 
         // Solve is necessary here: Disabled recipes have null ingredients (and products), and Solve is the call that updates hierarchyEnabled.

--- a/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
@@ -18,9 +18,9 @@ public class SerializationTreeChangeDetection {
         [typeof(ModuleFillerParameters)] = new() {
             [nameof(ModuleFillerParameters.fillMiners)] = typeof(bool),
             [nameof(ModuleFillerParameters.autoFillPayback)] = typeof(float),
-            [nameof(ModuleFillerParameters.fillerModule)] = typeof(ObjectWithQuality<Module>),
-            [nameof(ModuleFillerParameters.beacon)] = typeof(ObjectWithQuality<EntityBeacon>),
-            [nameof(ModuleFillerParameters.beaconModule)] = typeof(ObjectWithQuality<Module>),
+            [nameof(ModuleFillerParameters.fillerModule)] = typeof(IObjectWithQuality<Module>),
+            [nameof(ModuleFillerParameters.beacon)] = typeof(IObjectWithQuality<EntityBeacon>),
+            [nameof(ModuleFillerParameters.beaconModule)] = typeof(IObjectWithQuality<Module>),
             [nameof(ModuleFillerParameters.beaconsPerBuilding)] = typeof(int),
             [nameof(ModuleFillerParameters.overrideCrafterBeacons)] = typeof(OverrideCrafterBeacons),
         },
@@ -35,7 +35,7 @@ public class SerializationTreeChangeDetection {
             [nameof(ProductionSummaryEntry.subgroup)] = typeof(ProductionSummaryGroup),
         },
         [typeof(ProductionSummaryColumn)] = new() {
-            [nameof(ProductionSummaryColumn.goods)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(ProductionSummaryColumn.goods)] = typeof(IObjectWithQuality<Goods>),
         },
         [typeof(ProductionSummary)] = new() {
             [nameof(ProductionSummary.group)] = typeof(ProductionSummaryGroup),
@@ -48,22 +48,22 @@ public class SerializationTreeChangeDetection {
             [nameof(ProductionTable.modules)] = typeof(ModuleFillerParameters),
         },
         [typeof(RecipeRowCustomModule)] = new() {
-            [nameof(RecipeRowCustomModule.module)] = typeof(ObjectWithQuality<Module>),
+            [nameof(RecipeRowCustomModule.module)] = typeof(IObjectWithQuality<Module>),
             [nameof(RecipeRowCustomModule.fixedCount)] = typeof(int),
         },
         [typeof(ModuleTemplate)] = new() {
-            [nameof(ModuleTemplate.beacon)] = typeof(ObjectWithQuality<EntityBeacon>),
+            [nameof(ModuleTemplate.beacon)] = typeof(IObjectWithQuality<EntityBeacon>),
             [nameof(ModuleTemplate.list)] = typeof(ReadOnlyCollection<RecipeRowCustomModule>),
             [nameof(ModuleTemplate.beaconList)] = typeof(ReadOnlyCollection<RecipeRowCustomModule>),
         },
         [typeof(RecipeRow)] = new() {
-            [nameof(RecipeRow.recipe)] = typeof(ObjectWithQuality<RecipeOrTechnology>),
-            [nameof(RecipeRow.entity)] = typeof(ObjectWithQuality<EntityCrafter>),
-            [nameof(RecipeRow.fuel)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(RecipeRow.recipe)] = typeof(IObjectWithQuality<RecipeOrTechnology>),
+            [nameof(RecipeRow.entity)] = typeof(IObjectWithQuality<EntityCrafter>),
+            [nameof(RecipeRow.fuel)] = typeof(IObjectWithQuality<Goods>),
             [nameof(RecipeRow.fixedBuildings)] = typeof(float),
             [nameof(RecipeRow.fixedFuel)] = typeof(bool),
-            [nameof(RecipeRow.fixedIngredient)] = typeof(ObjectWithQuality<Goods>),
-            [nameof(RecipeRow.fixedProduct)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(RecipeRow.fixedIngredient)] = typeof(IObjectWithQuality<Goods>),
+            [nameof(RecipeRow.fixedProduct)] = typeof(IObjectWithQuality<Goods>),
             [nameof(RecipeRow.builtBuildings)] = typeof(int?),
             [nameof(RecipeRow.showTotalIO)] = typeof(bool),
             [nameof(RecipeRow.enabled)] = typeof(bool),
@@ -73,7 +73,7 @@ public class SerializationTreeChangeDetection {
             [nameof(RecipeRow.variants)] = typeof(HashSet<FactorioObject>),
         },
         [typeof(ProductionLink)] = new() {
-            [nameof(ProductionLink.goods)] = typeof(ObjectWithQuality<Goods>),
+            [nameof(ProductionLink.goods)] = typeof(IObjectWithQuality<Goods>),
             [nameof(ProductionLink.amount)] = typeof(float),
             [nameof(ProductionLink.algorithm)] = typeof(LinkAlgorithm),
         },
@@ -131,30 +131,10 @@ public class SerializationTreeChangeDetection {
             [nameof(AutoPlannerGoal.item)] = typeof(Goods),
             [nameof(AutoPlannerGoal.amount)] = typeof(float),
         },
-        [typeof(ObjectWithQuality<Module>)] = new() {
-            [nameof(ObjectWithQuality<Module>.target)] = typeof(Module),
-            [nameof(ObjectWithQuality<Module>.quality)] = typeof(Quality),
-        },
-        [typeof(ObjectWithQuality<EntityBeacon>)] = new() {
-            [nameof(ObjectWithQuality<EntityBeacon>.target)] = typeof(EntityBeacon),
-            [nameof(ObjectWithQuality<EntityBeacon>.quality)] = typeof(Quality),
-        },
         [typeof(BeaconOverrideConfiguration)] = new() {
-            [nameof(BeaconOverrideConfiguration.beacon)] = typeof(ObjectWithQuality<EntityBeacon>),
+            [nameof(BeaconOverrideConfiguration.beacon)] = typeof(IObjectWithQuality<EntityBeacon>),
             [nameof(BeaconOverrideConfiguration.beaconCount)] = typeof(int),
-            [nameof(BeaconOverrideConfiguration.beaconModule)] = typeof(ObjectWithQuality<Module>),
-        },
-        [typeof(ObjectWithQuality<Goods>)] = new() {
-            [nameof(ObjectWithQuality<Goods>.target)] = typeof(Goods),
-            [nameof(ObjectWithQuality<Goods>.quality)] = typeof(Quality),
-        },
-        [typeof(ObjectWithQuality<RecipeOrTechnology>)] = new() {
-            [nameof(ObjectWithQuality<RecipeOrTechnology>.target)] = typeof(RecipeOrTechnology),
-            [nameof(ObjectWithQuality<RecipeOrTechnology>.quality)] = typeof(Quality),
-        },
-        [typeof(ObjectWithQuality<EntityCrafter>)] = new() {
-            [nameof(ObjectWithQuality<EntityCrafter>.target)] = typeof(EntityCrafter),
-            [nameof(ObjectWithQuality<EntityCrafter>.quality)] = typeof(Quality),
+            [nameof(BeaconOverrideConfiguration.beaconModule)] = typeof(IObjectWithQuality<Module>),
         },
     };
 

--- a/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
@@ -148,6 +148,9 @@ public class SerializationTreeChangeDetection {
     // Walk all serialized types (starting with all concrete ModelObjects), and check which types are serialized and the types of their
     // properties. Changes to this list may result in save/load issues, so require an extra step (modifying the above dictionary initializer)
     // to ensure those changes are intentional.
+    // 
+    // If this test fails, and the change is unintentional or the next steps are not obvious, consult Docs/Architecture/Serialization.md,
+    // probably starting in the section 'Guarding Tests' or 'Handling property type changes'.
     public void TreeHasNotChanged() {
         while (queue.TryDequeue(out Type type)) {
             Assert.True(propertyTree.Remove(type, out var expectedProperties), $"Serializing new type {MakeTypeName(type)}. Add `[typeof({MakeTypeName(type)})] = new() {{ /*properties*/ }},` to the propertyTree initializer.");

--- a/Yafc.Model.Tests/TestHelpers.cs
+++ b/Yafc.Model.Tests/TestHelpers.cs
@@ -10,6 +10,6 @@ internal static class TestHelpers {
     /// <typeparam name="T">The type of the input objects. Must be <see cref="FactorioObject"/> or one of its subclasses.</typeparam>
     /// <param name="values">The sequence of values that should have qualities applied to them.</param>
     /// <returns>The cartesian product of <paramref name="values"/> and the members of <see cref="Database.qualities"/>.</returns>
-    public static IEnumerable<ObjectWithQuality<T>> WithAllQualities<T>(this IEnumerable<T> values) where T : FactorioObject
+    public static IEnumerable<IObjectWithQuality<T>> WithAllQualities<T>(this IEnumerable<T> values) where T : FactorioObject
         => values.SelectMany(c => Database.qualities.all.Select(q => c.With(q))).Distinct();
 }

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -12,13 +12,13 @@ public static class Database {
     public static Item[] allSciencePacks { get; internal set; } = null!;
     public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
     public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
-    public static ObjectWithQuality<Goods> voidEnergy { get; internal set; } = null!;
-    public static ObjectWithQuality<Item> science { get; internal set; } = null!;
-    public static ObjectWithQuality<Goods> itemInput { get; internal set; } = null!;
-    public static ObjectWithQuality<Goods> itemOutput { get; internal set; } = null!;
-    public static ObjectWithQuality<Special> electricity { get; internal set; } = null!;
-    public static ObjectWithQuality<Recipe> electricityGeneration { get; internal set; } = null!;
-    public static ObjectWithQuality<Special> heat { get; internal set; } = null!;
+    public static IObjectWithQuality<Goods> voidEnergy { get; internal set; } = null!;
+    public static IObjectWithQuality<Item> science { get; internal set; } = null!;
+    public static IObjectWithQuality<Item> itemInput { get; internal set; } = null!;
+    public static IObjectWithQuality<Item> itemOutput { get; internal set; } = null!;
+    public static IObjectWithQuality<Special> electricity { get; internal set; } = null!;
+    public static IObjectWithQuality<Recipe> electricityGeneration { get; internal set; } = null!;
+    public static IObjectWithQuality<Special> heat { get; internal set; } = null!;
     public static Entity? character { get; internal set; }
     public static EntityCrafter[] allCrafters { get; internal set; } = null!;
     public static Module[] allModules { get; internal set; } = null!;

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -155,8 +155,8 @@ public class ProductionSummaryEntry(ProductionSummaryGroup owner) : ModelObject<
     }
 }
 
-public class ProductionSummaryColumn(ProductionSummary owner, ObjectWithQuality<Goods> goods) : ModelObject<ProductionSummary>(owner) {
-    public ObjectWithQuality<Goods> goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
+public class ProductionSummaryColumn(ProductionSummary owner, IObjectWithQuality<Goods> goods) : ModelObject<ProductionSummary>(owner) {
+    public IObjectWithQuality<Goods> goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
 }
 
 public class ProductionSummary : ProjectPageContents, IComparer<(IObjectWithQuality<Goods> goods, float amount)> {
@@ -169,7 +169,7 @@ public class ProductionSummary : ProjectPageContents, IComparer<(IObjectWithQual
     [SkipSerialization] public HashSet<IObjectWithQuality<Goods>> columnsExist { get; } = [];
 
     public override void InitNew() {
-        columns.Add(new ProductionSummaryColumn(this, new(Database.electricity.target, Quality.Normal)));
+        columns.Add(new ProductionSummaryColumn(this, Database.electricity));
         base.InitNew();
     }
 

--- a/Yafc.Model/Model/ProductionTable.GenuineRecipe.cs
+++ b/Yafc.Model/Model/ProductionTable.GenuineRecipe.cs
@@ -35,8 +35,8 @@ public partial class ProductionTable {
         }
 
         // Pass all remaining calls through to the underlying RecipeRow.
-        public ObjectWithQuality<EntityCrafter>? entity => row.entity;
-        public ObjectWithQuality<Goods>? fuel => row.fuel;
+        public IObjectWithQuality<EntityCrafter>? entity => row.entity;
+        public IObjectWithQuality<Goods>? fuel => row.fuel;
         public float fixedBuildings => row.fixedBuildings;
         public double recipesPerSecond { get => row.recipesPerSecond; set => row.recipesPerSecond = value; }
         public float RecipeTime => ((IRecipeRow)row).RecipeTime;

--- a/Yafc.Model/Model/ProductionTable.ImplicitLink.cs
+++ b/Yafc.Model/Model/ProductionTable.ImplicitLink.cs
@@ -6,17 +6,17 @@ public partial class ProductionTable {
     /// <summary>
     /// An implicitly-created link, used to ensure synthetic recipes are properly connected to the rest of the production table.
     /// </summary>
-    /// <param name="goods">The linked <see cref="ObjectWithQuality{T}"/>.</param>
+    /// <param name="goods">The linked <see cref="IObjectWithQuality{T}"/>.</param>
     /// <param name="owner">The <see cref="ProductionTable"/> that owns this link.</param>
     /// <param name="displayLink">The ordinary link that caused the creation of this implicit link, and the link that will be displayed if the
     /// user requests the summary for this link.</param>
-    private class ImplicitLink(ObjectWithQuality<Goods> goods, ProductionTable owner, ProductionLink displayLink) : IProductionLink {
+    private class ImplicitLink(IObjectWithQuality<Goods> goods, ProductionTable owner, ProductionLink displayLink) : IProductionLink {
         /// <summary>
         /// Always <see cref="LinkAlgorithm.Match"/>; implicit links never allow over/under production.
         /// </summary>
         public LinkAlgorithm algorithm => LinkAlgorithm.Match;
 
-        public ObjectWithQuality<Goods> goods { get; } = goods;
+        public IObjectWithQuality<Goods> goods { get; } = goods;
 
         /// <summary>
         /// Always 0; implicit links never request additional production or consumption.

--- a/Yafc.Model/Model/ProductionTable.ScienceDecomposition.cs
+++ b/Yafc.Model/Model/ProductionTable.ScienceDecomposition.cs
@@ -13,9 +13,9 @@ public partial class ProductionTable {
     /// <param name="productLink">The (genuine) link for the output pack.</param>
     /// <param name="ingredientLink">The (implicit) link for the input pack.</param>
     private class ScienceDecomposition(Goods pack, Quality quality, IProductionLink productLink, ImplicitLink ingredientLink) : IRecipeRow {
-        public ObjectWithQuality<EntityCrafter>? entity => null;
+        public IObjectWithQuality<EntityCrafter>? entity => null;
 
-        public ObjectWithQuality<Goods>? fuel => null;
+        public IObjectWithQuality<Goods>? fuel => null;
 
         /// <summary>
         /// Always 0; the solver must scale this recipe to match the available quality packs.

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -161,7 +161,7 @@ public sealed partial class ProductionTable : ProjectPageContents, IComparer<Pro
             // If the link is at the current level,
             if (link.owner == this) {
                 foreach (var quality in Database.qualities.all) {
-                    ObjectWithQuality<Goods> pack = goods.With(quality);
+                    IObjectWithQuality<Goods> pack = goods.With(quality);
                     // and there is unlinked production here or anywhere deeper: (This test only succeeds for non-normal qualities)
                     if (unlinkedProduction.Remove(pack)) { // Remove the quality pack, since it's about to be linked,
                         // and create the decomposition.
@@ -251,15 +251,15 @@ match:
     /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter or lab that can use this fuel, assuming such an entity exists.
     /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler/lab if any are available.</param>
     /// <param name="spentFuel"></param>
-    public void AddRecipe(ObjectWithQuality<RecipeOrTechnology> recipe, IComparer<Goods> ingredientVariantComparer,
-        ObjectWithQuality<Goods>? selectedFuel = null, IObjectWithQuality<Goods>? spentFuel = null) {
+    public void AddRecipe(IObjectWithQuality<RecipeOrTechnology> recipe, IComparer<Goods> ingredientVariantComparer,
+        IObjectWithQuality<Goods>? selectedFuel = null, IObjectWithQuality<Goods>? spentFuel = null) {
 
         RecipeRow recipeRow = new RecipeRow(this, recipe);
         this.RecordUndo().recipes.Add(recipeRow);
         EntityCrafter? selectedFuelCrafter = GetSelectedFuelCrafter(recipe.target, selectedFuel);
         EntityCrafter? spentFuelRecipeCrafter = GetSpentFuelCrafter(recipe.target, spentFuel);
 
-        recipeRow.entity = (selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.target.crafters.AutoSelect(DataUtils.FavoriteCrafter), Quality.Normal);
+        recipeRow.entity = (selectedFuelCrafter ?? spentFuelRecipeCrafter ?? recipe.target.crafters.AutoSelect(DataUtils.FavoriteCrafter)).With(Quality.Normal);
 
         if (recipeRow.entity != null) {
             recipeRow.fuel = GetSelectedFuel(selectedFuel, recipeRow)
@@ -275,7 +275,7 @@ match:
         }
     }
 
-    private static EntityCrafter? GetSelectedFuelCrafter(RecipeOrTechnology recipe, ObjectWithQuality<Goods>? selectedFuel) =>
+    private static EntityCrafter? GetSelectedFuelCrafter(RecipeOrTechnology recipe, IObjectWithQuality<Goods>? selectedFuel) =>
         selectedFuel?.target.fuelFor.OfType<EntityCrafter>()
             .Where(e => e.recipes.Contains(recipe))
             .AutoSelect(DataUtils.FavoriteCrafter);
@@ -290,7 +290,7 @@ match:
             .AutoSelect(DataUtils.FavoriteCrafter);
     }
 
-    private static ObjectWithQuality<Goods>? GetFuelForSpentFuel(IObjectWithQuality<Goods>? spentFuel, [NotNull] RecipeRow recipeRow) {
+    private static IObjectWithQuality<Goods>? GetFuelForSpentFuel(IObjectWithQuality<Goods>? spentFuel, [NotNull] RecipeRow recipeRow) {
         if (spentFuel is null) {
             return null;
         }
@@ -299,7 +299,7 @@ match:
             .AutoSelect(DataUtils.FavoriteFuel).With(spentFuel.quality);
     }
 
-    private static ObjectWithQuality<Goods>? GetSelectedFuel(ObjectWithQuality<Goods>? selectedFuel, [NotNull] RecipeRow recipeRow) =>
+    private static IObjectWithQuality<Goods>? GetSelectedFuel(IObjectWithQuality<Goods>? selectedFuel, [NotNull] RecipeRow recipeRow) =>
         // Skipping AutoSelect since there will only be one result at most.
         recipeRow.entity?.target.energy?.fuels.FirstOrDefault(e => e == selectedFuel?.target)?.With(selectedFuel!.quality);
 

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -31,8 +31,8 @@ public enum WarningFlags {
 }
 
 public struct UsedModule {
-    public (ObjectWithQuality<Module> module, int count, bool beacon)[]? modules;
-    public ObjectWithQuality<EntityBeacon>? beacon;
+    public (IObjectWithQuality<Module> module, int count, bool beacon)[]? modules;
+    public IObjectWithQuality<EntityBeacon>? beacon;
     public int beaconCount;
 }
 
@@ -50,9 +50,9 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
 
     public static RecipeParameters CalculateParameters(IRecipeRow row) {
         WarningFlags warningFlags = 0;
-        ObjectWithQuality<EntityCrafter>? entity = row.entity;
-        ObjectWithQuality<RecipeOrTechnology>? recipe = row.RecipeRow?.recipe;
-        ObjectWithQuality<Goods>? fuel = row.fuel;
+        IObjectWithQuality<EntityCrafter>? entity = row.entity;
+        IObjectWithQuality<RecipeOrTechnology>? recipe = row.RecipeRow?.recipe;
+        IObjectWithQuality<Goods>? fuel = row.fuel;
         float recipeTime, fuelUsagePerSecondPerBuilding = 0, productivity, speed, consumption;
         ModuleEffects activeEffects = default;
         UsedModule modules = default;

--- a/Yafc.Model/Serialization/PropertySerializers.cs
+++ b/Yafc.Model/Serialization/PropertySerializers.cs
@@ -64,6 +64,14 @@ internal abstract class PropertySerializer<TOwner, TPropertyType>(PropertyInfo p
     }
 }
 
+/// <summary>
+/// With <see cref="ValueSerializer{T}">ValueSerializer&lt;<typeparamref name="TPropertyType"/>></see>, serializes and deserializes all values
+/// stored in writable properties.
+/// </summary>
+/// <typeparam name="TOwner">The type (not a <see langword="struct"/>) that contains this property.</typeparam>
+/// <typeparam name="TPropertyType">The declared type of this property. This type must be listed in
+/// <see cref="ValueSerializer.IsValueSerializerSupported"/>.</typeparam>
+/// <param name="property">This property's <see cref="PropertyInfo"/>.</param>
 internal sealed class ValuePropertySerializer<TOwner, TPropertyType>(PropertyInfo property) :
     PropertySerializer<TOwner, TPropertyType>(property, PropertyType.Normal, true) where TOwner : class {
 
@@ -81,13 +89,8 @@ internal sealed class ValuePropertySerializer<TOwner, TPropertyType>(PropertyInf
 
         var result = _getter(owner);
 
-        if (result == null) {
-            if (CanBeNull) {
-                return default;
-            }
-            else {
-                throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not return null.");
-            }
+        if (result == null && !CanBeNull) {
+            throw new InvalidOperationException($"{property.DeclaringType}.{propertyName} must not return null.");
         }
 
         return result;
@@ -111,7 +114,12 @@ internal sealed class ValuePropertySerializer<TOwner, TPropertyType>(PropertyInf
     public override bool CanBeNull => ValueSerializer.CanBeNull;
 }
 
-// Serializes read-only sub-value with support of polymorphism
+/// <summary>
+/// With <see cref="ModelObjectSerializer{T}">ModelObjectSerializer&lt;<typeparamref name="TPropertyType"/>></see>, serializes and deserializes 
+/// <see cref="ModelObject"/>s stored in non-writable properties.
+/// </summary>
+/// <typeparam name="TOwner">The type (<see cref="ModelObject"/> or a derived type) that contains this property.</typeparam>
+/// <typeparam name="TPropertyType">The declared type (<see cref="ModelObject"/> or a derived type) of this property.</typeparam>
 internal class ReadOnlyReferenceSerializer<TOwner, TPropertyType> :
     PropertySerializer<TOwner, TPropertyType> where TOwner : ModelObject where TPropertyType : ModelObject {
 
@@ -159,6 +167,16 @@ internal class ReadOnlyReferenceSerializer<TOwner, TPropertyType> :
     public override void DeserializeFromUndoBuilder(TOwner owner, UndoSnapshotReader reader) { }
 }
 
+/// <summary>
+/// With <see cref="ValueSerializer{T}">ValueSerializer&lt;<typeparamref name="TElement"/>></see>, serializes and deserializes most collection
+/// values (stored in non-writable properties).
+/// </summary>
+/// <typeparam name="TOwner">The type (not a <see langword="struct"/>) that contains this property.</typeparam>
+/// <typeparam name="TCollection">The declared type of this property, which implements
+/// <see cref="ICollection{T}">ICollection&lt;<typeparamref name="TElement"/>></see></typeparam>
+/// <typeparam name="TElement">The element type stored in the serialized collection. This type must be listed in
+/// <see cref="ValueSerializer.IsValueSerializerSupported"/>.</typeparam>
+/// <param name="property">This property's <see cref="PropertyInfo"/>.</param>
 internal sealed class CollectionSerializer<TOwner, TCollection, TElement>(PropertyInfo property) :
     PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
     where TCollection : ICollection<TElement?> where TOwner : class {
@@ -212,6 +230,16 @@ internal sealed class CollectionSerializer<TOwner, TCollection, TElement>(Proper
     }
 }
 
+/// <summary>
+/// With <see cref="ValueSerializer{T}">ValueSerializer&lt;<typeparamref name="TElement"/>></see>, serializes and deserializes
+/// <see cref="ReadOnlyCollection{T}"/>s (stored in non-writable properties).
+/// </summary>
+/// <typeparam name="TOwner">The type (not a <see langword="struct"/>) that contains this property.</typeparam>
+/// <typeparam name="TCollection">The declared type of this property, which is or derives from
+/// <see cref="ReadOnlyCollection{T}">ReadOnlyCollection&lt;<typeparamref name="TElement"/>></see>.</typeparam>
+/// <typeparam name="TElement">The element type stored in the serialized collection. This type must be listed in
+/// <see cref="ValueSerializer.IsValueSerializerSupported"/>.</typeparam>
+/// <param name="property">This property's <see cref="PropertyInfo"/>.</param>
 internal sealed class ReadOnlyCollectionSerializer<TOwner, TCollection, TElement>(PropertyInfo property) :
     PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
     // This is ReadOnlyCollection, not IReadOnlyCollection, because we rely on knowing about the mutable backing storage of ReadOnlyCollection.
@@ -271,6 +299,21 @@ internal sealed class ReadOnlyCollectionSerializer<TOwner, TCollection, TElement
     }
 }
 
+/// <summary>
+/// With <see cref="ValueSerializer{T}">ValueSerializer&lt;<typeparamref name="TKey"/>></see> and
+/// <see cref="ValueSerializer{T}">ValueSerializer&lt;<typeparamref name="TValue"/>></see>, serializes and deserializes dictionary values (stored
+/// in non-writable properties).
+/// </summary>
+/// <typeparam name="TOwner">The type (not a <see langword="struct"/>) that contains this property.</typeparam>
+/// <typeparam name="TCollection">The declared type of this property, which implements
+/// <see cref="IDictionary{TKey, TValue}">IDictionary&lt;<typeparamref name="TKey"/>, <typeparamref name="TValue"/>></see></typeparam>
+/// <typeparam name="TKey">The type of the keys stored in the dictionary. This type must be listed in
+/// <see cref="ValueSerializer.IsKeySerializerSupported"/> and <see cref="ValueSerializer.IsValueSerializerSupported"/>, and 
+/// <see cref="ValueSerializer{T}">ValueSerializer&lt;<typeparamref name="TKey"/>></see>.<see cref="ValueSerializer{T}.Default">Default</see>
+/// must have an overridden <see cref="ValueSerializer{T}.ReadFromJsonProperty"/> method.</typeparam>
+/// <typeparam name="TValue">The type of the values stored in the dictionary. This type must be listed in
+/// <see cref="ValueSerializer.IsValueSerializerSupported"/>.</typeparam>
+/// <param name="property">This property's <see cref="PropertyInfo"/>.</param>
 internal class DictionarySerializer<TOwner, TCollection, TKey, TValue>(PropertyInfo property) :
     PropertySerializer<TOwner, TCollection>(property, PropertyType.Normal, false)
     where TCollection : IDictionary<TKey, TValue?> where TOwner : class {

--- a/Yafc.Model/Serialization/ValueSerializers.cs
+++ b/Yafc.Model/Serialization/ValueSerializers.cs
@@ -28,7 +28,7 @@ internal static class ValueSerializer {
             return true;
         }
 
-        if (type.IsClass && (typeof(ModelObject).IsAssignableFrom(type) || type.GetCustomAttribute<SerializableAttribute>() != null)) {
+        if (type.IsClass && !type.IsAbstract && (typeof(ModelObject).IsAssignableFrom(type) || type.GetCustomAttribute<SerializableAttribute>() != null)) {
             return true;
         }
 
@@ -121,13 +121,14 @@ internal abstract class ValueSerializer<T> {
             return Activator.CreateInstance(typeof(EnumSerializer<>).MakeGenericType(typeof(T)))!;
         }
 
-        if (typeof(T).IsClass) {
+        if (typeof(T).IsClass && !typeof(T).IsAbstract) {
             if (typeof(ModelObject).IsAssignableFrom(typeof(T))) {
                 return Activator.CreateInstance(typeof(ModelObjectSerializer<>).MakeGenericType(typeof(T)))!;
             }
 
             return Activator.CreateInstance(typeof(PlainClassesSerializer<>).MakeGenericType(typeof(T)))!;
         }
+
         if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Nullable<>)) {
             return Activator.CreateInstance(typeof(NullableSerializer<>).MakeGenericType(typeof(T).GetGenericArguments()[0]))!;
         }

--- a/Yafc.Model/Serialization/ValueSerializers.cs
+++ b/Yafc.Model/Serialization/ValueSerializers.cs
@@ -59,8 +59,8 @@ internal static class ValueSerializer {
 }
 
 /// <summary>
-/// The base class for serializing property values that are [<see cref="SerializableAttribute">Serializable</see>], native
-/// (e.g. <see langword="int"/>, <see langword="float"/>), or native-like (e.g. <see cref="PageReference"/>).
+/// The base class for serializing values that are [<see cref="SerializableAttribute">Serializable</see>], native (e.g. <see langword="int"/>,
+/// <see langword="float"/>), or native-like (e.g. <see cref="PageReference"/>).
 /// </summary>
 /// <typeparam name="T">The type to be serialized/deserialized by this instance.</typeparam>
 internal abstract class ValueSerializer<T> {

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -169,6 +169,7 @@ internal partial class FactorioDataDeserializer {
         var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
         UpdateRecipeCatalysts();
         CalculateItemWeights();
+        ObjectWithQuality.LoadCache(allObjects);
         ExportBuiltData();
         progress.Report(("Post-processing", "Calculating dependencies"));
         Dependencies.Calculate();

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -189,13 +189,13 @@ internal partial class FactorioDataDeserializer {
         }
 
         Database.allSciencePacks = [.. sciencePacks];
-        Database.voidEnergy = new(voidEnergy, Quality.Normal);
-        Database.science = new(science, Quality.Normal);
-        Database.itemInput = new(totalItemInput, Quality.Normal);
-        Database.itemOutput = new(totalItemOutput, Quality.Normal);
-        Database.electricity = new(electricity, Quality.Normal);
-        Database.electricityGeneration = new(generatorProduction, Quality.Normal);
-        Database.heat = new(heat, Quality.Normal);
+        Database.voidEnergy = voidEnergy.With(Quality.Normal);
+        Database.science = science.With(Quality.Normal);
+        Database.itemInput = totalItemInput.With(Quality.Normal);
+        Database.itemOutput = totalItemOutput.With(Quality.Normal);
+        Database.electricity = electricity.With(Quality.Normal);
+        Database.electricityGeneration = generatorProduction.With(Quality.Normal);
+        Database.heat = heat.With(Quality.Normal);
         Database.character = character;
         int firstSpecial = 0;
         int firstItem = Skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -323,14 +323,14 @@ public static class ImmediateWidgets {
     /// <param name="selectQuality">If not <see langword="null"/>, this will be called, and the dropdown will be closed, when the user selects a quality.
     /// In general, set this parameter when modifying an existing object, and leave it <see langword="null"/> when setting a new object.</param>
     /// <param name="width">Width of the popup. Make sure the header text fits!</param>
-    public static void BuildObjectQualitySelectDropDown<T>(this ImGui gui, ICollection<T> list, Action<ObjectWithQuality<T>> selectItem, ObjectSelectOptions<T> options,
+    public static void BuildObjectQualitySelectDropDown<T>(this ImGui gui, ICollection<T> list, Action<IObjectWithQuality<T>> selectItem, ObjectSelectOptions<T> options,
         Quality quality, Action<Quality>? selectQuality = null, float width = 20f) where T : FactorioObject
 
         => gui.ShowDropDown(gui => {
             if (gui.BuildQualityList(quality, out quality) && selectQuality != null && gui.CloseDropdown()) {
                 selectQuality(quality);
             }
-            gui.BuildInlineObjectListAndButton(list, i => selectItem(new(i, quality)), options);
+            gui.BuildInlineObjectListAndButton(list, i => selectItem(i.With(quality)), options);
         }, width);
 
     /// <summary>Shows a dropdown containing the (partial) <paramref name="list"/> of elements, with an action for when an element is selected.
@@ -343,14 +343,14 @@ public static class ImmediateWidgets {
     /// Also shows the available quality levels, and allows the user to select a quality.</summary>
     /// <param name="selectQuality">This will be called, and the dropdown will be closed, when the user selects a quality.</param>
     /// <param name="width">Width of the popup. Make sure the header text fits!</param>
-    public static void BuildObjectQualitySelectDropDownWithNone<T>(this ImGui gui, ICollection<T> list, Action<ObjectWithQuality<T>?> selectItem, ObjectSelectOptions<T> options,
+    public static void BuildObjectQualitySelectDropDownWithNone<T>(this ImGui gui, ICollection<T> list, Action<IObjectWithQuality<T>?> selectItem, ObjectSelectOptions<T> options,
         Quality quality, Action<Quality> selectQuality, float width = 20f) where T : FactorioObject
 
         => gui.ShowDropDown(gui => {
             if (gui.BuildQualityList(quality, out quality) && gui.CloseDropdown()) {
                 selectQuality(quality);
             }
-            gui.BuildInlineObjectListAndButtonWithNone(list, i => selectItem((i, quality)), options);
+            gui.BuildInlineObjectListAndButtonWithNone(list, i => selectItem(i.With(quality)), options);
         }, width);
 
     /// <summary>Draws a button displaying the icon belonging to a <see cref="FactorioObject"/>, or an empty box as a placeholder if no object is available.

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -276,7 +276,7 @@ doneDrawing:;
             using (gui.EnterGroup(contentPadding)) {
                 if (entity.spoilResult != null) {
                     gui.BuildText($"After {DataUtils.FormatTime(spoilTime)} of no production, spoils into");
-                    gui.BuildFactorioObjectButtonWithText(new ObjectWithQuality<Entity>(entity.spoilResult, quality), iconDisplayStyle: IconDisplayStyle.Default with { AlwaysAccessible = true });
+                    gui.BuildFactorioObjectButtonWithText(entity.spoilResult.With(quality), iconDisplayStyle: IconDisplayStyle.Default with { AlwaysAccessible = true });
                 }
                 else {
                     gui.BuildText($"Expires after {DataUtils.FormatTime(spoilTime)} of no production");

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -165,12 +166,12 @@ public class ProjectPageSettingsPanel : PseudoScreen {
 
         public ExportRecipe(RecipeRow row) {
             Recipe = row.recipe.QualityName();
-            Building = row.entity;
+            Building = ObjectWithQuality.Get(row.entity);
             BuildingCount = row.buildingCount;
             Fuel = new ExportMaterial(row.fuel?.QualityName() ?? "<No fuel selected>", row.FuelInformation.Amount);
             Inputs = row.Ingredients.Select(i => new ExportMaterial(i.Goods?.QualityName() ?? "Recipe disabled", i.Amount));
             Outputs = row.Products.Select(p => new ExportMaterial(p.Goods?.QualityName() ?? "Recipe disabled", p.Amount));
-            Beacon = row.usedModules.beacon;
+            Beacon = ObjectWithQuality.Get(row.usedModules.beacon);
             BeaconCount = row.usedModules.beaconCount;
 
             if (row.usedModules.modules is null) {
@@ -182,10 +183,10 @@ public class ProjectPageSettingsPanel : PseudoScreen {
 
                 foreach (var (module, count, isBeacon) in row.usedModules.modules) {
                     if (isBeacon) {
-                        beaconModules.AddRange(Enumerable.Repeat<ObjectWithQuality>(module, count));
+                        beaconModules.AddRange(Enumerable.Repeat(ObjectWithQuality.Get(module).Value, count));
                     }
                     else {
-                        modules.AddRange(Enumerable.Repeat<ObjectWithQuality>(module, count));
+                        modules.AddRange(Enumerable.Repeat(ObjectWithQuality.Get(module).Value, count));
                     }
                 }
 
@@ -277,8 +278,8 @@ public class ProjectPageSettingsPanel : PseudoScreen {
     }
 
     private record struct ObjectWithQuality(string Name, string Quality) {
-        public static implicit operator ObjectWithQuality?(ObjectWithQuality<EntityCrafter>? value) => value == null ? default(ObjectWithQuality?) : new ObjectWithQuality(value.target.name, value.quality.name);
-        public static implicit operator ObjectWithQuality(ObjectWithQuality<Module> value) => new ObjectWithQuality(value.target.name, value.quality.name);
-        public static implicit operator ObjectWithQuality?(ObjectWithQuality<EntityBeacon>? value) => value == null ? default(ObjectWithQuality?) : new ObjectWithQuality(value.target.name, value.quality.name);
+        [return: NotNullIfNotNull(nameof(objectWithQuality))]
+        public static ObjectWithQuality? Get(IObjectWithQuality<FactorioObject>? objectWithQuality)
+            => objectWithQuality == null ? default : new(objectWithQuality.target.name, objectWithQuality.quality.name);
     }
 }

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -40,7 +40,7 @@ public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObje
     /// <param name="header">The string that describes to the user why they're selecting these items.</param>
     /// <param name="selectItem">An action to be called for each selected item when the panel is closed.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-    public static void SelectWithQuality<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>> selectItem, Quality currentQuality,
+    public static void SelectWithQuality<T>(IEnumerable<T> list, string header, Action<IObjectWithQuality<T>> selectItem, Quality currentQuality,
         IComparer<T>? ordering = null, Predicate<T>? checkMark = null, Predicate<T>? yellowMark = null) where T : FactorioObject {
 
         SelectMultiObjectPanel panel = new(o => checkMark?.Invoke((T)o) ?? false, o => yellowMark?.Invoke((T)o) ?? false); // This casting is messy, but pushing T all the way around the call stack and type tree was messier.

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -25,9 +25,9 @@ public abstract class SelectObjectPanel<T> : PseudoScreenWithResult<T> {
 
     protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject?>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
 
-    protected void SelectWithQuality<U>(IEnumerable<U> list, string? header, Action<ObjectWithQuality<U>?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult,
+    protected void SelectWithQuality<U>(IEnumerable<U> list, string? header, Action<IObjectWithQuality<U>?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult,
         bool allowNone, string? noneTooltip, Quality? currentQuality) where U : FactorioObject
-        => Select(list, header, u => selectItem((u, this.currentQuality!)), ordering, mapResult, allowNone, noneTooltip, currentQuality ?? Quality.Normal);
+        => Select(list, header, u => selectItem(u.With(this.currentQuality!)), ordering, mapResult, allowNone, noneTooltip, currentQuality ?? Quality.Normal);
 
     /// <summary>
     /// Opens a <see cref="SelectObjectPanel{T}"/> to allow the user to select zero or more <see cref="FactorioObject"/>s.

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -32,7 +32,7 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// <param name="selectItem">An action to be called for the selected item when the panel is closed.
     /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-    public static void SelectWithQuality<T>(IEnumerable<T> list, string header, Action<ObjectWithQuality<T>> selectItem, Quality? currentQuality,
+    public static void SelectWithQuality<T>(IEnumerable<T> list, string header, Action<IObjectWithQuality<T>> selectItem, Quality? currentQuality,
         IComparer<T>? ordering = null) where T : FactorioObject
       // null-forgiving: selectItem will not be called with null, because allowNone is false.
       => Instance.SelectWithQuality(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false, null, currentQuality);
@@ -60,7 +60,7 @@ public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
     /// The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
     /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
     /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
-    public static void SelectQualityWithNone<T>(IEnumerable<T> list, string? header, Action<ObjectWithQuality<T>?> selectItem, Quality? currentQuality, IComparer<T>? ordering = null,
+    public static void SelectQualityWithNone<T>(IEnumerable<T> list, string? header, Action<IObjectWithQuality<T>?> selectItem, Quality? currentQuality, IComparer<T>? ordering = null,
         string? noneTooltip = null) where T : FactorioObject
         => Instance.SelectWithQuality(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip, currentQuality);
 

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -59,7 +59,7 @@ public class ShoppingListScreen : PseudoScreen {
         Dictionary<IObjectWithQuality<FactorioObject>, int> counts = [];
         foreach (RecipeRow recipe in recipes) {
             if (recipe.entity != null) {
-                ObjectWithQuality<FactorioObject> shopItem = new(recipe.entity.target.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity.target, recipe.entity.quality);
+                IObjectWithQuality<FactorioObject> shopItem = (recipe.entity.target.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity.target).With(recipe.entity.quality);
                 _ = counts.TryGetValue(shopItem, out int prev);
                 int builtCount = recipe.builtBuildings ?? (assumeAdequate ? MathUtils.Ceil(recipe.buildingCount) : 0);
                 int displayCount = displayState switch {
@@ -71,7 +71,7 @@ public class ShoppingListScreen : PseudoScreen {
                 totalHeat += recipe.entity.target.heatingPower * displayCount;
                 counts[shopItem] = prev + displayCount;
                 if (recipe.usedModules.modules != null) {
-                    foreach ((ObjectWithQuality<Module> module, int moduleCount, bool beacon) in recipe.usedModules.modules) {
+                    foreach ((IObjectWithQuality<Module> module, int moduleCount, bool beacon) in recipe.usedModules.modules) {
                         if (!beacon) {
                             _ = counts.TryGetValue(module, out prev);
                             counts[module] = prev + displayCount * moduleCount;
@@ -191,11 +191,11 @@ public class ShoppingListScreen : PseudoScreen {
                 continue;
             }
 
-            if (element.Is(out IObjectWithQuality<T>? g)) {
+            if (element is IObjectWithQuality<T> g) {
                 items.Add((g, rounded));
             }
-            else if (element.Is(out IObjectWithQuality<Entity>? e) && e.target.itemsToPlace.Length > 0) {
-                items.Add((new ObjectWithQuality<T>((T)(object)e.target.itemsToPlace[0], e.quality), rounded));
+            else if (element is IObjectWithQuality<Entity> e && e.target.itemsToPlace.Length > 0) {
+                items.Add((((T)(object)e.target.itemsToPlace[0]).With(e.quality), rounded));
             }
         }
 
@@ -238,7 +238,7 @@ public class ShoppingListScreen : PseudoScreen {
         Dictionary<IObjectWithQuality<FactorioObject>, float> decomposeResult = [];
 
         void addDecomposition(FactorioObject obj, Quality quality, float amount) {
-            ObjectWithQuality<FactorioObject> key = new(obj, quality);
+            IObjectWithQuality<FactorioObject> key = obj.With(quality);
             if (!decomposeResult.TryGetValue(key, out float prev)) {
                 decompositionQueue.Enqueue(key);
             }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -9,7 +9,7 @@ namespace Yafc;
 public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
     private readonly DataGrid<ProductionSummaryEntry> grid;
     private readonly FlatHierarchy<ProductionSummaryEntry, ProductionSummaryGroup> flatHierarchy;
-    private ObjectWithQuality<Goods>? filteredGoods;
+    private IObjectWithQuality<Goods>? filteredGoods;
     private readonly Dictionary<ProductionSummaryColumn, GoodsColumn> goodsToColumn = [];
     private readonly PaddingColumn padding;
     private readonly SummaryColumn firstColumn;
@@ -148,7 +148,7 @@ public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
     private class GoodsColumn(ProductionSummaryColumn column, ProductionSummaryView view) : DataColumn<ProductionSummaryEntry>(4f) {
         public readonly ProductionSummaryColumn column = column;
 
-        public ObjectWithQuality<Goods> goods { get; } = column.goods as ObjectWithQuality<Goods> ?? new(column.goods.target, column.goods.quality);
+        public IObjectWithQuality<Goods> goods { get; } = column.goods as IObjectWithQuality<Goods> ?? column.goods.target.With(column.goods.quality);
 
         public override void BuildHeader(ImGui gui) {
             var moveHandle = gui.statePosition;
@@ -200,7 +200,7 @@ public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
         }
     }
 
-    private void ApplyFilter(ObjectWithQuality<Goods> goods) {
+    private void ApplyFilter(IObjectWithQuality<Goods> goods) {
         var filter = filteredGoods == goods ? null : goods;
         filteredGoods = filter;
         model.group.UpdateFilter(goods, default);
@@ -266,7 +266,7 @@ public class ProductionSummaryView : ProjectPageView<ProductionSummary> {
         }
 
         if (!found) {
-            model.columns.Add(new ProductionSummaryColumn(model, new(goods.target, goods.quality)));
+            model.columns.Add(new ProductionSummaryColumn(model, goods));
         }
     }
 

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -193,7 +193,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
         }
     }
 
-    private Module[] GetModules(ObjectWithQuality<EntityBeacon>? beacon) {
+    private Module[] GetModules(IObjectWithQuality<EntityBeacon>? beacon) {
         var modules = (beacon == null && recipe is { recipe: IObjectWithQuality<RecipeOrTechnology> rec })
             ? [.. Database.allModules.Where(rec.CanAcceptModule)]
             : Database.allModules;
@@ -205,13 +205,13 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
         return [.. modules.Where(x => filter.CanAcceptModule(x.moduleSpecification))];
     }
 
-    private void DrawRecipeModules(ImGui gui, ObjectWithQuality<EntityBeacon>? beacon, ref ModuleEffects effects) {
+    private void DrawRecipeModules(ImGui gui, IObjectWithQuality<EntityBeacon>? beacon, ref ModuleEffects effects) {
         int remainingModules = recipe?.entity?.target.moduleSlots ?? 0;
         using var grid = gui.EnterInlineGrid(3f, 1f);
         var list = beacon != null ? modules!.beaconList : modules!.list;// null-forgiving: Both calls are from places where we know modules is not null
         for (int i = 0; i < list.Count; i++) {
             grid.Next();
-            (ObjectWithQuality<Module> module, int fixedCount) = list[i];
+            (IObjectWithQuality<Module> module, int fixedCount) = list[i];
             DisplayAmount amount = fixedCount;
             switch (gui.BuildFactorioObjectWithEditableAmount(module, amount, ButtonDisplayStyle.ProductionTableUnscaled)) {
                 case GoodsWithAmountEvent.LeftButtonClick:
@@ -226,7 +226,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                         }
                         gui.Rebuild();
                     }, new("Select module", DataUtils.FavoriteModule), list[idx].module.quality, quality => {
-                        list[idx] = list[idx] with { module = new(list[idx].module.target, quality) };
+                        list[idx] = list[idx] with { module = list[idx].module.target.With(quality) };
                         gui.Rebuild();
                     });
                     break;

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -55,7 +55,7 @@ public class ModuleFillerParametersScreen : PseudoScreen {
                         if (!selectedBeacon.target.CanAcceptModule(modules.overrideCrafterBeacons[crafter].beaconModule)) {
                             _ = Database.GetDefaultModuleFor(selectedBeacon.target, out Module? module);
                             // null-forgiving: Anything from usableBeacons accepts at least one module.
-                            modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconModule = new(module!, Quality.MaxAccessible) };
+                            modules.overrideCrafterBeacons[crafter] = modules.overrideCrafterBeacons[crafter] with { beaconModule = module!.With(Quality.MaxAccessible) };
                         }
                     }
 
@@ -111,8 +111,8 @@ public class ModuleFillerParametersScreen : PseudoScreen {
     public override void Build(ImGui gui) {
         EntityBeacon? beacon = Database.usableBeacons.FirstOrDefault();
         _ = Database.GetDefaultModuleFor(beacon, out Module? defaultBeaconModule);
-        ObjectWithQuality<EntityBeacon>? defaultBeacon = beacon == null ? null : new(beacon, Quality.MaxAccessible);
-        ObjectWithQuality<Module>? beaconFillerModule = (defaultBeaconModule, Quality.MaxAccessible);
+        IObjectWithQuality<EntityBeacon>? defaultBeacon = beacon.With(Quality.MaxAccessible);
+        IObjectWithQuality<Module>? beaconFillerModule = defaultBeaconModule.With(Quality.MaxAccessible);
 
         BuildHeader(gui, "Module autofill parameters");
         BuildSimple(gui, modules);

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -158,7 +158,7 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
             if (gui.BuildFactorioObjectButtonWithText(row.recipe, amount, tooltipOptions: DrawParentRecipes(row.owner, "recipe")) == Click.Left) {
                 // Find the corresponding links associated with the clicked recipe,
                 IEnumerable<IObjectWithQuality<Goods>> goods = (isLinkOutput ? row.Products.Select(p => p.Goods) : row.Ingredients.Select(i => i.Goods))!;
-                Dictionary<ObjectWithQuality<Goods>, ProductionLink> links = goods
+                Dictionary<IObjectWithQuality<Goods>, ProductionLink> links = goods
                     .Select(goods => { row.FindLink(goods, out IProductionLink? link); return link as ProductionLink; })
                     .WhereNotNull()
                     .ToDictionary(x => x.goods);
@@ -182,13 +182,13 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
                     }
                     else {
                         IComparer<IObjectWithQuality<Goods>> comparer = DataUtils.DefaultOrdering;
-                        if (isLinkOutput && row.recipe.mainProduct().Is<Goods>(out var mainProduct)) {
+                        if (isLinkOutput && row.recipe.mainProduct() is IObjectWithQuality<Goods> mainProduct) {
                             comparer = DataUtils.CustomFirstItemComparer(mainProduct, comparer);
                         }
 
                         string header = isLinkOutput ? "Select product link to inspect" : "Select ingredient link to inspect";
-                        ObjectSelectOptions<ObjectWithQuality<Goods>> options = new(header, comparer, int.MaxValue);
-                        if (gui.BuildInlineObjectList(links.Keys, out ObjectWithQuality<Goods>? selected, options) && gui.CloseDropdown()) {
+                        ObjectSelectOptions<IObjectWithQuality<Goods>> options = new(header, comparer, int.MaxValue);
+                        if (gui.BuildInlineObjectList(links.Keys, out IObjectWithQuality<Goods>? selected, options) && gui.CloseDropdown()) {
                             changeLinkView(links[selected]);
                         }
                     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,11 @@
 //     Internal changes:
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Internal changes:
+        - Quality objects now have reference equality, like FactorioObjects.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.0
 Date: March 21st 2025
     Features:

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 Version:
 Date:
     Internal changes:
-        - Quality objects now have reference equality, like FactorioObjects.
+        - Quality objects now have reference equality and abstract serialization, like FactorioObjects.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.0
 Date: March 21st 2025


### PR DESCRIPTION
The initial driver for this was removing the warning that "The `==` operator will silently revert to reference equality if both sides of are the interface type." This is no longer a concern, as reference equality will now do the right thing.

As I switched from `ICustomJsonDeserializer` to `QualityObjectSerializer`, I also decided it was a good idea to produce more documentation of how the serialization system worked and what related test failures likely meant.