### PR TITLE
fix(#501): Milestone checks now look at the current project.

### DIFF
--- a/Yafc.Model.Tests/Analysis/MilestonesLuaTests.cs
+++ b/Yafc.Model.Tests/Analysis/MilestonesLuaTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+using Xunit;
+
+namespace Yafc.Model.Tests;
+
+[Collection("LuaDependentTests")]
+public class MilestonesLuaTests {
+    [Fact]
+    public void SecondProjectIsOpened_ShouldUpdateProjectField() {
+        FieldInfo projectField = typeof(Milestones).GetField("project", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        // Open the first project:
+        var project = LuaDependentTestHelper.GetProjectForLua("Yafc.Model.Tests.BareMinimumLuaData.lua");
+        Assert.Equal(projectField.GetValue(Milestones.Instance), project);
+
+        // Now open a second project:
+        project = LuaDependentTestHelper.GetProjectForLua("Yafc.Model.Tests.BareMinimumLuaData.lua");
+        Assert.Equal(projectField.GetValue(Milestones.Instance), project);
+
+        // Just for the fun of it, open a third too:
+        project = LuaDependentTestHelper.GetProjectForLua("Yafc.Model.Tests.BareMinimumLuaData.lua");
+        Assert.Equal(projectField.GetValue(Milestones.Instance), project);
+    }
+}

--- a/Yafc.Model.Tests/BareMinimumLuaData.lua
+++ b/Yafc.Model.Tests/BareMinimumLuaData.lua
@@ -1,0 +1,5 @@
+data = { raw = {} }
+defines.prototypes = { 
+    item = {},
+    entity = {},
+}

--- a/Yafc.Model.Tests/Yafc.Model.Tests.csproj
+++ b/Yafc.Model.Tests/Yafc.Model.Tests.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="BareMinimumLuaData.lua" />
     <EmbeddedResource Include="Model\ProductionTableContentTests.lua" />
     <EmbeddedResource Include="Model\RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua" />
     <EmbeddedResource Include="Model\SelectableVariantsTests.lua" />

--- a/Yafc.Model/Analysis/Milestones.cs
+++ b/Yafc.Model/Analysis/Milestones.cs
@@ -107,7 +107,10 @@ public class Milestones : Analysis {
     }
 
     public void ComputeWithParameters(Project project, ErrorCollector warnings, FactorioObject[] milestones, bool autoSort) {
-        if (this.project == null) {
+        if (this.project != project) {
+            if (this.project != null) {
+                this.project.settings.changed -= ProjectSettingsChanged;
+            }
             this.project = project;
             project.settings.changed += ProjectSettingsChanged;
         }


### PR DESCRIPTION
This fixes #501; Yafc cached the first-opened project and used its milestones instead of the current milestones for some checks.