### PR TITLE
Add simplified support for debug.getinfo(). Fixes #455, #504

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,11 @@
 //         Changes to the code that do not affect the behavior of the program.
 
 ----------------------------------------------------------------------------------------------------------------------
+Version:
+Date:
+    Fixes:
+        - Add simplified support for debug.getinfo(), only returns short_src. Fixes #455, #504.
+----------------------------------------------------------------------------------------------------------------------
 Version: 2.15.0
 Date: September 1st 2025
     Features:


### PR DESCRIPTION
Adds a simplified debug.getinfo() function to yafc-ce lua. It only returns "short_src", the part used by mods that needs this function.

Tested with mod from #455, and whole py suite.