### PR TITLE
fix(#465): Don't auto-calculate catalysts in Factorio 2.0.

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -56,13 +56,15 @@ internal partial class FactorioDataDeserializer {
     }
 
     private void UpdateRecipeCatalysts() {
-        foreach (var recipe in allObjects.OfType<Recipe>()) {
-            foreach (var product in recipe.products) {
-                if (product.productivityAmount == product.amount) {
-                    float catalyst = recipe.GetConsumptionPerRecipe(product.goods);
+        if (factorioVersion < new Version(2, 0, 0)) {
+            foreach (var recipe in allObjects.OfType<Recipe>()) {
+                foreach (var product in recipe.products) {
+                    if (product.productivityAmount == product.amount) {
+                        float catalyst = recipe.GetConsumptionPerRecipe(product.goods);
 
-                    if (catalyst > 0f) {
-                        product.SetCatalyst(catalyst);
+                        if (catalyst > 0f) {
+                            product.SetCatalyst(catalyst);
+                        }
                     }
                 }
             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date:
         - If the requested mod version isn't found, use the latest, like Factorio.
         - Fix amounts loaded from other pages in the legacy summary page.
         - Improved precision for building count calculation.
+        - Remove automatic catalyst amount calculations when loading Factorio 2.0 data.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.1
 Date: April 5th 2025


### PR DESCRIPTION
This fixes #465 for 2.0, while preserving the auto-calculations that applied in 1.1 and earlier.