### PR TITLE
476 creating a new project throws a permission denied error

### DIFF
--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -147,7 +147,8 @@ public static class ImGuiUtils {
     }
 
     // null-forgiving: OnlyOnFaulted guarantees that Exception is non-null.
-    public static void CaptureException(this Task task) => _ = task.ContinueWith(t => throw t.Exception!, TaskContinuationOptions.OnlyOnFaulted);
+    public static void CaptureException(this Task task) =>
+        _ = task.ContinueWith(t => Ui.DispatchInMainThread(_ => throw t.Exception!, null), TaskContinuationOptions.OnlyOnFaulted);
 
     public static bool BuildMouseOverIcon(this ImGui gui, Icon icon, SchemeColor color = SchemeColor.BackgroundText) {
         if (gui.isBuilding && gui.IsMouseOver(gui.lastRect)) {

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -439,6 +439,7 @@ override-font=Override font
 override-font-long=Override the font that YAFC uses
 load-project-name=Load '__1__'
 welcome-alert-missing-directory=Project directory does not exist
+welcome-alert-path-is-directory=Project location is a directory
 welcome-create-project-name=Create '__1__'
 welcome-create-unnamed-project=Create new project
 welcome-browse-button=...

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -70,6 +70,15 @@ public class FilesystemScreen : TaskWindow<string?>, IKeyboardFocus {
 
     private void BuildSelectButton(ImGui gui) {
         if (gui.BuildButton(button, active: resultValid)) {
+            OkClicked();
+        }
+    }
+
+    private void OkClicked() {
+        if (mode is Mode.SelectFile or Mode.SelectOrCreateFile && Directory.Exists(selectedResult)) {
+            SetLocation(selectedResult);
+        }
+        else {
             CloseWithResult(selectedResult);
         }
     }
@@ -177,7 +186,7 @@ public class FilesystemScreen : TaskWindow<string?>, IKeyboardFocus {
 
     public bool KeyDown(SDL.SDL_Keysym key) {
         if (key.sym is SDL.SDL_Keycode.SDLK_KP_ENTER or SDL.SDL_Keycode.SDLK_RETURN or SDL.SDL_Keycode.SDLK_RETURN2) {
-            CloseWithResult(selectedResult);
+            OkClicked();
             return true;
         }
         else if (key.sym == SDL.SDL_Keycode.SDLK_ESCAPE) {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -652,8 +652,11 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
 
     private Task<bool> SaveProject() {
         if (!string.IsNullOrEmpty(project.attachedFileName)) {
-            project.Save(project.attachedFileName);
-            return Task.FromResult(true);
+            try {
+                project.Save(project.attachedFileName);
+                return Task.FromResult(true);
+            }
+            catch (Exception) { /* Error saving. Fall back to save as */ }
         }
 
         return SaveProjectAs();

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -416,6 +416,11 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
                 canCreate = false;
                 return;
             }
+            else if (Directory.Exists(path)) {
+                createText = LSs.WelcomeAlertPathIsDirectory;
+                canCreate = false;
+                return;
+            }
             createText = LSs.WelcomeCreateProjectName.L(Path.GetFileNameWithoutExtension(path));
         }
         else {

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Date:
         - Improved precision for building count calculation.
         - Remove automatic catalyst amount calculations when loading Factorio 2.0 data.
         - Update documentation for changing the selected Factorio-object language.
+        - Make it much harder for the user to select a folder when YAFC is expecting a file.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.11.1
 Date: April 5th 2025


### PR DESCRIPTION
This fixes #476. There were several places where the user could select a folder when Yafc was expecting a file, and the two are not interchangeable.