### PR TITLE
fix(#459): Use correct amounts from other tabs in the legacy summary.

### DIFF
--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -133,9 +133,8 @@ public class ProductionSummaryEntry(ProductionSummaryGroup owner) : ModelObject<
             }
 
             foreach (var link in subTable.allLinks) {
-                if (link.amount != 0) {
-                    _ = flow.TryGetValue(link.goods, out float prevValue);
-                    flow[link.goods] = prevValue + (link.amount * multiplier);
+                if (link.amount != 0 && !flow.ContainsKey(link.goods)) {
+                    flow[link.goods] = link.amount * multiplier;
                 }
             }
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date:
         - When loading duplicate research productivity effects, obey both of them, instead of failing.
         - Fixed a crash when item.weight == 0, related to ultracube.
         - If the requested mod version isn't found, use the latest, like Factorio.
+        - Fix amounts loaded from other pages in the legacy summary page.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.1
 Date: April 5th 2025


### PR DESCRIPTION
This appears to fix #459, but I can't really explain why `!flow.ContainsKey` is the correct test.

It gets the correct values for unlinked products, requested products, and requested products with overproduction; tested with Moss from Moss Redesign.