### PR TITLE
Feat/percentage based ingredient consumption

### DIFF
--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -458,6 +458,7 @@ match:
             var link = allLinks[i];
             float min = link.algorithm == LinkAlgorithm.AllowOverConsumption ? float.NegativeInfinity : link.amount;
             float max = link.algorithm == LinkAlgorithm.AllowOverProduction ? float.PositiveInfinity : link.amount;
+
             var constraint = productionTableSolver.MakeConstraint(min, max, link.goods.QualityName() + "_recipe");
             constraints[i] = constraint;
             link.solverIndex = i;
@@ -491,7 +492,10 @@ match:
             foreach (var ingredient in recipe.IngredientsForSolver) {
                 if (recipe.FindLink(ingredient.Goods, out var link)) {
                     link.flags |= ProductionLink.Flags.HasConsumption;
-                    AddLinkCoefficient(constraints[link.solverIndex], recipeVar, link, recipe, -ingredient.Amount);
+                    float ingredientAmount = -ingredient.Amount;
+
+
+                    AddLinkCoefficient(constraints[link.solverIndex], recipeVar, link, recipe, ingredientAmount);
                 }
 
                 links.ingredients[ingredient.LinkIndex] = link as ProductionLink;
@@ -537,6 +541,150 @@ match:
 
         for (int i = 0; i < allRecipes.Count; i++) {
             objective.SetCoefficient(vars[i], allRecipes[i].BaseCost);
+        }
+
+        // Add percentage-based ingredient consumption constraints BEFORE solving
+        // Group recipes by shared ingredients that have percentage constraints
+        var ingredientGroups = new Dictionary<IObjectWithQuality<Goods>, List<(IRecipeRow recipe, float percentage)>>();
+
+        foreach (var recipe in allRecipes) {
+            if (recipe.RecipeRow?.ingredientConsumptionPercentages != null) {
+                foreach (var (goods, percentage) in recipe.RecipeRow.ingredientConsumptionPercentages) {
+                    if (!ingredientGroups.ContainsKey(goods)) {
+                        ingredientGroups[goods] = [];
+                    }
+                    ingredientGroups[goods].Add((recipe, percentage));
+                    logger.Information("Found percentage constraint: {recipe} wants {percentage}% of {goods}",
+                        recipe.SolverName, percentage * 100, goods.target.name);
+                }
+            }
+        }
+
+        // For each ingredient that has percentage constraints, create proportional constraints
+        foreach (var (goods, recipesWithPercentages) in ingredientGroups) {
+            logger.Information("Processing ingredient {goods} with {count} recipes having percentage constraints",
+                goods.target.name, recipesWithPercentages.Count);
+
+            if (recipesWithPercentages.Count > 1) {
+                // Multiple recipes share this ingredient with percentage constraints
+                // Create proportional constraints between them
+                var firstRecipe = recipesWithPercentages[0];
+                var firstIngredient = firstRecipe.recipe.IngredientsForSolver.FirstOrDefault(i => i.Goods == goods);
+
+                if (firstIngredient != null) {
+                    float firstIngredientAmount = (float)Math.Abs(firstIngredient.Amount);
+
+                    for (int i = 1; i < recipesWithPercentages.Count; i++) {
+                        var otherRecipe = recipesWithPercentages[i];
+                        var otherIngredient = otherRecipe.recipe.IngredientsForSolver.FirstOrDefault(ing => ing.Goods == goods);
+
+                        if (otherIngredient != null) {
+                            float otherIngredientAmount = (float)Math.Abs(otherIngredient.Amount);
+
+                            // Create proportional constraint:
+                            // firstRecipe_var * firstAmount * otherPercentage = otherRecipe_var * otherAmount * firstPercentage
+                            // Rearranged: firstRecipe_var * firstAmount * otherPercentage - otherRecipe_var * otherAmount * firstPercentage = 0
+                            var proportionConstraint = productionTableSolver.MakeConstraint(0, 0,
+                                $"proportion_{goods.target.name}_{firstRecipe.recipe.GetType().Name}_{otherRecipe.recipe.GetType().Name}");
+
+                            float coeff1 = firstIngredientAmount * otherRecipe.percentage;
+                            float coeff2 = -otherIngredientAmount * firstRecipe.percentage;
+
+                            proportionConstraint.SetCoefficient(vars[allRecipes.IndexOf(firstRecipe.recipe)], coeff1);
+                            proportionConstraint.SetCoefficient(vars[allRecipes.IndexOf(otherRecipe.recipe)], coeff2);
+
+                            logger.Information("Created proportion constraint: {first}*{coeff1} + {second}*{coeff2} = 0",
+                                firstRecipe.recipe.SolverName, coeff1, otherRecipe.recipe.SolverName, coeff2);
+                        }
+                    }
+                }
+            }
+            else if (recipesWithPercentages.Count == 1) {
+                // Single recipe with percentage constraint - create consumption limit relative to production
+                var recipe = recipesWithPercentages[0];
+                var ingredient = recipe.recipe.IngredientsForSolver.FirstOrDefault(i => i.Goods == goods);
+
+                logger.Information("Processing single recipe percentage constraint: {recipe} wants {percentage}% of {goods}",
+                    recipe.recipe.SolverName, recipe.percentage * 100, goods.target.name);
+
+                if (ingredient != null) {
+                    float ingredientAmountPerRecipe = (float)Math.Abs(ingredient.Amount);
+                    logger.Information("Ingredient amount per recipe: {amount}", ingredientAmountPerRecipe);
+
+                    // Find the link for this goods and change its algorithm to allow over-production
+                    var link = allLinks.FirstOrDefault(l => l.goods == goods);
+                    if (link is ProductionLink productionLink) {
+                        // Change the link algorithm to allow over-production so surplus shows in flow
+                        productionLink.algorithm = LinkAlgorithm.AllowOverProduction;
+                        logger.Information("Set link algorithm to AllowOverProduction for {goods}", goods.target.name);
+                    }
+
+                    // NEW APPROACH: Force the recipe to run by creating a minimum consumption constraint
+                    // This ensures the recipe runs at least enough to consume some of the ingredient
+
+                    int consumingRecipeIndex = allRecipes.IndexOf(recipe.recipe);
+
+                    // First, modify the link constraint to allow surplus
+                    var targetLink = allLinks.FirstOrDefault(l => l.goods == goods);
+                    if (targetLink != null) {
+                        var constraint = constraints[targetLink.solverIndex];
+                        if (constraint != null) {
+                            // Change constraint bounds to allow surplus production
+                            constraint.SetBounds(0, double.PositiveInfinity);
+                            logger.Information("Set link constraint bounds to [0, inf] for {goods}", goods.target.name);
+                        }
+                    }
+
+                    // Create a constraint that limits consumption to a percentage of total production
+                    // We'll create a constraint that relates consumption directly to production variables
+
+                    // Find all recipes that produce this goods
+                    // In YAFC, production is represented as positive amounts in ProductsForSolver, not IngredientsForSolver
+                    var producingRecipes = new List<(IRecipeRow recipe, float productionPerRecipe, int index)>();
+                    foreach (var prodRecipe in allRecipes) {
+                        var prodProduct = prodRecipe.ProductsForSolver.FirstOrDefault(p => p.Goods == goods);
+                        if (prodProduct != null && prodProduct.Amount > 0) {
+                            int prodRecipeIndex = allRecipes.IndexOf(prodRecipe);
+                            float productionPerRecipe = prodProduct.Amount;
+                            producingRecipes.Add((prodRecipe, productionPerRecipe, prodRecipeIndex));
+
+                            logger.Information("Found producing recipe: {recipe} produces {amount} {goods}",
+                                prodRecipe.SolverName, productionPerRecipe, goods.target.name);
+                        }
+                    }
+
+                    if (producingRecipes.Count > 0) {
+                        // Create constraint: consumption = percentage * total_production
+                        // consumption_recipe * consumption_per_recipe = percentage * (sum of production_recipe * production_per_recipe)
+                        // Rearranged: consumption_recipe * consumption_per_recipe - percentage * (sum of production_recipe * production_per_recipe) = 0
+
+                        var percentageConstraint = productionTableSolver.MakeConstraint(0, 0,
+                            $"percentage_exact_{recipe.recipe.SolverName}_{goods.target.name}");
+
+                        // Add consumption term (positive coefficient)
+                        percentageConstraint.SetCoefficient(vars[consumingRecipeIndex], ingredientAmountPerRecipe);
+
+                        // Add production terms (negative coefficients scaled by percentage)
+                        foreach (var (prodRecipe, productionPerRecipe, prodIndex) in producingRecipes) {
+                            float prodCoeff = -productionPerRecipe * recipe.percentage;
+                            percentageConstraint.SetCoefficient(vars[prodIndex], prodCoeff);
+
+                            logger.Information("Added production term: {prodRecipe} * {coeff}",
+                                prodRecipe.SolverName, prodCoeff);
+                        }
+
+                        logger.Information("Created percentage constraint: {recipe} * {amount} <= {pct}% * total_production",
+                            recipe.recipe.SolverName, ingredientAmountPerRecipe, recipe.percentage * 100);
+                    }
+
+                    // Instead of minimum constraint, add to objective to encourage consumption
+                    // This will make the solver want to run the recipe more (negative cost = benefit)
+                    objective.SetCoefficient(vars[consumingRecipeIndex], -0.001f);
+
+                    logger.Information("Added objective incentive for {recipe} to encourage consumption",
+                        recipe.recipe.SolverName);
+                }
+            }
         }
 
         var result = productionTableSolver.Solve();
@@ -655,7 +803,18 @@ match:
 
         for (int i = 0; i < allRecipes.Count; i++) {
             var recipe = allRecipes[i];
-            recipe.recipesPerSecond = vars[i].SolutionValue();
+            double solutionValue = vars[i].SolutionValue();
+            recipe.recipesPerSecond = solutionValue;
+
+            // Debug percentage-constrained recipes
+            if (recipe.RecipeRow?.ingredientConsumptionPercentages?.Count > 0) {
+                logger.Information("POST-SOLVE: Recipe {recipe} (index {index}) solution value: {value}, recipesPerSecond: {rps}",
+                    recipe.SolverName, i, solutionValue, recipe.recipesPerSecond);
+
+                foreach (var (goods, percentage) in recipe.RecipeRow.ingredientConsumptionPercentages) {
+                    logger.Information("  - Has percentage constraint: {goods} at {pct}%", goods.target.name, percentage * 100);
+                }
+            }
         }
 
         bool builtCountExceeded = CheckBuiltCountExceeded();

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -444,7 +444,7 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
     /// </summary>
     public bool hierarchyEnabled { get; internal set; }
     public int tag { get; set; }
-    public Dictionary<IObjectWithQuality<Goods>, float> ingredientConsumptionPercentages { get; set; } = [];
+    public Dictionary<IObjectWithQuality<Goods>, float> ingredientConsumptionPercentages { get; } = [];
 
     public RowHighlighting highlighting =>
         tag switch {
@@ -501,7 +501,15 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
         for (int i = 0; i < recipe.target.ingredients.Length; i++) {
             Ingredient ingredient = recipe.target.ingredients[i];
             IObjectWithQuality<Goods> option = (ingredient.variants == null ? ingredient.goods : GetVariant(ingredient.variants)).With(recipe.quality);
-            yield return (option, ingredient.amount * factor, links.ingredients[i], i, ingredient.variants);
+
+            float amount = ingredient.amount;
+
+            // Apply percentage-based consumption if configured
+            if (ingredientConsumptionPercentages.TryGetValue(option, out float percentage)) {
+                amount *= percentage;
+            }
+
+            yield return (option, amount * factor, links.ingredients[i], i, ingredient.variants);
         }
     }
 
@@ -873,6 +881,7 @@ public class ProductionLink(ProductionTable group, IObjectWithQuality<Goods> goo
     /// <inheritdoc/>
     public HashSet<IRecipeRow> capturedRecipes { get; } = [];
     internal int solverIndex;
+    public float? splitPercentage { get; set; }
 
     // To avoid leaking these variables/methods (or just the setter, for recipesPerSecond) into public context,
     // these explicit interface implementations connect to internal members, instead of using implicit implementation via public members

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -444,6 +444,7 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
     /// </summary>
     public bool hierarchyEnabled { get; internal set; }
     public int tag { get; set; }
+    public Dictionary<IObjectWithQuality<Goods>, float> ingredientConsumptionPercentages { get; set; } = [];
 
     public RowHighlighting highlighting =>
         tag switch {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1189,6 +1189,27 @@ goodsHaveNoProduction:;
             }
             #endregion
 
+            #region Percentage-based ingredient consumption
+            if (goods != null && recipe != null && recipe.hierarchyEnabled && type == ProductDropdownType.Ingredient) {
+                bool hasPercentageConstraint = recipe.ingredientConsumptionPercentages.ContainsKey(goods);
+
+                if (!hasPercentageConstraint) {
+                    // Show button to set percentage constraint
+                    if (gui.BuildButton("Set consumption %") && gui.CloseDropdown()) {
+                        recipe.RecordUndo().ingredientConsumptionPercentages[goods] = 0.5f; // Default to 50%
+                        Console.WriteLine($"DEBUG: Set percentage for {goods.target.name} in {recipe.recipe.target.name} to 50%");
+                    }
+                }
+                else {
+                    // Show button to clear percentage constraint
+                    if (gui.BuildButton("Clear consumption %") && gui.CloseDropdown()) {
+                        _ = recipe.RecordUndo().ingredientConsumptionPercentages.Remove(goods);
+                    }
+                }
+                targetGui.Rebuild();
+            }
+            #endregion
+
             if (goods is { target: Item item }) {
                 BuildBeltInserterInfo(gui, item, amount, recipe?.buildingCount ?? 0);
             }
@@ -1317,7 +1338,7 @@ goodsHaveNoProduction:;
         if (isFixedAmount) {
             // Show editable amount for fixed amounts
             evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor, drawTransparent), tooltipOptions: tooltipOptions,
-                setKeyboardFocus: recipe.ShouldFocusFixedCountThisTime());
+                setKeyboardFocus: recipe?.ShouldFocusFixedCountThisTime() ?? SetKeyboardFocus.No);
         }
         else if (hasPercentageConstraint) {
             // For percentage constraints, show the consumption amount with editable percentage underneath

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -1305,13 +1305,49 @@ goodsHaveNoProduction:;
             };
         }
 
