### PR TITLE
Use system build variables when building liblua52.so

### DIFF
--- a/lua/build-linux.sh
+++ b/lua/build-linux.sh
@@ -28,7 +28,7 @@ patch -p0 -i "liblua.so.patch" || exit 1
 patch -d "lua-5.2.1/src" -p1 -i "../../lua-5.2.1.patch" || exit 1
 
 echo "Compiling Lua 5.2.1"
-make -C "lua-5.2.1" linux MYCFLAGS="-fPIC"
+make -C "lua-5.2.1" linux MYCFLAGS="${CFLAGS} -fPIC" MYLDFLAGS="${LDFLAGS}"
 
 echo "Copying liblua.so to Yafc"
 cp "lua-5.2.1/src/liblua.so.5.2.1"  ../Yafc/lib/linux/liblua52.so


### PR DESCRIPTION
Related to #515, liblua52.so can be built using the system CFLAGS variable. I noticed when building/modifying the AUR package that running the build script only included `-fPIC`, and built using only `-O2 -Wall -DLUA_COMPAT_ALL -DLUA_USE_LINUX -fPIC`. This didn't compile using the debug options set by makepkg.

Adding `${CFLAGS}` to MYCFLAGS in the build script allowed the library to compile with those symbols, as well as other security mitigations. SYSCFLAGS is set explicitly in Lua's Makefile, so it's safer to change MYCFLAGS and MYLDFLAGS instead without patching.