### PR TITLE
Fix 444: nested table shows some intermediates as products due to precision errors

### DIFF
--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -358,34 +358,12 @@ public static partial class DataUtils {
         return amount;
     }
 
-    public static float GetProductionForRow(this RecipeRow row, IObjectWithQuality<Goods> product) {
-        float amount = 0f;
-
-        foreach (var p in row.Products) {
-            if (p.Goods == product) {
-                amount += p.Amount;
-            }
-        }
-        return amount;
-    }
-
     public static float GetConsumptionPerRecipe(this RecipeOrTechnology recipe, Goods product) {
         float amount = 0f;
 
         foreach (var ingredient in recipe.ingredients) {
             if (ingredient.ContainsVariant(product)) {
                 amount += ingredient.amount;
-            }
-        }
-        return amount;
-    }
-
-    public static float GetConsumptionForRow(this RecipeRow row, IObjectWithQuality<Goods> ingredient) {
-        float amount = 0f;
-
-        foreach (var i in row.recipe.target.ingredients) {
-            if (i.goods.With(row.recipe.quality) == ingredient || (ingredient.quality == Quality.Normal && i.ContainsVariant(ingredient.target))) {
-                amount += i.amount * (float)row.recipesPerSecond;
             }
         }
         return amount;

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -771,6 +771,36 @@ public class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Productio
         }
     }
 
+    public float DetermineFlow(IObjectWithQuality<Goods> goods) {
+        float production = getProduction(goods);
+        float consumption = getConsumption(goods);
+        float fuelUsage = fuel == goods ? FuelInformation.Amount : 0;
+        float localFlow = production - consumption - fuelUsage;
+        return localFlow;
+
+        float getProduction(IObjectWithQuality<Goods> product) {
+            float amount = 0f;
+
+            foreach (var p in Products) {
+                if (p.Goods == product) {
+                    amount += p.Amount;
+                }
+            }
+            return amount;
+        }
+
+        float getConsumption(IObjectWithQuality<Goods> ingredient) {
+            float amount = 0f;
+
+            foreach (var i in recipe.target.ingredients) {
+                if (i.goods.With(recipe.quality) == ingredient || (ingredient.quality == Quality.Normal && i.ContainsVariant(ingredient.target))) {
+                    amount += i.amount * (float)recipesPerSecond;
+                }
+            }
+            return amount;
+        }
+    }
+
     // To avoid leaking these variables/methods (or just the setter, for recipesPerSecond) into public context,
     // these explicit interface implementations connect to internal members, instead of using implicit implementation via public members
     RecipeParameters IRecipeRow.parameters { get => parameters; set => parameters = value; }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -64,7 +64,7 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
                     || isNotRelatedToCurrentLink(row)) {
                     continue;
                 }
-                float localFlow = DetermineFlow(link.goods, row);
+                float localFlow = row.DetermineFlow(link.goods);
 
                 if ((row.FindLink(link.goods, out var otherLink) && otherLink != link)) {
                     if (!relationLinks.ContainsKey(otherLink)) {
@@ -264,7 +264,7 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
         List<(RecipeRow row, float flow)> input = [], output = [];
         totalInput = totalOutput = 0;
         foreach (var recipe in link.capturedRecipes.OfType<RecipeRow>()) {
-            float localFlow = DetermineFlow(link.goods, recipe);
+            float localFlow = recipe.DetermineFlow(link.goods);
             if (localFlow > 0) {
                 input.Add((recipe, localFlow));
                 totalInput += localFlow;
@@ -285,13 +285,6 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
         scrollArea.RebuildContents();
     }
 
-    private static float DetermineFlow(IObjectWithQuality<Goods> goods, RecipeRow recipe) {
-        float production = recipe.GetProductionForRow(goods);
-        float consumption = recipe.GetConsumptionForRow(goods);
-        float fuelUsage = recipe.fuel == goods ? recipe.FuelInformation.Amount : 0;
-        float localFlow = production - consumption - fuelUsage;
-        return localFlow;
-    }
 
     public static void Show(ProductionLink link) => _ = MainScreen.Instance.ShowPseudoScreen(new ProductionLinkSummaryScreen(link));
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-// The purpose of the changelog is to provide a concise overview of what was changed.
+﻿// The purpose of the changelog is to provide a concise overview of what was changed.
 // The purpose of the changelog format is to make it more organized.
 // If you want to add an entry to the changelog, then please add it to the section without a release date and version.
 // If there is no such section, then copypaste the previous version, remove the info, and put the result below the commented section.
@@ -28,6 +28,7 @@ Date:
         - Fix icon rendering.
         - Hide fluid temperature options when not part of a recipe or not accepted by that recipe.
         - Modify text colors for highlighted rows in dark mode to improve readability.
+        - Don't draw table intermediates as <1μ ingredients/products.
     Internal changes:
         - Enable mod-fixes for the data, data-updates, and data-final-fixes files.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #444 by filtering the input and output information provided to the UI.
It worked properly for me on a page where I was seeing this happen, even after reducing the total production to 0.1/h.