### PR TITLE
fix(#446): Unnamed projects could not be created.

### DIFF
--- a/Yafc.Model.Tests/Model/ProjectTests.cs
+++ b/Yafc.Model.Tests/Model/ProjectTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Xunit;
+
+namespace Yafc.Model.Tests;
+
+public class ProjectTests {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ReadFromFile_CanLoadWithEmptyString(bool useMostRecent)
+        => Assert.NotNull(Project.ReadFromFile("", new(), useMostRecent));
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ReadFromFile_CanLoadNonexistentFile(bool useMostRecent)
+        // Assuming that there are no files named <some-guid>.yafc in the current directory.
+        => Assert.NotNull(Project.ReadFromFile(Guid.NewGuid().ToString() + ".yafc", new(), useMostRecent));
+
+    [Fact]
+    // PerformAutoSave is expected to be a no-op in this case.
+    // This test may need more care and feeding if autosaving is added for nameless projects.
+    public void PerformAutoSave_NoThrowWhenLoadedWithEmptyString()
+        // No Assert in this test; the test passes if PerformAutoSave does not throw.
+        => Project.ReadFromFile("", new(), false).PerformAutoSave();
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,8 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version:
 Date:
+    Fixes:
+        - (regression) Fix opening new unnamed files.
     Internal changes:
         - Quality objects now have reference equality and abstract serialization, like FactorioObjects.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #446 and adds a few tests to prevent its re-occurrence,

This also fixes loading errors when the latest autosave is corrupt (truncated, in my experience), by falling back to the original file, but there are no unit tests for that.