### PR TITLE
fix(#416): Handle duplicate productivity effects correctly.

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -152,10 +152,11 @@ internal partial class FactorioDataDeserializer {
                                 continue;
                             }
 
-                            float change = modifier.Get("change", 0f);
+                            _ = technology.changeRecipeProductivity.TryGetValue(recipe, out float change);
+                            change += modifier.Get("change", 0f);
 
-                            technology.changeRecipeProductivity.Add(recipe, change);
-                            recipe.technologyProductivity.Add(technology, change);
+                            technology.changeRecipeProductivity[recipe] = change;
+                            recipe.technologyProductivity[technology] = change;
 
                             break;
                         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Fixes:
         - Prevent productivity bonuses from exceeding +300%, unless otherwise allowed by mods.
+        - When loading duplicate research productivity effects, obey both of them, instead of failing.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.1
 Date: April 5th 2025


### PR DESCRIPTION
When using both mods, ["rocket-part-productivity-_N_"].effects contains two instances of { change = 0.1, recipe = "maraxsis-rocket-part", type = "change-recipe-productivity" }. Personally, I think this is a bug in one or both mods. That said, Factorio loads and obeys both +10% effects, so now Yafc does too.