### PR TITLE
fix: Inserters cannot hold more than one stack of items.

### DIFF
--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1193,8 +1193,8 @@ goodsHaveNoProduction:;
             }
             #endregion
 
-            if (goods.Is<Item>()) {
-                BuildBeltInserterInfo(gui, amount, recipe?.buildingCount ?? 0);
+            if (goods is { target: Item item }) {
+                BuildBeltInserterInfo(gui, item, amount, recipe?.buildingCount ?? 0);
             }
         }
     }
@@ -1408,7 +1408,7 @@ goodsHaveNoProduction:;
 
     private void BuildShoppingList(RecipeRow? recipeRoot) => ShoppingListScreen.Show(recipeRoot == null ? GetRecipesRecursive() : GetRecipesRecursive(recipeRoot));
 
-    private static void BuildBeltInserterInfo(ImGui gui, float amount, float buildingCount) {
+    private static void BuildBeltInserterInfo(ImGui gui, Item item, float amount, float buildingCount) {
         var preferences = Project.current.preferences;
         var belt = preferences.defaultBelt;
         var inserter = preferences.defaultInserter;
@@ -1431,7 +1431,7 @@ goodsHaveNoProduction:;
         }
 
         using (gui.EnterRow()) {
-            int capacity = preferences.inserterCapacity;
+            int capacity = Math.Min(item.stackSize, preferences.inserterCapacity);
             float inserterBase = inserter.inserterSwingTime * amount / capacity;
             click |= gui.BuildFactorioObjectButton(inserter, ButtonDisplayStyle.Default) == Click.Left;
             string text = DataUtils.FormatAmount(inserterBase, UnitOfMeasure.None);

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Date:
     Fixes:
         - (regression) Fix opening new unnamed files.
         - (.NET 9) Fix page name display in the search-all dropdown.
+        - When calculating the required inserters, remember that inserters cannot hold more than one stack.
     Internal changes:
         - Quality objects now have reference equality and abstract serialization, like FactorioObjects.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This applies especially to asteroid chunks: inserters are limited to a maximum of 1 stack of items, regardless of their actual hand size.

With this change, the value on the left (0.42 inserters) will be shown regardless of the inserter capacity, since asteroid chunks have a stack size of 1. In general, the calculations are now done based on either the hand size or the stack size, whichever is smaller.

![image](https://github.com/user-attachments/assets/5471e864-3999-4c1c-bfdb-963d1b7aa5c5)
