### PR TITLE
fix(net9): Fix page list in the search all dropdown.

### DIFF
--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -295,6 +295,7 @@ public class VirtualScrollList<TData>(float height, Vector2 elementSize, Virtual
     private int elementsPerRow;
     private IReadOnlyList<TData> _data = [];
     private readonly int maxRowsVisible = MathUtils.Ceil(height / elementSize.Y) + BufferRows + 1;
+    private readonly Vector2 elementSize = elementSize.X > 0 && elementSize.Y > 0 ? elementSize : throw new ArgumentException("Both element size dimensions must be positive", nameof(elementSize));
     private float _spacing;
 
     public float spacing {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -55,7 +55,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         searchGui = new ImGui(BuildSearch, new Padding(1f)) { boxShadow = RectangleBorder.Thin, boxColor = SchemeColor.Background };
         Instance = this;
         tabBar = new MainScreenTabBar(this);
-        allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, collapsible: true);
+        allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(float.PositiveInfinity, 2f), BuildPage, collapsible: true);
 
         Create("Yet Another Factorio Calculator CE v" + YafcLib.version.ToString(3), display, Preferences.Instance.initialMainScreenWidth,
             Preferences.Instance.initialMainScreenHeight, Preferences.Instance.maximizeMainScreen);

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Fixes:
         - (regression) Fix opening new unnamed files.
+        - (.NET 9) Fix page name display in the search-all dropdown.
     Internal changes:
         - Quality objects now have reference equality and abstract serialization, like FactorioObjects.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As reported a couple times on Discord, the page list is broken on .NET 9. This fixes that, by removing and preventing the divide-by-zero that (eventually) causes the issue.
![image](https://github.com/user-attachments/assets/dfae122c-fc56-43a3-a980-cd8cf6547f53)

This happened because .NET 9 changed (fixed) the float->int conversion behavior on x86: https://learn.microsoft.com/en-us/dotnet/core/compatibility/jit/9.0/fp-to-integer