### PR TITLE
fix(#478): ./build.sh works from clean source again.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ rm -rf Build
 VERSION=$(grep -oPm1 "(?<=<AssemblyVersion>)[^<]+" Yafc/Yafc.csproj)
 echo "Building YAFC version $VERSION..."
 
+dotnet build Yafc.I18n.Generator
 dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows
 dotnet publish Yafc/Yafc.csproj -r win-x64 --self-contained -c Release -o Build/Windows-self-contained
 dotnet publish Yafc/Yafc.csproj -r osx-x64 -c Release -o Build/OSX


### PR DESCRIPTION
This fixes #478, at least for ./build.sh. Attempts to use `dotnet run --project Yafc` from clean source are still broken, but it doesn't appear anyone is trying to do that.

Other solutions I tried all seemed to have more pain than benefits: `dotnet build FactorioCalc.sln --target:Yafc:Publish -r win-x64` would try to run an explicitly x64 version of I18n.Generate on arm64 processors, or vice versa. Using project-level dependencies requires a #if to prevent introducing a warning, and adds extra files to the publish folders.