### PR TITLE
Fix #306 Wrong temperature handling in fluid products

### DIFF
--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -139,7 +139,7 @@ public class ProductionTableContentTests {
 
                         foreach (var (display, solver) in row.Ingredients.Zip(((IRecipeRow)row).IngredientsForSolver)) {
                             var (solverGoods, solverAmount, _, _) = solver;
-                            var (displayGoods, displayAmount, _, _) = display;
+                            var (displayGoods, displayAmount, _) = display;
 
                             try {
                                 // If this fails, something weird went wrong
@@ -211,7 +211,7 @@ public class ProductionTableContentTests {
 
         // Ensure that the fuel consumption remains constant, except when the entity and fuel change simultaneously.
         row.fixedFuel = true;
-        ((Goods oldFuel, _), float fuelAmount, _, _) = row.FuelInformation;
+        ((Goods oldFuel, _), float fuelAmount, _) = row.FuelInformation;
         testCombinations(row, table, testFuel(row, table));
         row.fixedFuel = false;
 
@@ -243,7 +243,7 @@ public class ProductionTableContentTests {
                 row.fixedBuildings = 1;
                 row.fixedFuel = true;
                 table.Solve((ProjectPage)table.owner).Wait();
-                ((oldFuel, _), fuelAmount, _, _) = row.FuelInformation;
+                ((oldFuel, _), fuelAmount, _) = row.FuelInformation;
                 assertCalls++;
             }
         };

--- a/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
+++ b/Yafc.Model.Tests/Model/SelectableVariantsTests.cs
@@ -19,7 +19,7 @@ public class SelectableVariantsTests {
         await table.Solve((ProjectPage)table.owner);
         Assert.Equal("steam@165", row.FuelInformation.Goods.target.name);
 
-        row.fuel = row.FuelInformation.Variants[1].With(Quality.Normal);
+        row.fuel = row.FuelInformation.Goods.target.fluid.variants[1].With(Quality.Normal);
         await table.Solve((ProjectPage)table.owner);
         Assert.Equal("steam@500", row.FuelInformation.Goods.target.name);
     }
@@ -38,7 +38,7 @@ public class SelectableVariantsTests {
         await table.Solve((ProjectPage)table.owner);
         Assert.Equal("steam@500", row.FuelInformation.Goods.target.name);
 
-        row.fuel = row.FuelInformation.Variants[0].With(Quality.Normal);
+        row.fuel = row.FuelInformation.Goods.target.fluid.variants[0].With(Quality.Normal);
         await table.Solve((ProjectPage)table.owner);
         Assert.Equal("steam@165", row.FuelInformation.Goods.target.name);
     }
@@ -56,7 +56,7 @@ public class SelectableVariantsTests {
         await table.Solve((ProjectPage)table.owner);
         Assert.Equal("steam@165", row.Ingredients.Single().Goods.target.name);
 
-        row.ChangeVariant(row.Ingredients.Single().Goods.target, row.Ingredients.Single().Variants[1]);
+        row.ChangeVariant(row.Ingredients.Single().Goods.target, row.Ingredients.Single().Goods.target.fluid.variants[1]);
         await table.Solve((ProjectPage)table.owner);
         Assert.Equal("steam@500", row.Ingredients.Single().Goods.target.name);
     }

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -823,4 +823,13 @@ match:
     /// </summary>
     /// <remarks>This is most commonly used for deciding whether to draw a yellow checkmark.</remarks>
     public bool ContainsAnywhere(RecipeOrTechnology obj) => rootTable.GetAllRecipes().Any(r => r.recipe.target == obj);
+
+    public bool CreateLink(IObjectWithQuality<Goods> goods) {
+        if (linkMap.GetValueOrDefault(goods) is ProductionLink || !goods.target.isLinkable) {
+            return false;
+        }
+
+        this.RecordUndo().links.Add(new(this, goods.target.With(goods.quality)));
+        return true;
+    }
 }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -481,14 +481,14 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
     public HashSet<FactorioObject> variants { get; } = [];
     [SkipSerialization] public ProductionTable linkRoot => subgroup ?? owner;
 
-    public RecipeRowIngredient FuelInformation => new(fuel, fuelUsagePerSecond, links.fuel, (fuel?.target as Fluid)?.variants?.ToArray());
+    public RecipeRowIngredient FuelInformation => new(fuel, fuelUsagePerSecond, links.fuel);
     public IEnumerable<RecipeRowIngredient> Ingredients {
         get {
             if (hierarchyEnabled) {
                 return BuildIngredients(false).Select(RecipeRowIngredient.FromSolver);
             }
             else {
-                return Enumerable.Repeat(new RecipeRowIngredient(null, 0, null, null), recipe.target.ingredients.Length);
+                return Enumerable.Repeat(new RecipeRowIngredient(null, 0, null), recipe.target.ingredients.Length);
             }
         }
     }
@@ -922,13 +922,13 @@ public class ProductionLink(ProductionTable group, IObjectWithQuality<Goods> goo
 /// <summary>
 /// An ingredient for a recipe row, as reported to the UI.
 /// </summary>
-public record RecipeRowIngredient(IObjectWithQuality<Goods>? Goods, float Amount, ProductionLink? Link, Goods[]? Variants) {
+public record RecipeRowIngredient(IObjectWithQuality<Goods>? Goods, float Amount, ProductionLink? Link) {
     /// <summary>
     /// Convert from a <see cref="SolverIngredient"/> (the form initially generated when reporting ingredients) to a
     /// <see cref="RecipeRowIngredient"/>.
     /// </summary>
     internal static RecipeRowIngredient FromSolver(SolverIngredient value)
-        => new(value.Goods, value.Amount, value.Link as ProductionLink, value.Goods.target.fluid?.variants?.ToArray());
+        => new(value.Goods, value.Amount, value.Link as ProductionLink);
 }
 
 /// <summary>

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -909,6 +909,14 @@ public class ProductionLink(ProductionTable group, IObjectWithQuality<Goods> goo
             }
         }
     }
+
+    public bool Destroy() {
+        if (owner.links.Contains(this)) {
+            _ = owner.RecordUndo().links.Remove(this);
+            return true;
+        }
+        return false;
+    }
 }
 
 /// <summary>

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Date:
     Fixes:
         - Personal equipment names are localized again.
         - Quality prompts from dropdowns now also appear in subsequent selection panels.
+        - Fix output temperature selection for recipes that didn't specify the output fluid temperature.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.13.0
 Date: May 14th 2025


### PR DESCRIPTION
This closes #306, by both fixing the fluid temperature when data.raw doesn't specify it, and by changing the recipe selection to only show recipes for the selected ingredient variant.

There's also some refactoring that happened while I was trying to make OpenProductDropdown__dropDownContent less messy.