-        if (recipe != null && recipe.fixedBuildings > 0 && recipe.hierarchyEnabled
+        bool isFixedAmount = recipe != null && recipe.fixedBuildings > 0 && recipe.hierarchyEnabled
             && ((dropdownType == ProductDropdownType.Fuel && recipe.fixedFuel)
             || (dropdownType == ProductDropdownType.Ingredient && recipe.fixedIngredient == goods)
-            || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
+            || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods));
 
+        bool hasPercentageConstraint = recipe != null && recipe.hierarchyEnabled && goods != null
+            && dropdownType == ProductDropdownType.Ingredient
+            && recipe.ingredientConsumptionPercentages.ContainsKey(goods);
+
+        if (isFixedAmount) {
+            // Show editable amount for fixed amounts
             evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor, drawTransparent), tooltipOptions: tooltipOptions,
                 setKeyboardFocus: recipe.ShouldFocusFixedCountThisTime());
+        }
+        else if (hasPercentageConstraint) {
+            // For percentage constraints, show the consumption amount with editable percentage underneath
+            evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor, drawTransparent),
+                TextBlockDisplayStyle.Centered with { Color = textColor }, tooltipOptions: tooltipOptions);
+
+            // Add percentage input field underneath, similar to fixed building count
+            if (recipe != null && goods != null) {
+                float currentPercentage = recipe.ingredientConsumptionPercentages[goods];
+                DisplayAmount percentageAmount = new DisplayAmount(currentPercentage, UnitOfMeasure.Percent);
+
+                // Show just the percentage text without the icon to avoid duplication
+                using (gui.EnterRow()) {
+                    gui.spacing = 0.25f;
+                    if (gui.BuildFloatInput(percentageAmount, TextBoxDisplayStyle.FactorioObjectInput)) {
+                        // percentageAmount.Value is already the decimal value (e.g., 0.6 for 60%)
+                        // No need to divide by 100 - DisplayAmount with UnitOfMeasure.Percent handles the conversion
+                        float newPercentage = percentageAmount.Value;
+                        if (newPercentage <= 0f || newPercentage > 1f) {
+                            // Remove percentage setting if set to 0, negative, or over 100%
+                            _ = recipe.RecordUndo().ingredientConsumptionPercentages.Remove(goods);
+                            Console.WriteLine($"DEBUG: Removed percentage constraint for {goods.target.name} in {recipe.recipe.target.name} (value was {newPercentage * 100f}%)");
+                        }
+                        else {
+                            recipe.RecordUndo().ingredientConsumptionPercentages[goods] = newPercentage;
+                            Console.WriteLine($"DEBUG: Updated percentage for {goods.target.name} in {recipe.recipe.target.name} to {newPercentage * 100f}% (stored as {newPercentage})");
+                        }
+                    }
+                }
+            }
         }
         else {
             evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor, drawTransparent),
