### PR TITLE
fix(#454): Ignore invalid version specifiers.

### DIFF
--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -235,9 +235,12 @@ public static partial class FactorioDataSource {
             foreach (var mod in allFoundMods) {
                 CurrentLoadingMod = mod.name;
 
-                if (mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out var existing)
-                    && (existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null))
-                    && (!versionSpecifiers.TryGetValue(mod.name, out var version) || existing?.parsedVersion != version)) {
+                ModInfo? existing = null;
+                bool modFound = mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out existing);
+                bool higherVersionOrFolder = existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null);
+                bool existingMatchesVersionDirective = versionSpecifiers.TryGetValue(mod.name, out var version) && existing?.parsedVersion == version;
+
+                if (modFound && higherVersionOrFolder && !existingMatchesVersionDirective) {
                     existing?.Dispose();
                     allMods[mod.name] = mod;
                 }

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -235,7 +235,9 @@ public static partial class FactorioDataSource {
             foreach (var mod in allFoundMods) {
                 CurrentLoadingMod = mod.name;
 
-                if (mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out var existing) && (existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null)) && (!versionSpecifiers.TryGetValue(mod.name, out var version) || mod.parsedVersion == version)) {
+                if (mod.ValidForFactorioVersion(factorioVersion) && allMods.TryGetValue(mod.name, out var existing)
+                    && (existing == null || mod.parsedVersion > existing.parsedVersion || (mod.parsedVersion == existing.parsedVersion && existing.zipArchive != null && mod.zipArchive == null))
+                    && (!versionSpecifiers.TryGetValue(mod.name, out var version) || existing?.parsedVersion != version)) {
                     existing?.Dispose();
                     allMods[mod.name] = mod;
                 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Date:
         - Prevent productivity bonuses from exceeding +300%, unless otherwise allowed by mods.
         - When loading duplicate research productivity effects, obey both of them, instead of failing.
         - Fixed a crash when item.weight == 0, related to ultracube.
+        - If the requested mod version isn't found, use the latest, like Factorio.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.1
 Date: April 5th 2025


### PR DESCRIPTION
This should fix #454; if the version specified in mod-list.json is not found, we (like Factorio) will now load the newest version instead of failing.