### PR TITLE
fix: Personal equipment names were not localized properly.

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -55,7 +55,8 @@ public abstract class FactorioObject : IFactorioObjectWrapper, IComparable<Facto
             }
             else {
                 locName = other.locName;
-                locDescr = description.L(locName);
+                // locName could still be null at this point. Use name instead, since we have nothing better.
+                locDescr = description.L(locName ?? name);
             }
         }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -425,7 +425,8 @@ internal partial class FactorioDataDeserializer {
 
         item.stackSize = table.Get("stack_size", 1);
 
-        if (item.locName == null && table.Get("placed_as_equipment_result", out string? result)) {
+        // place_as for 2.0, placed_as for 1.1
+        if (item.locName == null && (table.Get("place_as_equipment_result", out string? result) || table.Get("placed_as_equipment_result", out result))) {
             item.locName = LocalisedStringParser.ParseKey("equipment-name." + result, [])!;
         }
         if (table.Get("fuel_value", out string? fuelValue)) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version:
 Date:
     Features:
     Fixes:
+        - Personal equipment names are localized again.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.13.0
 Date: May 14th 2025


### PR DESCRIPTION
In 2.0, Factorio decided to be cute and rename "placed_as_..." to "place_as_...", causing
![image](https://github.com/user-attachments/assets/aceba78e-9d1b-4065-b633-28a32796e7ac)
This was fine, except that I also decided to be cute and make it painful for developers when the localization fails.

So now it's fixed. As a bonus, the fallback description string is now "A recipe to create exoskeleton-equipment" instead of just "A recipe to create".