### PR TITLE
feat: Add Ctrl+Shift+Click to add best-cost recipe

### DIFF
--- a/Yafc/Data/Tips.txt
+++ b/Yafc/Data/Tips.txt
@@ -15,3 +15,4 @@ Tip: Specify <number>k to multiply the production by 1000. Other SI prefixes wor
 Tip: You can enable the dark mode by clicking on the light-bulb icon on the welcome screen.
 Tip: You can switch between tabs using Ctrl+PgUp or Down and reorder them using Ctrl+Shift+PgUp or Down.
 Tip: You can make Yafc load faster by copying the mods folder and disabling the mods that don't affect calculations in mod-list.json.
+Tip: You can Control+Shift+Click on an ingredient to add the most cost-effective accessible recipe to the production tab.

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 Version:
 Date:
     Features:
+        - Add Ctrl+Shift+Click to add the most cost-effective, accessible recipe for an item.
         
     Fixes:
         - Fix icon rendering.


### PR DESCRIPTION
This pull request adds a new feature that allows users to quickly add the most cost-effective recipe for an item by holding Ctrl+Shift and clicking on it.

Note that this de-prioritizes barreling recipes by default.