@@ -1329,8 +1365,21 @@ goodsHaveNoProduction:;
                 RebuildIf(pLink.Destroy());
                 break;
             case GoodsWithAmountEvent.TextEditing when displayAmount.Value >= 0:
-                // The amount is always stored in fixedBuildings. Scale it to match the requested change to this item.
-                recipe!.RecordUndo().fixedBuildings *= displayAmount.Value / amount;
+                if (hasPercentageConstraint && !isFixedAmount && recipe != null && goods != null) {
+                    // Handle percentage constraint editing
+                    float newPercentage = displayAmount.Value / 100f; // Convert from percentage to decimal
+                    if (newPercentage <= 0f || newPercentage >= 1f) {
+                        // Remove percentage setting if set to 0, negative, or 100%
+                        _ = recipe.RecordUndo().ingredientConsumptionPercentages.Remove(goods);
+                    }
+                    else {
+                        recipe.RecordUndo().ingredientConsumptionPercentages[goods] = newPercentage;
+                    }
+                }
+                else if (recipe != null) {
+                    // The amount is always stored in fixedBuildings. Scale it to match the requested change to this item.
+                    recipe.RecordUndo().fixedBuildings *= displayAmount.Value / amount;
+                }
                 break;
         }
     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+// If you want to add an entry to the changelog, then please add it to the section without a release date and version.
+// If there is no such section, then copypaste the previous version, remove the info, and put the result below the commented section.
+// Below is the format and the purpose of each field and section:
 // The purpose of the changelog is to provide a concise overview of what was changed.
 // The purpose of the changelog format is to make it more organized.
 // Versioning follows the x.y.z pattern. Since 0.8.0, the increment has the following meaning:
@@ -18,7 +21,8 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version:
 Date:
-    Features:
+    Features:        
+        - Add the ability to specify ingredient consumption as a percentage.
         
     Fixes:
         - Fix icon rendering.


### PR DESCRIPTION
This PR introduces the ability to set a consumption % on items.

<img width="1261" height="540" alt="image" src="https://github.com/user-attachments/assets/4c05eb4f-b24a-4f87-ae4d-21916b4b3cec" />

Given the above, we want 40% of the bitumen to go to Residual mixture, and 60% to dirty syngas.

This PR introduces a new button on the production item dropdown to "Set consumption %"

<img width="920" height="748" alt="image" src="https://github.com/user-attachments/assets/31d2fa44-e857-4ab1-84d3-8aaf9bdfcc6e" />

Clicking this immediately sets that item to 50% consumption as shown here:

<img width="1255" height="431" alt="image" src="https://github.com/user-attachments/assets/15b2c29d-b02a-4e93-b405-f2ee04dcf172" />

Note: Due to how yafc handles things in the solver, we need to forcefully enable overproduction for the linked item, to ensure the "remaining" product goes to the "extra products". (Eg; send 50% to residual mixture, but save/buffer the other 50% somewhere else)

If you can think of a better way to handle this specifically, let me know. Short of adding a lot of new solver parameters and states/types, I couldn't think of a better solution.

Adding consumption % to dirty syngas, we get this:

<img width="1497" height="589" alt="image" src="https://github.com/user-attachments/assets/a29c6ea5-09b6-4629-b818-f77d495472ff" />

It now consumes 50% for each (currently have to manually remove the overproduction flag when a 2nd recipe is introduced)

And for 60/40:

<img width="1457" height="567" alt="image" src="https://github.com/user-attachments/assets/a034534a-71f0-48c2-b35d-c0445bb2eadb" />